### PR TITLE
#5 fix(trees): shift canopy with trunkHeight

### DIFF
--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -329,6 +329,51 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 		});
 	});
 
+	describe('REQ-T-02b: canopy follows trunk height', () => {
+		// Oak: defaultTrunkTop = H*0.45 = 135, trunkBottom = H*0.95 = 285.
+		// trunkHeight=50 → eff = 285 - 150*0.5 = 210 → delta = +75 (canopy shifts down).
+		it('oak canopy centroid shifts down by 75 when trunkHeight drops 100 → 50', () => {
+			const base = generateTree(makeConfig({ trunkHeight: 100, seed: 42 }));
+			const shortTrunk = generateTree(makeConfig({ trunkHeight: 50, seed: 42 }));
+			const shift = shortTrunk.anchors.canopyCenter.y - base.anchors.canopyCenter.y;
+			expect(shift).toBeCloseTo(75, 5);
+		});
+
+		// Pine: defaultTrunkTop = H*0.55 = 165, trunkBottom = H*0.95 = 285.
+		// trunkHeight=50 → eff = 225 → delta = +60.
+		it('pine canopy centroid shifts down by 60 when trunkHeight drops 100 → 50', () => {
+			const base = generateTree(makeConfig({ trunkHeight: 100, seed: 42, shape: 'pine' }));
+			const shortTrunk = generateTree(
+				makeConfig({ trunkHeight: 50, seed: 42, shape: 'pine' }),
+			);
+			const shift = shortTrunk.anchors.canopyCenter.y - base.anchors.canopyCenter.y;
+			expect(shift).toBeCloseTo(60, 5);
+		});
+
+		// Canopy shift must equal the effectiveTrunkTop shift (delta invariant).
+		it('oak canopy shift equals trunkTop shift between trunkHeight 100 and 50', () => {
+			const base = generateTree(makeConfig({ trunkHeight: 100, seed: 42 }));
+			const shortTrunk = generateTree(makeConfig({ trunkHeight: 50, seed: 42 }));
+			const canopyShift = shortTrunk.anchors.canopyCenter.y - base.anchors.canopyCenter.y;
+			const trunkShift = shortTrunk.anchors.trunkTop.y - base.anchors.trunkTop.y;
+			expect(canopyShift).toBeCloseTo(trunkShift, 5);
+		});
+
+		it('trunk top enters largest blob by ≥15px across oak, pine, birch at 50/100/150', () => {
+			for (const shape of ['oak', 'pine', 'birch'] as const) {
+				for (const trunkHeight of [50, 100, 150]) {
+					const geo = generateTree(makeConfig({ trunkHeight, seed: 42, shape }));
+					const canopyMaxY = Math.max(
+						...geo.canopyBlobs.flatMap((b) =>
+							b.triangles.flatMap((t) => t.points.map((p) => p.y)),
+						),
+					);
+					expect(geo.anchors.trunkTop.y + 15).toBeLessThanOrEqual(canopyMaxY);
+				}
+			}
+		});
+	});
+
 	describe('REQ-T-05: branches in separate layer', () => {
 		it('branch triangles are separate from trunk', () => {
 			const geo = generateTree(makeConfig({ branchCount: 5 }));

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -12,7 +12,6 @@ import { GEOMETRY_GROUPS, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, TREE_SHAPES } from './t
 import { createPrng, poissonSample, randomInRange } from './prng.js';
 import {
 	getShapeDefinition,
-	computeTrunkTop,
 	computeEffectiveTrunkTop,
 	isPointInTrunk,
 	isPointInBranch,
@@ -28,6 +27,7 @@ import {
 	generateTiers,
 	isPointInTier,
 	getTiersBounds,
+	TRUNK_ENTRY_MIN_PX,
 	type Blob,
 	type BranchSegment,
 } from './shapes.js';
@@ -403,6 +403,10 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 	const isPine = config.shape === TREE_SHAPES.pine;
 
 	const effectiveTrunkTop = computeEffectiveTrunkTop(shapeDef, config.trunkHeight);
+	// Canopy must follow trunk top so that raising/lowering the trunk shifts the
+	// whole canopy in lock-step. Delta is the per-axis offset applied to every
+	// blob cy (and tier y) after shape-specific positioning runs at defaults.
+	const canopyDelta = effectiveTrunkTop - shapeDef.defaultTrunkTop;
 
 	const trunkLean = randomInRange(rng, -8, 8);
 
@@ -419,6 +423,9 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 
 	if (!isPine) {
 		applyCanopySize(blobs, config.canopySize);
+		for (const blob of blobs) {
+			blob.cy += canopyDelta;
+		}
 	}
 
 	const tiers = isPine
@@ -431,14 +438,16 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 				config.blobCloseness,
 				config.blobSizeVariance,
 				config.canopySize,
+				canopyDelta,
 			)
 		: [];
 
 	const canopyBounds = isPine ? getTiersBounds(tiers) : getBlobsBounds(blobs);
 
-	const trunkTop = isPine
-		? Math.min(effectiveTrunkTop, canopyBounds.maxY - 15)
-		: Math.min(effectiveTrunkTop, computeTrunkTop(shapeDef, blobs));
+	// Enforce the trunk-penetration invariant: trunk top must enter the lowest
+	// canopy edge by at least TRUNK_ENTRY_MIN_PX. If the user's chosen trunk
+	// height would leave the trunk dangling below the canopy, clamp upward.
+	const trunkTop = Math.min(effectiveTrunkTop, canopyBounds.maxY - TRUNK_ENTRY_MIN_PX);
 	const trunkBottom = shapeDef.trunkBottom;
 
 	const branches = isPine

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -29,7 +29,7 @@ export interface BranchSegment {
 const W = VIEWBOX_WIDTH;
 const H = VIEWBOX_HEIGHT;
 
-const TRUNK_ENTRY_MIN_PX = 15;
+export const TRUNK_ENTRY_MIN_PX = 15;
 const RADIAL_JITTER_FACTOR = 0.15;
 const ACUTE_ANGLE_THRESHOLD_RAD = Math.PI / 2;
 // Sub-branch widths pre-scaled by 1.75 (issue #4 base rescale).
@@ -206,11 +206,6 @@ export function getShapeDefinition(shape: TreeShape): ShapeDefinition {
 // Trunk helpers
 // ---------------------------------------------------------------------------
 
-export function computeTrunkTop(shapeDef: ShapeDefinition, blobs: readonly Blob[]): number {
-	const blobsBounds = getBlobsBounds(blobs);
-	return Math.min(shapeDef.defaultTrunkTop, blobsBounds.maxY - TRUNK_ENTRY_MIN_PX);
-}
-
 export function computeEffectiveTrunkTop(shapeDef: ShapeDefinition, trunkHeight: number): number {
 	const trunkBottom = shapeDef.trunkBottom;
 	const defaultTop = shapeDef.defaultTrunkTop;
@@ -266,12 +261,13 @@ export function generateTiers(
 	blobCloseness: number,
 	blobSizeVariance: number,
 	canopySize: number,
+	verticalShift: number,
 ): Tier[] {
 	const tiers: Tier[] = [];
 	const count = Math.max(1, blobCount);
 	const centerX = W / 2;
-	const tipY = H * 0.05;
-	const baseY = H * 0.6;
+	const tipY = H * 0.05 + verticalShift;
+	const baseY = H * 0.6 + verticalShift;
 	const totalHeight = baseY - tipY;
 
 	const canopyScale = canopySize / 100;


### PR DESCRIPTION
## Description

- Compute `canopyDelta = effectiveTrunkTop - shapeDef.defaultTrunkTop` and shift every blob `cy` (and pine tier Y coords) by delta before computing canopy bounds — so the canopy visibly moves with the trunk height slider.
- Inline the penetration-invariant clamp (`trunkTop ≤ canopyBounds.maxY − TRUNK_ENTRY_MIN_PX`) using the shifted bounds; drop the now-redundant `computeTrunkTop` helper that clamped to `defaultTrunkTop` and masked the bug.
- `generateTiers` now takes an explicit `verticalShift` parameter so pine tiers track the delta.

## Resolves

Closes #5

## Testing

- [x] `pnpm run check:all`
- [x] `pnpm run test` (61 passed — 3 new REQ-T-02b tests)
- [x] `pnpm run test:e2e` (8 passed)
- [x] Unit: oak canopy centroid shifts by +75 when `trunkHeight` drops 100→50
- [x] Unit: pine canopy centroid shifts by +60 when `trunkHeight` drops 100→50
- [x] Unit: oak canopy shift equals trunk-top shift
- [x] Unit: trunk-penetration invariant holds for oak/pine/birch at 50/100/150