### PR TITLE
#4 feat(trees): base value rescaling (1.75x) + type expansion + defaults

### DIFF
--- a/src/lib/trees/disabled_params.test.ts
+++ b/src/lib/trees/disabled_params.test.ts
@@ -6,9 +6,16 @@ describe('DISABLED_PARAMS_BY_SHAPE', () => {
 		expect(DISABLED_PARAMS_BY_SHAPE.pine).toEqual(['branchCount', 'trunkBranchRatio']);
 	});
 
-	it('exposes empty disabled lists for oak and birch', () => {
+	it('exposes the fir disabled list (same as pine per REQ-S-12)', () => {
+		expect(DISABLED_PARAMS_BY_SHAPE.fir).toEqual(['branchCount', 'trunkBranchRatio']);
+	});
+
+	it('exposes empty disabled lists for oak, birch, maple, willow, custom', () => {
 		expect(DISABLED_PARAMS_BY_SHAPE.oak).toEqual([]);
 		expect(DISABLED_PARAMS_BY_SHAPE.birch).toEqual([]);
+		expect(DISABLED_PARAMS_BY_SHAPE.maple).toEqual([]);
+		expect(DISABLED_PARAMS_BY_SHAPE.willow).toEqual([]);
+		expect(DISABLED_PARAMS_BY_SHAPE.custom).toEqual([]);
 	});
 });
 

--- a/src/lib/trees/disabled_params.ts
+++ b/src/lib/trees/disabled_params.ts
@@ -3,12 +3,17 @@ import { TREE_SHAPES, type TreeShape } from './types.js';
 /**
  * Per-shape list of TreeConfig parameters that should be disabled in the UI.
  *
- * Note: `fir` will be added when issue #8 lands (same disabled set as `pine`).
+ * `fir` shares pine's disabled set per REQ-S-12 (branchCount always 0,
+ * trunkBranchRatio not applicable to tiered canopies).
  */
 export const DISABLED_PARAMS_BY_SHAPE = {
 	[TREE_SHAPES.oak]: [],
 	[TREE_SHAPES.pine]: ['branchCount', 'trunkBranchRatio'],
 	[TREE_SHAPES.birch]: [],
+	[TREE_SHAPES.fir]: ['branchCount', 'trunkBranchRatio'],
+	[TREE_SHAPES.maple]: [],
+	[TREE_SHAPES.willow]: [],
+	[TREE_SHAPES.custom]: [],
 } as const satisfies Record<TreeShape, readonly string[]>;
 
 /**

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -32,8 +32,9 @@ const H = VIEWBOX_HEIGHT;
 const TRUNK_ENTRY_MIN_PX = 15;
 const RADIAL_JITTER_FACTOR = 0.15;
 const ACUTE_ANGLE_THRESHOLD_RAD = Math.PI / 2;
-const SUB_BRANCH_WIDTH_MIN = 2;
-const SUB_BRANCH_WIDTH_MAX = 4;
+// Sub-branch widths pre-scaled by 1.75 (issue #4 base rescale).
+const SUB_BRANCH_WIDTH_MIN = 3.5;
+const SUB_BRANCH_WIDTH_MAX = 7;
 const BRANCH_ANGLE_MIN_RAD = (30 * Math.PI) / 180;
 const BRANCH_ANGLE_MAX_ATTEMPTS = 20;
 
@@ -82,44 +83,46 @@ function ensureLargestBlobInBottomHalf(blobs: Blob[]): void {
 	}
 }
 
+function generateOakBlobs(rng: () => number, blobCount: number): Blob[] {
+	const blobs: Blob[] = [];
+	const centerX = W / 2;
+	const canopyCenterY = H * 0.3;
+	const spreadRadius = W * 0.22;
+
+	// D9: blob 0 on trunk axis
+	if (blobCount >= 1) {
+		const rx = randomInRange(rng, W * 0.2275, W * 0.385);
+		const ry = randomInRange(rng, H * 0.14, H * 0.2625);
+		blobs.push({ cx: centerX, cy: canopyCenterY, rx, ry });
+	}
+
+	// D9: remaining blobs balanced left/right
+	for (let i = 1; i < blobCount; i++) {
+		const side = i % 2 === 0 ? 1 : -1;
+		const dist = randomInRange(rng, spreadRadius * 0.3, spreadRadius * 0.9);
+		const angleJitter = randomInRange(rng, -0.5, 0.5);
+		const angle = (Math.PI / 4) * Math.ceil(i / 2) + angleJitter;
+		const cx = centerX + Math.cos(angle) * dist * side;
+		const cy = canopyCenterY + Math.sin(angle) * dist * 0.5 * (rng() > 0.5 ? -1 : 1);
+		const rx = randomInRange(rng, W * 0.2275, W * 0.385);
+		const ry = randomInRange(rng, H * 0.14, H * 0.2625);
+		blobs.push({ cx, cy, rx, ry });
+	}
+	ensureLargestBlobInBottomHalf(blobs);
+	return blobs;
+}
+
 const shapeDefinitions: Record<TreeShape, ShapeDefinition> = {
 	oak: {
-		trunkBaseWidth: 16,
-		trunkTopWidth: 10,
+		trunkBaseWidth: 28,
+		trunkTopWidth: 17.5,
 		trunkBottom: H * 0.95,
 		defaultTrunkTop: H * 0.45,
-		generateBlobs(rng, blobCount) {
-			const blobs: Blob[] = [];
-			const centerX = W / 2;
-			const canopyCenterY = H * 0.3;
-			const spreadRadius = W * 0.22;
-
-			// D9: blob 0 on trunk axis
-			if (blobCount >= 1) {
-				const rx = randomInRange(rng, W * 0.13, W * 0.22);
-				const ry = randomInRange(rng, H * 0.08, H * 0.15);
-				blobs.push({ cx: centerX, cy: canopyCenterY, rx, ry });
-			}
-
-			// D9: remaining blobs balanced left/right
-			for (let i = 1; i < blobCount; i++) {
-				const side = i % 2 === 0 ? 1 : -1;
-				const dist = randomInRange(rng, spreadRadius * 0.3, spreadRadius * 0.9);
-				const angleJitter = randomInRange(rng, -0.5, 0.5);
-				const angle = (Math.PI / 4) * Math.ceil(i / 2) + angleJitter;
-				const cx = centerX + Math.cos(angle) * dist * side;
-				const cy = canopyCenterY + Math.sin(angle) * dist * 0.5 * (rng() > 0.5 ? -1 : 1);
-				const rx = randomInRange(rng, W * 0.13, W * 0.22);
-				const ry = randomInRange(rng, H * 0.08, H * 0.15);
-				blobs.push({ cx, cy, rx, ry });
-			}
-			ensureLargestBlobInBottomHalf(blobs);
-			return blobs;
-		},
+		generateBlobs: generateOakBlobs,
 	},
 	pine: {
-		trunkBaseWidth: 12,
-		trunkTopWidth: 7,
+		trunkBaseWidth: 21,
+		trunkTopWidth: 12.25,
 		trunkBottom: H * 0.95,
 		defaultTrunkTop: H * 0.55,
 		generateBlobs() {
@@ -127,8 +130,8 @@ const shapeDefinitions: Record<TreeShape, ShapeDefinition> = {
 		},
 	},
 	birch: {
-		trunkBaseWidth: 10,
-		trunkTopWidth: 6,
+		trunkBaseWidth: 17.5,
+		trunkTopWidth: 10.5,
 		trunkBottom: H * 0.95,
 		defaultTrunkTop: H * 0.45,
 		generateBlobs(rng, blobCount) {
@@ -138,8 +141,8 @@ const shapeDefinitions: Record<TreeShape, ShapeDefinition> = {
 
 			// D9: blob 0 on trunk axis
 			if (blobCount >= 1) {
-				const rx = randomInRange(rng, W * 0.06, W * 0.12);
-				const ry = randomInRange(rng, H * 0.12, H * 0.22);
+				const rx = randomInRange(rng, W * 0.105, W * 0.21);
+				const ry = randomInRange(rng, H * 0.21, H * 0.385);
 				blobs.push({ cx: centerX, cy: canopyCenterY, rx, ry });
 			}
 
@@ -150,13 +153,44 @@ const shapeDefinitions: Record<TreeShape, ShapeDefinition> = {
 				const horizontalOffset = randomInRange(rng, W * 0.02, W * 0.08) * side;
 				const cx = centerX + horizontalOffset;
 				const cy = canopyCenterY + verticalOffset;
-				const rx = randomInRange(rng, W * 0.06, W * 0.12);
-				const ry = randomInRange(rng, H * 0.12, H * 0.22);
+				const rx = randomInRange(rng, W * 0.105, W * 0.21);
+				const ry = randomInRange(rng, H * 0.21, H * 0.385);
 				blobs.push({ cx, cy, rx, ry });
 			}
 			ensureLargestBlobInBottomHalf(blobs);
 			return blobs;
 		},
+	},
+	// Placeholder definitions for shapes whose real generators arrive in issue #8.
+	// Trunk widths rescaled by 1.75 per issue #4. Blob generators reuse oak's
+	// radial distribution until dedicated generators land.
+	fir: {
+		trunkBaseWidth: 21,
+		trunkTopWidth: 12.25,
+		trunkBottom: H * 0.95,
+		defaultTrunkTop: H * 0.55,
+		generateBlobs: generateOakBlobs,
+	},
+	maple: {
+		trunkBaseWidth: 28,
+		trunkTopWidth: 17.5,
+		trunkBottom: H * 0.95,
+		defaultTrunkTop: H * 0.45,
+		generateBlobs: generateOakBlobs,
+	},
+	willow: {
+		trunkBaseWidth: 28,
+		trunkTopWidth: 17.5,
+		trunkBottom: H * 0.95,
+		defaultTrunkTop: H * 0.45,
+		generateBlobs: generateOakBlobs,
+	},
+	custom: {
+		trunkBaseWidth: 28,
+		trunkTopWidth: 17.5,
+		trunkBottom: H * 0.95,
+		defaultTrunkTop: H * 0.45,
+		generateBlobs: generateOakBlobs,
 	},
 };
 
@@ -255,7 +289,7 @@ export function generateTiers(
 		const topScale = 1 / blobSizeVariance;
 		const widthScale = lerp(topScale, 1.0, widthT);
 
-		const baseHalfWidth = (W * 0.06 + t1 * W * 0.22) * widthScale * canopyScale;
+		const baseHalfWidth = (W * 0.105 + t1 * W * 0.385) * widthScale * canopyScale;
 
 		// D10: tiers follow trunk lean
 		const leanOffset =
@@ -659,8 +693,8 @@ export function generateBranches(
 
 		const endX = startX + Math.cos(upAngle) * length * side;
 		let endY = startY - Math.sin(upAngle) * length;
-		const widthStart = randomInRange(rng, 4, 7) * branchThicknessScale;
-		const widthEnd = randomInRange(rng, 1, 3) * branchThicknessScale;
+		const widthStart = randomInRange(rng, 7, 12.25) * branchThicknessScale;
+		const widthEnd = randomInRange(rng, 1.75, 5.25) * branchThicknessScale;
 
 		if (endY < canopyBottom && !isPointInBlobs(endX, endY, blobs)) {
 			const dirX = endX - startX;
@@ -747,7 +781,7 @@ export function generateBranches(
 			widthStart:
 				randomInRange(rng, SUB_BRANCH_WIDTH_MIN, SUB_BRANCH_WIDTH_MAX) *
 				branchThicknessScale,
-			widthEnd: randomInRange(rng, 1, 2) * branchThicknessScale,
+			widthEnd: randomInRange(rng, 1.75, 3.5) * branchThicknessScale,
 		});
 	}
 
@@ -765,8 +799,8 @@ export function generateBranches(
 			y1: originY,
 			x2: blob.cx,
 			y2: blob.cy,
-			widthStart: randomInRange(rng, 3, 5) * branchThicknessScale,
-			widthEnd: randomInRange(rng, 1, 2) * branchThicknessScale,
+			widthStart: randomInRange(rng, 5.25, 8.75) * branchThicknessScale,
+			widthEnd: randomInRange(rng, 1.75, 3.5) * branchThicknessScale,
 		});
 	}
 
@@ -863,8 +897,8 @@ export function validateNoFloatingBlobs(
 			y1: Math.min(trunkY, VIEWBOX_HEIGHT * 0.9),
 			x2: blob.cx,
 			y2: blob.cy,
-			widthStart: 4,
-			widthEnd: 1,
+			widthStart: 7,
+			widthEnd: 1.75,
 		});
 	}
 

--- a/src/lib/trees/types.test.ts
+++ b/src/lib/trees/types.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+	DEFAULT_TREE_CONFIG,
+	SHAPE_DEFAULTS,
+	TREE_SHAPES,
+	TREE_SHAPE_OPTIONS,
+	type TreeShape,
+} from './types.js';
+
+describe('TREE_SHAPES union', () => {
+	it('includes all 7 Plan v4 shapes', () => {
+		expect(Object.keys(TREE_SHAPES).sort()).toEqual(
+			['birch', 'custom', 'fir', 'maple', 'oak', 'pine', 'willow'].sort(),
+		);
+	});
+
+	it('TREE_SHAPE_OPTIONS exposes all 7 shapes for UI selectors', () => {
+		const values = TREE_SHAPE_OPTIONS.map((o) => o.value).sort();
+		expect(values).toEqual(['birch', 'custom', 'fir', 'maple', 'oak', 'pine', 'willow'].sort());
+	});
+});
+
+describe('DEFAULT_TREE_CONFIG', () => {
+	it('uses lightAngle 130 (REQ-P-12)', () => {
+		expect(DEFAULT_TREE_CONFIG.lightAngle).toBe(130);
+	});
+});
+
+describe('SHAPE_DEFAULTS §2.5', () => {
+	const nonCustomShapes: readonly Exclude<TreeShape, 'custom'>[] = [
+		'oak',
+		'pine',
+		'birch',
+		'fir',
+		'maple',
+		'willow',
+	];
+
+	it('contains an entry for all 6 non-custom shapes', () => {
+		for (const shape of nonCustomShapes) {
+			expect(SHAPE_DEFAULTS[shape]).toBeDefined();
+		}
+	});
+
+	it('has oak defaults', () => {
+		expect(SHAPE_DEFAULTS.oak).toEqual({
+			blobCount: 5,
+			branchCount: 2,
+			blobSizeVariance: 3.0,
+			blobCloseness: 50,
+			branchThickness: 100,
+		});
+	});
+
+	it('has pine defaults', () => {
+		expect(SHAPE_DEFAULTS.pine).toEqual({
+			blobCount: 3,
+			branchCount: 0,
+			blobSizeVariance: 3.0,
+			blobCloseness: 50,
+			branchThickness: 100,
+		});
+	});
+
+	it('has birch defaults', () => {
+		expect(SHAPE_DEFAULTS.birch).toEqual({
+			blobCount: 3,
+			branchCount: 1,
+			blobSizeVariance: 3.0,
+			blobCloseness: 50,
+			branchThickness: 100,
+		});
+	});
+
+	it('has fir defaults', () => {
+		expect(SHAPE_DEFAULTS.fir).toEqual({
+			blobCount: 4,
+			branchCount: 0,
+			blobSizeVariance: 3.0,
+			blobCloseness: 50,
+			branchThickness: 100,
+		});
+	});
+
+	it('has maple defaults (low closeness, low variance)', () => {
+		expect(SHAPE_DEFAULTS.maple).toEqual({
+			blobCount: 5,
+			branchCount: 5,
+			blobSizeVariance: 2.0,
+			blobCloseness: 30,
+			branchThickness: 100,
+		});
+	});
+
+	it('has willow defaults (thick branches 150)', () => {
+		expect(SHAPE_DEFAULTS.willow).toEqual({
+			blobCount: 4,
+			branchCount: 4,
+			blobSizeVariance: 3.0,
+			blobCloseness: 50,
+			branchThickness: 150,
+		});
+	});
+});

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -2,6 +2,10 @@ export const TREE_SHAPES = {
 	oak: 'oak',
 	pine: 'pine',
 	birch: 'birch',
+	fir: 'fir',
+	maple: 'maple',
+	willow: 'willow',
+	custom: 'custom',
 } as const;
 
 export type TreeShape = (typeof TREE_SHAPES)[keyof typeof TREE_SHAPES];
@@ -10,6 +14,10 @@ export const TREE_SHAPE_OPTIONS: readonly { value: TreeShape; label: string }[] 
 	{ value: TREE_SHAPES.oak, label: 'Oak' },
 	{ value: TREE_SHAPES.pine, label: 'Pine' },
 	{ value: TREE_SHAPES.birch, label: 'Birch' },
+	{ value: TREE_SHAPES.fir, label: 'Fir' },
+	{ value: TREE_SHAPES.maple, label: 'Maple' },
+	{ value: TREE_SHAPES.willow, label: 'Willow' },
+	{ value: TREE_SHAPES.custom, label: 'Custom' },
 ] as const;
 
 export const GEOMETRY_GROUPS = {
@@ -97,7 +105,7 @@ export const DEFAULT_TREE_CONFIG: TreeConfig = {
 	trunkHue: 25,
 	trunkSaturation: 50,
 	trunkLightness: 25,
-	lightAngle: 315,
+	lightAngle: 130,
 	blobCount: 5,
 	branchCount: 2,
 	depthVariance: 1.0,
@@ -110,14 +118,63 @@ export const DEFAULT_TREE_CONFIG: TreeConfig = {
 	trunkBranchRatio: 70,
 } as const;
 
-export const SHAPE_DEFAULTS: Record<
-	TreeShape,
-	Pick<TreeConfig, 'blobCount' | 'branchCount' | 'blobSizeVariance' | 'blobCloseness'>
-> = {
-	[TREE_SHAPES.oak]: { blobCount: 5, branchCount: 2, blobSizeVariance: 3.0, blobCloseness: 50 },
-	[TREE_SHAPES.pine]: { blobCount: 3, branchCount: 0, blobSizeVariance: 3.0, blobCloseness: 50 },
-	[TREE_SHAPES.birch]: { blobCount: 3, branchCount: 1, blobSizeVariance: 3.0, blobCloseness: 50 },
-};
+/**
+ * Per-shape defaults from REQUIREMENTS.md §2.5. `custom` is intentionally
+ * excluded — the custom editor retains whatever the user has configured.
+ *
+ * Fields `trunkSegments` and `trunkCrookedness` from §2.5 are omitted until
+ * their own issues add them to `TreeConfig`.
+ */
+export const SHAPE_DEFAULTS = {
+	[TREE_SHAPES.oak]: {
+		blobCount: 5,
+		branchCount: 2,
+		blobSizeVariance: 3.0,
+		blobCloseness: 50,
+		branchThickness: 100,
+	},
+	[TREE_SHAPES.pine]: {
+		blobCount: 3,
+		branchCount: 0,
+		blobSizeVariance: 3.0,
+		blobCloseness: 50,
+		branchThickness: 100,
+	},
+	[TREE_SHAPES.birch]: {
+		blobCount: 3,
+		branchCount: 1,
+		blobSizeVariance: 3.0,
+		blobCloseness: 50,
+		branchThickness: 100,
+	},
+	[TREE_SHAPES.fir]: {
+		blobCount: 4,
+		branchCount: 0,
+		blobSizeVariance: 3.0,
+		blobCloseness: 50,
+		branchThickness: 100,
+	},
+	[TREE_SHAPES.maple]: {
+		blobCount: 5,
+		branchCount: 5,
+		blobSizeVariance: 2.0,
+		blobCloseness: 30,
+		branchThickness: 100,
+	},
+	[TREE_SHAPES.willow]: {
+		blobCount: 4,
+		branchCount: 4,
+		blobSizeVariance: 3.0,
+		blobCloseness: 50,
+		branchThickness: 150,
+	},
+} as const satisfies Record<
+	Exclude<TreeShape, 'custom'>,
+	Pick<
+		TreeConfig,
+		'blobCount' | 'branchCount' | 'blobSizeVariance' | 'blobCloseness' | 'branchThickness'
+	>
+>;
 
 export const VIEWBOX_WIDTH = 200;
 export const VIEWBOX_HEIGHT = 300;

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -8,6 +8,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import {
+		TREE_SHAPES,
 		TREE_SHAPE_OPTIONS,
 		SHAPE_DEFAULTS,
 		DEFAULT_TREE_CONFIG,
@@ -48,13 +49,24 @@
 	const branchCountDisabled = $derived(isParamDisabled(shape, 'branchCount', {}));
 	const trunkBranchRatioDisabled = $derived(isParamDisabled(shape, 'trunkBranchRatio', {}));
 
+	function isTreeShape(value: string): value is TreeShape {
+		return (Object.values(TREE_SHAPES) as readonly string[]).includes(value);
+	}
+
 	function onShapeChange(value: string) {
-		shape = value as TreeShape;
-		const defaults = SHAPE_DEFAULTS[shape];
+		if (!isTreeShape(value)) {
+			return;
+		}
+		shape = value;
+		if (value === TREE_SHAPES.custom) {
+			return;
+		}
+		const defaults = SHAPE_DEFAULTS[value];
 		blobCount = defaults.blobCount;
 		branchCount = defaults.branchCount;
 		blobSizeVariance = defaults.blobSizeVariance;
 		blobCloseness = defaults.blobCloseness;
+		branchThickness = defaults.branchThickness;
 	}
 
 	function randomizeSeed() {
@@ -173,8 +185,9 @@
 							<Label>Canopy Size: {canopySize}%</Label>
 							<input
 								type="range"
-								min="50"
-								max="200"
+								min="25"
+								max="400"
+								step="5"
 								bind:value={canopySize}
 								class="w-full accent-primary"
 							/>
@@ -287,8 +300,9 @@
 							<Label>Trunk Thickness: {trunkThickness}%</Label>
 							<input
 								type="range"
-								min="50"
-								max="200"
+								min="25"
+								max="400"
+								step="5"
 								bind:value={trunkThickness}
 								class="w-full accent-primary"
 							/>
@@ -297,8 +311,9 @@
 							<Label>Branch Thickness: {branchThickness}%</Label>
 							<input
 								type="range"
-								min="50"
-								max="200"
+								min="25"
+								max="400"
+								step="5"
 								bind:value={branchThickness}
 								class="w-full accent-primary"
 							/>

--- a/src/routes/showcase/scene/+page.svelte
+++ b/src/routes/showcase/scene/+page.svelte
@@ -38,6 +38,10 @@
 		seed = Math.floor(Math.random() * 100000);
 	}
 
+	// Scene currently previews oak/pine/birch only. REQ-S-06 (all 6 non-custom
+	// shapes side by side) lands with issue #8, when fir/maple/willow get real
+	// generators. The placeholder generators for those shapes would render as
+	// oak clones, which would be misleading in the scene preview.
 	const trees = [
 		{ shape: 'oak' as const, ...SHAPE_DEFAULTS.oak, seedOffset: 0 },
 		{ shape: 'pine' as const, ...SHAPE_DEFAULTS.pine, seedOffset: 1000 },
@@ -123,8 +127,9 @@
 						<Label>Canopy Size: {canopySize}%</Label>
 						<input
 							type="range"
-							min="50"
-							max="200"
+							min="25"
+							max="400"
+							step="5"
 							bind:value={canopySize}
 							class="w-full accent-primary"
 						/>
@@ -146,8 +151,9 @@
 						<Label>Trunk Thickness: {trunkThickness}%</Label>
 						<input
 							type="range"
-							min="50"
-							max="200"
+							min="25"
+							max="400"
+							step="5"
 							bind:value={trunkThickness}
 							class="w-full accent-primary"
 						/>
@@ -156,8 +162,9 @@
 						<Label>Branch Thickness: {branchThickness}%</Label>
 						<input
 							type="range"
-							min="50"
-							max="200"
+							min="25"
+							max="400"
+							step="5"
 							bind:value={branchThickness}
 							class="w-full accent-primary"
 						/>


### PR DESCRIPTION
## Description
- Bake 1.75x scaling into `shapes.ts` constants (trunk widths, blob radii, branch/sub-branch widths, pine tier baseHalfWidth, validateNoFloatingBlobs). No runtime multiplication.
- Expand `TreeShape` union to `oak | pine | birch | fir | maple | willow | custom`; extend `TREE_SHAPE_OPTIONS` and `DISABLED_PARAMS_BY_SHAPE` to cover all 7.
- Rewrite `SHAPE_DEFAULTS` per REQUIREMENTS.md §2.5 for the 6 non-custom shapes (`as const satisfies` for literal types; omits `trunkSegments`/`trunkCrookedness` until future issues add them to `TreeConfig`).
- `DEFAULT_TREE_CONFIG.lightAngle`: 315 → 130.
- Widen `canopySize` / `trunkThickness` / `branchThickness` slider ranges to **25–400%** step 5 in both `/showcase` and `/showcase/scene`.
- `onShapeChange`: type-guarded input, skip defaults when `custom`.
- Placeholder generator `generateOakBlobs` reused by fir/maple/willow/custom until issue #8 ships their real generators.

## Resolves
Closes #4

## Testing
- [x] New unit tests for `SHAPE_DEFAULTS` (all 6 non-custom shapes) and `DEFAULT_TREE_CONFIG.lightAngle=130` (`src/lib/trees/types.test.ts`).
- [x] `DISABLED_PARAMS_BY_SHAPE` tests extended to cover the 4 new shapes.
- [x] `pnpm run check:all` — clean.
- [x] `pnpm run test` — 57/57 passing (includes rescale-invariant ratio checks).
- [x] `pnpm run test:e2e` — 8/8 passing.

## Scope Notes
Out of scope for this issue (tracked separately):
- `branchLength` slider range (param not yet in `TreeConfig`, added by later issue).
- Real fir/maple/willow canopy generators (issue #8).
- Scene view all-6-shapes display (REQ-S-06) — deferred until real generators exist; comment added in `scene/+page.svelte`.