### PR TITLE
#3 feat(ui): slider UX fix + scene editor card reorganization

### DIFF
--- a/.claude/rules/shadcn-svelte.md
+++ b/.claude/rules/shadcn-svelte.md
@@ -1,1 +1,1 @@
-C:/_MP_projects/mpx-claude-code/rules-per-project/shadcn-svelte.md
+C:/\_MP_projects/mpx-claude-code/rules-per-project/shadcn-svelte.md

--- a/.claude/rules/svelte-context.md
+++ b/.claude/rules/svelte-context.md
@@ -1,1 +1,1 @@
-C:/_MP_projects/mpx-claude-code/rules-per-project/svelte-context.md
+C:/\_MP_projects/mpx-claude-code/rules-per-project/svelte-context.md

--- a/.claude/rules/sveltekit-paths.md
+++ b/.claude/rules/sveltekit-paths.md
@@ -1,1 +1,1 @@
-C:/_MP_projects/mpx-claude-code/rules-per-project/sveltekit-paths.md
+C:/\_MP_projects/mpx-claude-code/rules-per-project/sveltekit-paths.md

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ export default [
 		ignores: [
 			'.svelte-kit',
 			'.storybook',
+			'.wrangler',
 			'build',
 			'node_modules',
 			'src/lib/paraglide',

--- a/src/lib/components/composed/LabeledRangeSlider.svelte
+++ b/src/lib/components/composed/LabeledRangeSlider.svelte
@@ -27,7 +27,13 @@
 		class: className,
 	}: Props = $props();
 
-	const inputId = $derived(id ?? `range-${label.toLowerCase().replace(/\s+/g, '-')}`);
+	const inputId = $derived(
+		id ??
+			`range-${label
+				.toLowerCase()
+				.replace(/[^a-z0-9]+/g, '-')
+				.replace(/^-|-$/g, '')}`,
+	);
 	const displayValue = $derived(format ? format(value) : String(value));
 	const suffix = $derived(unit ?? '');
 </script>

--- a/src/lib/components/composed/LabeledRangeSlider.svelte
+++ b/src/lib/components/composed/LabeledRangeSlider.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Label } from '$lib/components/ui/label/index.js';
+
+	interface Props {
+		label: string;
+		value: number;
+		min: number;
+		max: number;
+		step?: number;
+		unit?: string;
+		format?: (value: number) => string;
+		disabled?: boolean;
+		id?: string;
+		class?: string;
+	}
+
+	let {
+		label,
+		value = $bindable(),
+		min,
+		max,
+		step = 1,
+		unit,
+		format,
+		disabled = false,
+		id,
+		class: className,
+	}: Props = $props();
+
+	const inputId = $derived(id ?? `range-${label.toLowerCase().replace(/\s+/g, '-')}`);
+	const displayValue = $derived(format ? format(value) : String(value));
+	const suffix = $derived(unit ?? '');
+</script>
+
+<div class="space-y-2 {className ?? ''}">
+	<Label for={inputId}>{label}: {displayValue}{suffix}</Label>
+	<input
+		type="range"
+		id={inputId}
+		{min}
+		{max}
+		{step}
+		bind:value
+		{disabled}
+		class="w-full accent-primary disabled:cursor-not-allowed disabled:opacity-50"
+	/>
+</div>

--- a/src/lib/trees/disabled_params.test.ts
+++ b/src/lib/trees/disabled_params.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { DISABLED_PARAMS_BY_SHAPE, isParamDisabled } from './disabled_params.js';
+
+describe('DISABLED_PARAMS_BY_SHAPE', () => {
+	it('exposes the pine disabled list with branchCount and trunkBranchRatio', () => {
+		expect(DISABLED_PARAMS_BY_SHAPE.pine).toEqual(['branchCount', 'trunkBranchRatio']);
+	});
+
+	it('exposes empty disabled lists for oak and birch', () => {
+		expect(DISABLED_PARAMS_BY_SHAPE.oak).toEqual([]);
+		expect(DISABLED_PARAMS_BY_SHAPE.birch).toEqual([]);
+	});
+});
+
+describe('isParamDisabled', () => {
+	describe('per-shape static rules', () => {
+		it('disables branchCount for pine', () => {
+			expect(isParamDisabled('pine', 'branchCount', {})).toBe(true);
+		});
+
+		it('disables trunkBranchRatio for pine', () => {
+			expect(isParamDisabled('pine', 'trunkBranchRatio', {})).toBe(true);
+		});
+
+		it('does not disable branchCount for oak', () => {
+			expect(isParamDisabled('oak', 'branchCount', {})).toBe(false);
+		});
+
+		it('does not disable trunkBranchRatio for oak', () => {
+			expect(isParamDisabled('oak', 'trunkBranchRatio', {})).toBe(false);
+		});
+
+		it('does not disable branchCount for birch', () => {
+			expect(isParamDisabled('birch', 'branchCount', {})).toBe(false);
+		});
+	});
+
+	describe('cross-param rules', () => {
+		it('disables trunkCrookedness when trunkSegments === 1', () => {
+			expect(isParamDisabled('oak', 'trunkCrookedness', { trunkSegments: 1 })).toBe(true);
+		});
+
+		it('does not disable trunkCrookedness when trunkSegments === 3', () => {
+			expect(isParamDisabled('oak', 'trunkCrookedness', { trunkSegments: 3 })).toBe(false);
+		});
+
+		it('does not disable trunkCrookedness when trunkSegments is undefined', () => {
+			expect(isParamDisabled('oak', 'trunkCrookedness', {})).toBe(false);
+		});
+	});
+});

--- a/src/lib/trees/disabled_params.ts
+++ b/src/lib/trees/disabled_params.ts
@@ -1,0 +1,41 @@
+import { TREE_SHAPES, type TreeShape } from './types.js';
+
+/**
+ * Per-shape list of TreeConfig parameters that should be disabled in the UI.
+ *
+ * Note: `fir` will be added when issue #8 lands (same disabled set as `pine`).
+ */
+export const DISABLED_PARAMS_BY_SHAPE = {
+	[TREE_SHAPES.oak]: [],
+	[TREE_SHAPES.pine]: ['branchCount', 'trunkBranchRatio'],
+	[TREE_SHAPES.birch]: [],
+} as const satisfies Record<TreeShape, readonly string[]>;
+
+/**
+ * Config shape used for cross-param disable rules. Keeping this narrow so
+ * callers only pass the fields that actually affect disable state.
+ */
+interface DisabledParamConfig {
+	readonly trunkSegments?: number;
+}
+
+/**
+ * Returns `true` when a given parameter should be disabled for the current
+ * shape and config. Combines per-shape static rules with cross-param rules.
+ */
+export function isParamDisabled(
+	shape: TreeShape,
+	param: string,
+	config: DisabledParamConfig,
+): boolean {
+	const shapeDisabledParams: readonly string[] = DISABLED_PARAMS_BY_SHAPE[shape];
+	if (shapeDisabledParams.includes(param)) {
+		return true;
+	}
+
+	if (param === 'trunkCrookedness' && config.trunkSegments === 1) {
+		return true;
+	}
+
+	return false;
+}

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import LowPolyTree from '$lib/trees/LowPolyTree.svelte';
 	import LabeledSelect from '$lib/components/composed/LabeledSelect.svelte';
+	import LabeledRangeSlider from '$lib/components/composed/LabeledRangeSlider.svelte';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -12,6 +13,7 @@
 		DEFAULT_TREE_CONFIG,
 		type TreeShape,
 	} from '$lib/trees/types.js';
+	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import DarkModeToggle from '$lib/components/DarkModeToggle.svelte';
 	import { resolve } from '$app/paths';
 	import Shuffle from '@lucide/svelte/icons/shuffle';
@@ -42,6 +44,9 @@
 	let showCanopy = $state(true);
 	let showBranches = $state(true);
 	let showTrunk = $state(true);
+
+	const branchCountDisabled = $derived(isParamDisabled(shape, 'branchCount', {}));
+	const trunkBranchRatioDisabled = $derived(isParamDisabled(shape, 'trunkBranchRatio', {}));
 
 	function onShapeChange(value: string) {
 		shape = value as TreeShape;
@@ -75,7 +80,7 @@
 
 	<div class="grid grid-cols-[320px_1fr] overflow-hidden xl:grid-cols-[640px_1fr]">
 		<!-- Controls -->
-		<aside class="overflow-y-auto p-6">
+		<aside class="select-none overflow-y-auto p-6">
 			<div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
 				<Card.Root>
 					<Card.Header>
@@ -136,16 +141,13 @@
 								class="w-full accent-primary"
 							/>
 						</div>
-						<div class="space-y-2">
-							<Label>Branches: {branchCount}</Label>
-							<input
-								type="range"
-								min="0"
-								max="20"
-								bind:value={branchCount}
-								class="w-full accent-primary"
-							/>
-						</div>
+						<LabeledRangeSlider
+							label="Branches"
+							min={0}
+							max={20}
+							bind:value={branchCount}
+							disabled={branchCountDisabled}
+						/>
 						<div class="space-y-2">
 							<Label>Blob Size Variance: {blobSizeVariance.toFixed(1)}x</Label>
 							<input
@@ -301,16 +303,14 @@
 								class="w-full accent-primary"
 							/>
 						</div>
-						<div class="space-y-2">
-							<Label>Trunk/Branch Ratio: {trunkBranchRatio}%</Label>
-							<input
-								type="range"
-								min="30"
-								max="100"
-								bind:value={trunkBranchRatio}
-								class="w-full accent-primary"
-							/>
-						</div>
+						<LabeledRangeSlider
+							label="Trunk/Branch Ratio"
+							min={30}
+							max={100}
+							unit="%"
+							bind:value={trunkBranchRatio}
+							disabled={trunkBranchRatioDisabled}
+						/>
 					</Card.Content>
 				</Card.Root>
 

--- a/src/routes/showcase/scene/+page.svelte
+++ b/src/routes/showcase/scene/+page.svelte
@@ -3,8 +3,8 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import * as Card from '$lib/components/ui/card/index.js';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import SectionCard from '$lib/components/composed/SectionCard.svelte';
 	import { DEFAULT_TREE_CONFIG, SHAPE_DEFAULTS } from '$lib/trees/types.js';
 	import DarkModeToggle from '$lib/components/DarkModeToggle.svelte';
 	import { resolve } from '$app/paths';
@@ -63,258 +63,247 @@
 
 	<div class="grid grid-cols-[320px_1fr] overflow-hidden xl:grid-cols-[640px_1fr]">
 		<!-- Shared Controls -->
-		<aside class="overflow-y-auto p-6">
+		<aside class="select-none overflow-y-auto p-6">
 			<div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Scene Settings</Card.Title>
-					</Card.Header>
-					<Card.Content class="space-y-4">
-						<div class="space-y-2">
-							<Label>Base Seed</Label>
-							<div class="flex gap-2">
-								<Input type="number" bind:value={seed} class="flex-1" />
-								<Button variant="outline" size="icon" onclick={randomizeSeed}>
-									<Shuffle />
-								</Button>
-							</div>
+				<SectionCard title="Scene Settings" contentClass="space-y-4">
+					<div class="space-y-2">
+						<Label>Base Seed</Label>
+						<div class="flex gap-2">
+							<Input type="number" bind:value={seed} class="flex-1" />
+							<Button variant="outline" size="icon" onclick={randomizeSeed}>
+								<Shuffle />
+							</Button>
 						</div>
-						<div class="space-y-2">
-							<Label>Canopy Polygons: {canopyPolygons}</Label>
-							<input
-								type="range"
-								min="10"
-								max="150"
-								bind:value={canopyPolygons}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Trunk Polygons: {trunkPolygons}</Label>
-							<input
-								type="range"
-								min="10"
-								max="100"
-								bind:value={trunkPolygons}
-								class="w-full accent-primary"
-							/>
-						</div>
-					</Card.Content>
-				</Card.Root>
+					</div>
+					<div class="space-y-2">
+						<Label>Canopy Polygons: {canopyPolygons}</Label>
+						<input
+							type="range"
+							min="10"
+							max="150"
+							bind:value={canopyPolygons}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Trunk Polygons: {trunkPolygons}</Label>
+						<input
+							type="range"
+							min="10"
+							max="100"
+							bind:value={trunkPolygons}
+							class="w-full accent-primary"
+						/>
+					</div>
+				</SectionCard>
 
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Canopy Color</Card.Title>
-					</Card.Header>
-					<Card.Content class="space-y-4">
-						<div class="space-y-2">
-							<Label>Hue: {canopyHue}°</Label>
-							<input
-								type="range"
-								min="0"
-								max="360"
-								bind:value={canopyHue}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Hue Spread: {canopyHueSpread}</Label>
-							<input
-								type="range"
-								min="0"
-								max="80"
-								bind:value={canopyHueSpread}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Saturation: {canopySaturation}%</Label>
-							<input
-								type="range"
-								min="0"
-								max="100"
-								bind:value={canopySaturation}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Lightness: {canopyLightness}%</Label>
-							<input
-								type="range"
-								min="10"
-								max="80"
-								bind:value={canopyLightness}
-								class="w-full accent-primary"
-							/>
-						</div>
-					</Card.Content>
-				</Card.Root>
+				<SectionCard title="Canopy" contentClass="space-y-4">
+					<div class="space-y-2">
+						<Label>Blob Size Variance: {blobSizeVariance.toFixed(1)}x</Label>
+						<input
+							type="range"
+							min="1"
+							max="10"
+							step="0.1"
+							bind:value={blobSizeVariance}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Blob Closeness: {blobCloseness}%</Label>
+						<input
+							type="range"
+							min="0"
+							max="100"
+							bind:value={blobCloseness}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Canopy Size: {canopySize}%</Label>
+						<input
+							type="range"
+							min="50"
+							max="200"
+							bind:value={canopySize}
+							class="w-full accent-primary"
+						/>
+					</div>
+				</SectionCard>
 
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Trunk Color</Card.Title>
-					</Card.Header>
-					<Card.Content class="space-y-4">
-						<div class="space-y-2">
-							<Label>Hue: {trunkHue}°</Label>
-							<input
-								type="range"
-								min="0"
-								max="360"
-								bind:value={trunkHue}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Saturation: {trunkSaturation}%</Label>
-							<input
-								type="range"
-								min="0"
-								max="100"
-								bind:value={trunkSaturation}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Lightness: {trunkLightness}%</Label>
-							<input
-								type="range"
-								min="5"
-								max="60"
-								bind:value={trunkLightness}
-								class="w-full accent-primary"
-							/>
-						</div>
-					</Card.Content>
-				</Card.Root>
+				<SectionCard title="Trunk & Branches" contentClass="space-y-4">
+					<div class="space-y-2">
+						<Label>Trunk Height: {trunkHeight}%</Label>
+						<input
+							type="range"
+							min="50"
+							max="150"
+							bind:value={trunkHeight}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Trunk Thickness: {trunkThickness}%</Label>
+						<input
+							type="range"
+							min="50"
+							max="200"
+							bind:value={trunkThickness}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Branch Thickness: {branchThickness}%</Label>
+						<input
+							type="range"
+							min="50"
+							max="200"
+							bind:value={branchThickness}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Trunk/Branch Ratio: {trunkBranchRatio}%</Label>
+						<input
+							type="range"
+							min="30"
+							max="100"
+							bind:value={trunkBranchRatio}
+							class="w-full accent-primary"
+						/>
+					</div>
+				</SectionCard>
 
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Lighting</Card.Title>
-					</Card.Header>
-					<Card.Content class="space-y-4">
-						<div class="space-y-2">
-							<Label>Light Angle: {lightAngle}°</Label>
-							<input
-								type="range"
-								min="0"
-								max="360"
-								bind:value={lightAngle}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Depth Variance: {depthVariance.toFixed(1)}</Label>
-							<input
-								type="range"
-								min="0"
-								max="2"
-								step="0.1"
-								bind:value={depthVariance}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Blob Size Variance: {blobSizeVariance.toFixed(1)}x</Label>
-							<input
-								type="range"
-								min="1"
-								max="10"
-								step="0.1"
-								bind:value={blobSizeVariance}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Blob Closeness: {blobCloseness}%</Label>
-							<input
-								type="range"
-								min="0"
-								max="100"
-								bind:value={blobCloseness}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Canopy Size: {canopySize}%</Label>
-							<input
-								type="range"
-								min="50"
-								max="200"
-								bind:value={canopySize}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Trunk Height: {trunkHeight}%</Label>
-							<input
-								type="range"
-								min="50"
-								max="150"
-								bind:value={trunkHeight}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Trunk Thickness: {trunkThickness}%</Label>
-							<input
-								type="range"
-								min="50"
-								max="200"
-								bind:value={trunkThickness}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Branch Thickness: {branchThickness}%</Label>
-							<input
-								type="range"
-								min="50"
-								max="200"
-								bind:value={branchThickness}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Trunk/Branch Ratio: {trunkBranchRatio}%</Label>
-							<input
-								type="range"
-								min="30"
-								max="100"
-								bind:value={trunkBranchRatio}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="flex items-center gap-2">
-							<Checkbox
-								checked={showCanopy}
-								onCheckedChange={(v) => (showCanopy = v === true)}
-							/>
-							<Label>Show Canopy</Label>
-						</div>
-						<div class="flex items-center gap-2">
-							<Checkbox
-								checked={showBranches}
-								onCheckedChange={(v) => (showBranches = v === true)}
-							/>
-							<Label>Show Branches</Label>
-						</div>
-						<div class="flex items-center gap-2">
-							<Checkbox
-								checked={showTrunk}
-								onCheckedChange={(v) => (showTrunk = v === true)}
-							/>
-							<Label>Show Trunk</Label>
-						</div>
-						<div class="flex items-center gap-2">
-							<Checkbox
-								checked={showAnchors}
-								onCheckedChange={(v) => (showAnchors = v === true)}
-							/>
-							<Label>Show Anchor Points</Label>
-						</div>
-					</Card.Content>
-				</Card.Root>
+				<SectionCard title="Canopy Color" contentClass="space-y-4">
+					<div class="space-y-2">
+						<Label>Hue: {canopyHue}°</Label>
+						<input
+							type="range"
+							min="0"
+							max="360"
+							bind:value={canopyHue}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Hue Spread: {canopyHueSpread}</Label>
+						<input
+							type="range"
+							min="0"
+							max="80"
+							bind:value={canopyHueSpread}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Saturation: {canopySaturation}%</Label>
+						<input
+							type="range"
+							min="0"
+							max="100"
+							bind:value={canopySaturation}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Lightness: {canopyLightness}%</Label>
+						<input
+							type="range"
+							min="10"
+							max="80"
+							bind:value={canopyLightness}
+							class="w-full accent-primary"
+						/>
+					</div>
+				</SectionCard>
+
+				<SectionCard title="Trunk Color" contentClass="space-y-4">
+					<div class="space-y-2">
+						<Label>Hue: {trunkHue}°</Label>
+						<input
+							type="range"
+							min="0"
+							max="360"
+							bind:value={trunkHue}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Saturation: {trunkSaturation}%</Label>
+						<input
+							type="range"
+							min="0"
+							max="100"
+							bind:value={trunkSaturation}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Lightness: {trunkLightness}%</Label>
+						<input
+							type="range"
+							min="5"
+							max="60"
+							bind:value={trunkLightness}
+							class="w-full accent-primary"
+						/>
+					</div>
+				</SectionCard>
+
+				<SectionCard title="Lighting" contentClass="space-y-4">
+					<div class="space-y-2">
+						<Label>Light Angle: {lightAngle}°</Label>
+						<input
+							type="range"
+							min="0"
+							max="360"
+							bind:value={lightAngle}
+							class="w-full accent-primary"
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label>Depth Variance: {depthVariance.toFixed(1)}</Label>
+						<input
+							type="range"
+							min="0"
+							max="2"
+							step="0.1"
+							bind:value={depthVariance}
+							class="w-full accent-primary"
+						/>
+					</div>
+				</SectionCard>
+
+				<SectionCard title="Debug" contentClass="space-y-4">
+					<div class="flex items-center gap-2">
+						<Checkbox
+							checked={showCanopy}
+							onCheckedChange={(v) => (showCanopy = v === true)}
+						/>
+						<Label>Show Canopy</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							checked={showBranches}
+							onCheckedChange={(v) => (showBranches = v === true)}
+						/>
+						<Label>Show Branches</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							checked={showTrunk}
+							onCheckedChange={(v) => (showTrunk = v === true)}
+						/>
+						<Label>Show Trunk</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							checked={showAnchors}
+							onCheckedChange={(v) => (showAnchors = v === true)}
+						/>
+						<Label>Show Anchor Points</Label>
+					</div>
+				</SectionCard>
 			</div>
 		</aside>
 

--- a/tests/e2e/verify_issue3.spec.ts
+++ b/tests/e2e/verify_issue3.spec.ts
@@ -49,9 +49,7 @@ test.describe('Issue #3 — Slider UX + UI control reorganization', () => {
 		await page.goto('http://localhost:4173/showcase');
 		await page.waitForLoadState('networkidle');
 
-		// Select pine shape using the select component
-		const select = page.locator('select, [role="combobox"]').first();
-		// Try to use shadcn select — click trigger then pick pine
+		// Select pine shape via shadcn select trigger
 		const trigger = page.locator('[role="combobox"]').first();
 		await trigger.click();
 		await page.waitForTimeout(300);
@@ -71,10 +69,6 @@ test.describe('Issue #3 — Slider UX + UI control reorganization', () => {
 
 		expect(branchDisabled).not.toBeNull();
 		expect(trunkBranchDisabled).not.toBeNull();
-
-		// Check opacity-50 on parent wrapper
-		const branchWrapper = branchCountSlider.locator('..');
-		const trunkWrapper = trunkBranchSlider.locator('..');
 
 		// Visual check via screenshot
 		await page.screenshot({ path: '/tmp/pine_disabled.png', fullPage: false });

--- a/tests/e2e/verify_issue3.spec.ts
+++ b/tests/e2e/verify_issue3.spec.ts
@@ -49,8 +49,8 @@ test.describe('Issue #3 — Slider UX + UI control reorganization', () => {
 		await page.goto('http://localhost:4173/showcase');
 		await page.waitForLoadState('networkidle');
 
-		// Select pine shape via shadcn select trigger
-		const trigger = page.locator('[role="combobox"]').first();
+		// Select pine shape via shadcn select trigger (bits-ui uses data-slot, not role=combobox)
+		const trigger = page.locator('[data-slot="select-trigger"]').first();
 		await trigger.click();
 		await page.waitForTimeout(300);
 		// Find pine option
@@ -60,7 +60,7 @@ test.describe('Issue #3 — Slider UX + UI control reorganization', () => {
 
 		// Find branchCount slider by id
 		const branchCountSlider = page.locator('#range-branches');
-		const trunkBranchSlider = page.locator('#range-trunk/branch-ratio');
+		const trunkBranchSlider = page.locator('#range-trunk-branch-ratio');
 
 		const branchDisabled = await branchCountSlider.getAttribute('disabled');
 		const trunkBranchDisabled = await trunkBranchSlider.getAttribute('disabled');
@@ -82,7 +82,7 @@ test.describe('Issue #3 — Slider UX + UI control reorganization', () => {
 
 		// Should be oak by default, but let's confirm
 		const branchCountSlider = page.locator('#range-branches');
-		const trunkBranchSlider = page.locator('#range-trunk/branch-ratio');
+		const trunkBranchSlider = page.locator('#range-trunk-branch-ratio');
 
 		const branchDisabled = await branchCountSlider.getAttribute('disabled');
 		const trunkBranchDisabled = await trunkBranchSlider.getAttribute('disabled');

--- a/tests/e2e/verify_issue3.spec.ts
+++ b/tests/e2e/verify_issue3.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Issue #3 — Slider UX + UI control reorganization', () => {
+	test('1. /showcase aside has select-none class', async ({ page }) => {
+		await page.goto('http://localhost:4173/showcase');
+		await page.waitForLoadState('networkidle');
+		const aside = page.locator('aside');
+		const classes = await aside.getAttribute('class');
+		console.log('aside classes:', classes);
+		expect(classes).toContain('select-none');
+	});
+
+	test('2. /showcase slider drag produces no text selection', async ({ page }) => {
+		await page.goto('http://localhost:4173/showcase');
+		await page.waitForLoadState('networkidle');
+
+		// Find the first range input (Canopy Polygons)
+		const slider = page.locator('input[type="range"]').first();
+		const sliderBox = await slider.boundingBox();
+		expect(sliderBox).not.toBeNull();
+
+		// Get initial value
+		const initialValue = await slider.inputValue();
+
+		// Drag: mousedown on left edge, move right across label area, mouseup
+		const startX = sliderBox!.x + 10;
+		const startY = sliderBox!.y + sliderBox!.height / 2;
+		const endX = sliderBox!.x + sliderBox!.width - 10;
+
+		await page.mouse.move(startX, startY);
+		await page.mouse.down();
+		await page.mouse.move(endX, startY, { steps: 10 });
+		await page.mouse.up();
+
+		// Check no text selected
+		const selectedText = await page.evaluate(() => window.getSelection()?.toString() ?? '');
+		console.log('Selected text after drag:', JSON.stringify(selectedText));
+		expect(selectedText).toBe('');
+
+		// Check value changed
+		const finalValue = await slider.inputValue();
+		console.log(`Slider value: ${initialValue} -> ${finalValue}`);
+		expect(Number(finalValue)).not.toBe(Number(initialValue));
+	});
+
+	test('3a. /showcase pine shape disables branchCount and trunkBranchRatio sliders', async ({
+		page,
+	}) => {
+		await page.goto('http://localhost:4173/showcase');
+		await page.waitForLoadState('networkidle');
+
+		// Select pine shape using the select component
+		const select = page.locator('select, [role="combobox"]').first();
+		// Try to use shadcn select — click trigger then pick pine
+		const trigger = page.locator('[role="combobox"]').first();
+		await trigger.click();
+		await page.waitForTimeout(300);
+		// Find pine option
+		const pineOption = page.locator('[role="option"]').filter({ hasText: /pine/i }).first();
+		await pineOption.click();
+		await page.waitForTimeout(300);
+
+		// Find branchCount slider by id
+		const branchCountSlider = page.locator('#range-branches');
+		const trunkBranchSlider = page.locator('#range-trunk/branch-ratio');
+
+		const branchDisabled = await branchCountSlider.getAttribute('disabled');
+		const trunkBranchDisabled = await trunkBranchSlider.getAttribute('disabled');
+		console.log('branchCount disabled attr:', branchDisabled);
+		console.log('trunkBranchRatio disabled attr:', trunkBranchDisabled);
+
+		expect(branchDisabled).not.toBeNull();
+		expect(trunkBranchDisabled).not.toBeNull();
+
+		// Check opacity-50 on parent wrapper
+		const branchWrapper = branchCountSlider.locator('..');
+		const trunkWrapper = trunkBranchSlider.locator('..');
+
+		// Visual check via screenshot
+		await page.screenshot({ path: '/tmp/pine_disabled.png', fullPage: false });
+	});
+
+	test('3b. /showcase oak shape does NOT disable branchCount and trunkBranchRatio', async ({
+		page,
+	}) => {
+		await page.goto('http://localhost:4173/showcase');
+		await page.waitForLoadState('networkidle');
+
+		// Should be oak by default, but let's confirm
+		const branchCountSlider = page.locator('#range-branches');
+		const trunkBranchSlider = page.locator('#range-trunk/branch-ratio');
+
+		const branchDisabled = await branchCountSlider.getAttribute('disabled');
+		const trunkBranchDisabled = await trunkBranchSlider.getAttribute('disabled');
+		console.log('oak branchCount disabled:', branchDisabled);
+		console.log('oak trunkBranchRatio disabled:', trunkBranchDisabled);
+
+		expect(branchDisabled).toBeNull();
+		expect(trunkBranchDisabled).toBeNull();
+	});
+
+	test('4. /showcase/scene aside has select-none class', async ({ page }) => {
+		await page.goto('http://localhost:4173/showcase/scene');
+		await page.waitForLoadState('networkidle');
+		const aside = page.locator('aside');
+		const classes = await aside.getAttribute('class');
+		console.log('scene aside classes:', classes);
+		expect(classes).toContain('select-none');
+	});
+
+	test('5. /showcase/scene has all 7 card titles', async ({ page }) => {
+		await page.goto('http://localhost:4173/showcase/scene');
+		await page.waitForLoadState('networkidle');
+
+		const expectedTitles = [
+			'Scene Settings',
+			'Canopy',
+			'Trunk & Branches',
+			'Canopy Color',
+			'Trunk Color',
+			'Lighting',
+			'Debug',
+		];
+
+		for (const title of expectedTitles) {
+			const el = page.locator('text=' + title).first();
+			const visible = await el.isVisible();
+			console.log(`Card "${title}" visible:`, visible);
+			expect(visible, `Card title "${title}" should be visible`).toBe(true);
+		}
+
+		// Lighting card has light angle and depth variance sliders
+		const lightingSection = page.locator('text=Light Angle').first();
+		expect(await lightingSection.isVisible()).toBe(true);
+		const depthSection = page.locator('text=Depth Variance').first();
+		expect(await depthSection.isVisible()).toBe(true);
+	});
+
+	test('6. /showcase/scene slider drag produces no text selection', async ({ page }) => {
+		await page.goto('http://localhost:4173/showcase/scene');
+		await page.waitForLoadState('networkidle');
+
+		const slider = page.locator('input[type="range"]').first();
+		const sliderBox = await slider.boundingBox();
+		expect(sliderBox).not.toBeNull();
+
+		const initialValue = await slider.inputValue();
+		const startX = sliderBox!.x + 10;
+		const startY = sliderBox!.y + sliderBox!.height / 2;
+		const endX = sliderBox!.x + sliderBox!.width - 10;
+
+		await page.mouse.move(startX, startY);
+		await page.mouse.down();
+		await page.mouse.move(endX, startY, { steps: 10 });
+		await page.mouse.up();
+
+		const selectedText = await page.evaluate(() => window.getSelection()?.toString() ?? '');
+		console.log('Scene selected text after drag:', JSON.stringify(selectedText));
+		expect(selectedText).toBe('');
+
+		const finalValue = await slider.inputValue();
+		console.log(`Scene slider value: ${initialValue} -> ${finalValue}`);
+		expect(Number(finalValue)).not.toBe(Number(initialValue));
+	});
+});


### PR DESCRIPTION
## Description

- Add `select-none` to `<aside>` in both `/showcase` and `/showcase/scene` to prevent text selection hijacking slider drag
- Restructure scene editor controls into 7 `SectionCard` blocks per REQ-S-07: Scene Settings, Canopy, Trunk & Branches, Canopy Color, Trunk Color, Lighting (only `lightAngle` + `depthVariance`), Debug
- Add `LabeledRangeSlider` component with `disabled` prop support (`disabled:opacity-50 disabled:cursor-not-allowed`)
- Add data-driven `DISABLED_PARAMS_BY_SHAPE` map + `isParamDisabled()` helper in `src/lib/trees/disabled_params.ts`
- Wire pine `branchCount` and `trunkBranchRatio` as disabled via `$derived` + `isParamDisabled` in showcase editor

## Resolves

Closes #3

## Testing

- [x] Unit tests: `disabled_params.test.ts` — 10 tests covering pine/oak/birch disabled params + cross-param `trunkCrookedness` rule
- [x] E2E tests: `tests/e2e/verify_issue3.spec.ts` — 6 tests covering select-none, drag-no-selection, pine disabled sliders, scene 7-card structure
- [x] All checks pass (`pnpm run check:all`, `pnpm run test`)
- [x] Frontend verified via browser automation (9/9 checks pass)