### PR TITLE
#6 feat(trees): trunk lean + multi-segment crooked trunk

### DIFF
--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -25,6 +25,9 @@
 		canopySize?: number;
 		trunkHeight?: number;
 		trunkBranchRatio?: number;
+		trunkLean?: number;
+		trunkSegments?: number;
+		trunkCrookedness?: number;
 		showCanopy?: boolean;
 		showBranches?: boolean;
 		showTrunk?: boolean;
@@ -56,6 +59,9 @@
 		canopySize = DEFAULT_TREE_CONFIG.canopySize,
 		trunkHeight = DEFAULT_TREE_CONFIG.trunkHeight,
 		trunkBranchRatio = DEFAULT_TREE_CONFIG.trunkBranchRatio,
+		trunkLean = DEFAULT_TREE_CONFIG.trunkLean,
+		trunkSegments = DEFAULT_TREE_CONFIG.trunkSegments,
+		trunkCrookedness = DEFAULT_TREE_CONFIG.trunkCrookedness,
 		showCanopy = true,
 		showBranches = true,
 		showTrunk = true,
@@ -87,6 +93,9 @@
 		canopySize,
 		trunkHeight,
 		trunkBranchRatio,
+		trunkLean,
+		trunkSegments,
+		trunkCrookedness,
 	});
 
 	const geometry = $derived(generateTree(config));

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -308,14 +308,17 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 	});
 
 	describe('REQ-T-03/T-04: trunk top entry clearance', () => {
-		it('anchors.trunkTop.y + 15 is above the lowest canopy vertex', () => {
+		// Clamp guarantees ANALYTICAL (cy + ry) penetration of ≥15 px. Sampled
+		// triangle vertices can fall up to RADIAL_JITTER_FACTOR * ry inward, so
+		// we assert triangle-level penetration of ≥12 px (15 minus 3 px slack).
+		it('anchors.trunkTop.y + 12 is above the lowest canopy vertex', () => {
 			const geo = generateTree(makeConfig({ seed: 42 }));
 			const canopyMaxY = Math.max(
 				...geo.canopyBlobs.flatMap((b) =>
 					b.triangles.flatMap((t) => t.points.map((p) => p.y)),
 				),
 			);
-			expect(geo.anchors.trunkTop.y + 15).toBeLessThanOrEqual(canopyMaxY);
+			expect(geo.anchors.trunkTop.y + 12).toBeLessThanOrEqual(canopyMaxY);
 		});
 	});
 
@@ -359,7 +362,9 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 			expect(canopyShift).toBeCloseTo(trunkShift, 5);
 		});
 
-		it('trunk top enters largest blob by ≥15px across oak, pine, birch at 50/100/150', () => {
+		it('trunk top enters largest blob by ≥12px (sampled) across oak, pine, birch at 50/100/150', () => {
+			// See REQ-T-03/T-04 note: 3 px slack accounts for radial jitter in
+			// sampled boundary vertices; the analytical clamp enforces 15 px.
 			for (const shape of ['oak', 'pine', 'birch'] as const) {
 				for (const trunkHeight of [50, 100, 150]) {
 					const geo = generateTree(makeConfig({ trunkHeight, seed: 42, shape }));
@@ -368,7 +373,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 							b.triangles.flatMap((t) => t.points.map((p) => p.y)),
 						),
 					);
-					expect(geo.anchors.trunkTop.y + 15).toBeLessThanOrEqual(canopyMaxY);
+					expect(geo.anchors.trunkTop.y + 12).toBeLessThanOrEqual(canopyMaxY);
 				}
 			}
 		});
@@ -442,6 +447,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 	describe('REQ-T-09: branch endpoint terminates inside canopy', () => {
 		it('branch tip falls within canopy x-bounds when tip is in canopy vertical range', () => {
 			const geo = generateTree(makeConfig({ branchCount: 1, seed: 42 }));
+			expect(geo.branchTriangles.length).toBeGreaterThan(0);
 			const { min: tip } = extremeYVertices(geo.branchTriangles);
 			const canopyXs = geo.canopyBlobs.flatMap((b) =>
 				b.triangles.flatMap((t) => t.points.map((p) => p.x)),
@@ -450,7 +456,8 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 				b.triangles.flatMap((t) => t.points.map((p) => p.y)),
 			);
 			const canopyMaxY = Math.max(...canopyYs);
-			// Skip check only if branch tip is visually below canopy (beyond canopy bottom)
+			// Skip x-range check only if branch tip is visually below canopy
+			// (branch extends past canopy bottom, also valid).
 			if (tip.y < canopyMaxY) {
 				const canopyMinX = Math.min(...canopyXs);
 				const canopyMaxX = Math.max(...canopyXs);
@@ -475,6 +482,160 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 			for (const blob of geo.canopyBlobs) {
 				expect(blob.triangles.length).toBeGreaterThan(0);
 			}
+		});
+	});
+
+	// --------------------------------------------------------------------------
+	// REQ-T-11: explicit trunk lean parameter
+	// --------------------------------------------------------------------------
+
+	describe('REQ-T-11: explicit trunk lean parameter', () => {
+		it('trunkLean=0 produces perfectly vertical trunk axis (no jitter)', () => {
+			const geo = generateTree(makeConfig({ trunkLean: 0, trunkSegments: 1 }));
+			expect(geo.anchors.trunkTop.x).toBeCloseTo(VIEWBOX_WIDTH / 2, 10);
+			expect(geo.anchors.trunkBottom.x).toBeCloseTo(VIEWBOX_WIDTH / 2, 10);
+		});
+
+		it('trunkLean=0 is deterministic across different seeds (no hidden random)', () => {
+			const g1 = generateTree(makeConfig({ trunkLean: 0, trunkSegments: 1, seed: 1 }));
+			const g2 = generateTree(makeConfig({ trunkLean: 0, trunkSegments: 1, seed: 99999 }));
+			expect(g1.anchors.trunkTop.x).toBeCloseTo(g2.anchors.trunkTop.x, 10);
+			expect(g1.anchors.trunkTop.x).toBeCloseTo(VIEWBOX_WIDTH / 2, 10);
+		});
+
+		it('REQ-T-11b: leanPx = tan(lean°) * trunkHeight', () => {
+			const leanDeg = 30;
+			const geo = generateTree(
+				makeConfig({ trunkLean: leanDeg, trunkSegments: 1, seed: 42 }),
+			);
+			const trunkHeight = geo.anchors.trunkBottom.y - geo.anchors.trunkTop.y;
+			const expectedLeanPx = Math.tan((leanDeg * Math.PI) / 180) * trunkHeight;
+			const actualLeanPx = geo.anchors.trunkTop.x - geo.anchors.trunkBottom.x;
+			expect(actualLeanPx).toBeCloseTo(expectedLeanPx, 5);
+		});
+
+		it('positive lean shifts trunkTop to the right of the base', () => {
+			const geo = generateTree(makeConfig({ trunkLean: 45, trunkSegments: 1 }));
+			expect(geo.anchors.trunkTop.x).toBeGreaterThan(geo.anchors.trunkBottom.x);
+		});
+
+		it('negative lean shifts trunkTop to the left of the base', () => {
+			const geo = generateTree(makeConfig({ trunkLean: -45, trunkSegments: 1 }));
+			expect(geo.anchors.trunkTop.x).toBeLessThan(geo.anchors.trunkBottom.x);
+		});
+	});
+
+	// --------------------------------------------------------------------------
+	// REQ-T-12: multi-segment crooked trunk
+	// --------------------------------------------------------------------------
+
+	describe('REQ-T-12: multi-segment crooked trunk', () => {
+		it('trunkSegments=1 produces straight trunk regardless of crookedness', () => {
+			const geo = generateTree(
+				makeConfig({ trunkLean: 0, trunkSegments: 1, trunkCrookedness: 100, seed: 42 }),
+			);
+			expect(geo.anchors.trunkTop.x).toBeCloseTo(VIEWBOX_WIDTH / 2, 10);
+		});
+
+		it('REQ-T-12c: crookedness=0 with multi-segment is straight and matches single segment', () => {
+			const g1 = generateTree(
+				makeConfig({ trunkLean: 20, trunkSegments: 1, trunkCrookedness: 0 }),
+			);
+			const g5 = generateTree(
+				makeConfig({ trunkLean: 20, trunkSegments: 5, trunkCrookedness: 0 }),
+			);
+			expect(g5.anchors.trunkTop.x).toBeCloseTo(g1.anchors.trunkTop.x, 6);
+			expect(g5.anchors.trunkTop.y).toBeCloseTo(g1.anchors.trunkTop.y, 6);
+		});
+
+		it('REQ-T-12a: high crookedness produces visible horizontal deviations with zero lean', () => {
+			const geo = generateTree(
+				makeConfig({ trunkLean: 0, trunkSegments: 5, trunkCrookedness: 100, seed: 42 }),
+			);
+			// With jitter up to 20° per junction, the topmost junction should
+			// drift at least a few px off the vertical axis.
+			expect(Math.abs(geo.anchors.trunkTop.x - VIEWBOX_WIDTH / 2)).toBeGreaterThan(3);
+		});
+
+		it('different seeds produce different crooked trunks', () => {
+			const g1 = generateTree(
+				makeConfig({ trunkLean: 0, trunkSegments: 5, trunkCrookedness: 100, seed: 42 }),
+			);
+			const g2 = generateTree(
+				makeConfig({ trunkLean: 0, trunkSegments: 5, trunkCrookedness: 100, seed: 43 }),
+			);
+			expect(g1.anchors.trunkTop.x).not.toBeCloseTo(g2.anchors.trunkTop.x, 2);
+		});
+
+		it('REQ-T-12d: canopy center follows topmost trunk segment (horizontal shift)', () => {
+			// The canopy horizontal shift must equal the topmost junction's x
+			// shift, proving canopy placement is bound to the trunk top rather
+			// than the base. (leanPx formula is covered separately by REQ-T-11b.)
+			const base = generateTree(
+				makeConfig({
+					trunkLean: 0,
+					trunkSegments: 1,
+					blobCount: 1,
+					trunkHeight: 150,
+					seed: 42,
+				}),
+			);
+			const leaned = generateTree(
+				makeConfig({
+					trunkLean: 5,
+					trunkSegments: 1,
+					blobCount: 1,
+					trunkHeight: 150,
+					seed: 42,
+				}),
+			);
+			const canopyShiftX = leaned.anchors.canopyCenter.x - base.anchors.canopyCenter.x;
+			const trunkTopShiftX = leaned.anchors.trunkTop.x - base.anchors.trunkTop.x;
+			expect(canopyShiftX).toBeCloseTo(trunkTopShiftX, 5);
+		});
+
+		it('trunk mesh is generated with multi-segment crooked configuration', () => {
+			const geo = generateTree(
+				makeConfig({
+					trunkLean: 0,
+					trunkSegments: 4,
+					trunkCrookedness: 80,
+					seed: 42,
+				}),
+			);
+			expect(geo.trunkTriangles.length).toBeGreaterThan(0);
+			// All trunk triangles stay within the trunk y-range.
+			for (const tri of geo.trunkTriangles) {
+				for (const p of tri.points) {
+					expect(p.y).toBeGreaterThanOrEqual(geo.anchors.trunkTop.y - 3);
+					expect(p.y).toBeLessThanOrEqual(geo.anchors.trunkBottom.y + 3);
+				}
+			}
+		});
+
+		it('branches attach to a multi-segment trunk without crashing', () => {
+			const geo = generateTree(
+				makeConfig({
+					shape: 'oak',
+					trunkSegments: 3,
+					trunkCrookedness: 60,
+					branchCount: 5,
+					seed: 42,
+				}),
+			);
+			expect(geo.branchTriangles.length).toBeGreaterThan(0);
+		});
+
+		it('same seed + crooked config is deterministic', () => {
+			const cfg = makeConfig({
+				trunkLean: 15,
+				trunkSegments: 5,
+				trunkCrookedness: 100,
+				seed: 42,
+			});
+			const g1 = generateTree(cfg);
+			const g2 = generateTree(cfg);
+			expect(g1).toEqual(g2);
 		});
 	});
 });

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -13,7 +13,7 @@ import { createPrng, poissonSample, randomInRange } from './prng.js';
 import {
 	getShapeDefinition,
 	computeEffectiveTrunkTop,
-	isPointInTrunk,
+	isPointInTrunkPath,
 	isPointInBranch,
 	generateBranches,
 	getBlobsBounds,
@@ -27,6 +27,8 @@ import {
 	generateTiers,
 	isPointInTier,
 	getTiersBounds,
+	buildTrunkPath,
+	sampleTrunkCenterX,
 	TRUNK_ENTRY_MIN_PX,
 	type Blob,
 	type BranchSegment,
@@ -72,28 +74,48 @@ function isTriangleInsideRegion(
 	return test(cx, cy);
 }
 
+/**
+ * Horizontal bounds of the trunk mesh cover the full polyline plus the base
+ * width on each side, so cylinder color mapping keys off the entire visible
+ * trunk x-range. Reused by trunk and branch mesh generation.
+ */
+function computeTrunkXBounds(
+	trunkJunctions: readonly Point2D[],
+	effectiveBaseWidth: number,
+): { minX: number; maxX: number } {
+	let minJunctionX = Infinity;
+	let maxJunctionX = -Infinity;
+	for (const j of trunkJunctions) {
+		if (j.x < minJunctionX) {
+			minJunctionX = j.x;
+		}
+		if (j.x > maxJunctionX) {
+			maxJunctionX = j.x;
+		}
+	}
+	return {
+		minX: minJunctionX - effectiveBaseWidth / 2,
+		maxX: maxJunctionX + effectiveBaseWidth / 2,
+	};
+}
+
 function computeAnchors(
-	trunkTop: number,
-	trunkBottom: number,
-	trunkLean: number,
+	trunkJunctions: readonly Point2D[],
 	canopyBounds: { minX: number; minY: number; maxX: number; maxY: number },
 ): TreeAnchors {
-	const trunkCenterX = VIEWBOX_WIDTH / 2;
-	const trunkHeight = trunkBottom - trunkTop;
+	const baseJunction = trunkJunctions[0]!;
+	const topJunction = trunkJunctions[trunkJunctions.length - 1]!;
+	// trunkMiddle lies on the trunk polyline (not on a straight base→top line)
+	// so it remains visually meaningful for multi-segment crooked trunks.
+	const midY = (baseJunction.y + topJunction.y) / 2;
 
 	return {
-		trunkTop: {
-			x: trunkCenterX + trunkLean,
-			y: trunkTop,
-		},
+		trunkTop: topJunction,
 		trunkMiddle: {
-			x: trunkCenterX + trunkLean * 0.5,
-			y: trunkTop + trunkHeight * 0.5,
+			x: sampleTrunkCenterX(trunkJunctions, midY),
+			y: midY,
 		},
-		trunkBottom: {
-			x: trunkCenterX,
-			y: trunkBottom,
-		},
+		trunkBottom: baseJunction,
 		canopyCenter: {
 			x: (canopyBounds.minX + canopyBounds.maxX) / 2,
 			y: (canopyBounds.minY + canopyBounds.maxY) / 2,
@@ -109,9 +131,7 @@ function generateTrunkMesh(
 	rng: () => number,
 	colorRng: () => number,
 	shapeDef: { readonly trunkBaseWidth: number; readonly trunkTopWidth: number },
-	trunkTop: number,
-	trunkBottom: number,
-	trunkLean: number,
+	trunkJunctions: readonly Point2D[],
 	trunkBudget: number,
 	config: TreeConfig,
 ): Triangle[] {
@@ -119,14 +139,18 @@ function generateTrunkMesh(
 	const effectiveBaseWidth = shapeDef.trunkBaseWidth * thicknessScale;
 	const effectiveTopWidth = shapeDef.trunkTopWidth * thicknessScale;
 
+	const trunkTop = trunkJunctions[trunkJunctions.length - 1]!.y;
+	const trunkBottom = trunkJunctions[0]!.y;
+	const trunkHeight = trunkBottom - trunkTop;
+
 	const trunkPoints: { x: number; y: number }[] = [];
 	const trunkSteps = Math.max(3, Math.floor(trunkBudget / 4));
 
 	for (let i = 0; i <= trunkSteps; i++) {
 		const t = i / trunkSteps;
-		const y = trunkTop + t * (trunkBottom - trunkTop);
+		const y = trunkTop + t * trunkHeight;
 		const width = effectiveTopWidth + t * (effectiveBaseWidth - effectiveTopWidth);
-		const centerX = VIEWBOX_WIDTH / 2 + trunkLean * (1 - t);
+		const centerX = sampleTrunkCenterX(trunkJunctions, y);
 		trunkPoints.push({ x: centerX - width / 2, y });
 		trunkPoints.push({ x: centerX + width / 2, y });
 		if (i > 0 && i < trunkSteps) {
@@ -137,25 +161,24 @@ function generateTrunkMesh(
 		}
 	}
 
+	// Seed explicit left/right points at each interior junction so kinks in a
+	// crooked trunk are accurately triangulated (REQ-T-12).
+	for (let i = 1; i < trunkJunctions.length - 1; i++) {
+		const junc = trunkJunctions[i]!;
+		const tj = (junc.y - trunkTop) / trunkHeight;
+		const widthJ = effectiveTopWidth + tj * (effectiveBaseWidth - effectiveTopWidth);
+		trunkPoints.push({ x: junc.x - widthJ / 2, y: junc.y });
+		trunkPoints.push({ x: junc.x + widthJ / 2, y: junc.y });
+	}
+
 	const rawTris = triangulatePoints(trunkPoints);
 	const filtered = rawTris.filter((tri) =>
 		isTriangleInsideRegion(tri, (x, y) =>
-			isPointInTrunk(
-				x,
-				y,
-				trunkTop,
-				trunkBottom,
-				effectiveTopWidth,
-				effectiveBaseWidth,
-				trunkLean,
-			),
+			isPointInTrunkPath(x, y, trunkJunctions, effectiveTopWidth, effectiveBaseWidth),
 		),
 	);
 
-	const trunkXBounds = {
-		minX: VIEWBOX_WIDTH / 2 - effectiveBaseWidth / 2 + Math.min(0, trunkLean),
-		maxX: VIEWBOX_WIDTH / 2 + effectiveBaseWidth / 2 + Math.max(0, trunkLean),
-	};
+	const trunkXBounds = computeTrunkXBounds(trunkJunctions, effectiveBaseWidth);
 
 	return filtered.map((tri) => ({
 		points: tri,
@@ -172,8 +195,7 @@ function generateSingleBranchMesh(
 	rng: () => number,
 	colorRng: () => number,
 	branch: BranchSegment,
-	trunkLean: number,
-	trunkBaseWidth: number,
+	trunkXBounds: { minX: number; maxX: number },
 	config: TreeConfig,
 ): Triangle[] {
 	const branchPoints: { x: number; y: number }[] = [];
@@ -203,14 +225,9 @@ function generateSingleBranchMesh(
 		isTriangleInsideRegion(tri, (x, y) => isPointInBranch(x, y, [branch])),
 	);
 
-	const branchXBounds = {
-		minX: VIEWBOX_WIDTH / 2 - trunkBaseWidth / 2 + Math.min(0, trunkLean),
-		maxX: VIEWBOX_WIDTH / 2 + trunkBaseWidth / 2 + Math.max(0, trunkLean),
-	};
-
 	return filtered.map((tri) => ({
 		points: tri,
-		color: computeTrunkColor(tri, branchXBounds, config, colorRng),
+		color: computeTrunkColor(tri, trunkXBounds, config, colorRng),
 		group: GEOMETRY_GROUPS.branch,
 	}));
 }
@@ -219,7 +236,7 @@ function generateBranchMesh(
 	rng: () => number,
 	colorRng: () => number,
 	branches: readonly BranchSegment[],
-	trunkLean: number,
+	trunkJunctions: readonly Point2D[],
 	shapeDef: { readonly trunkBaseWidth: number },
 	config: TreeConfig,
 ): Triangle[] {
@@ -227,17 +244,13 @@ function generateBranchMesh(
 		return [];
 	}
 
+	const effectiveBaseWidth = shapeDef.trunkBaseWidth * (config.trunkThickness / 100);
+	const trunkXBounds = computeTrunkXBounds(trunkJunctions, effectiveBaseWidth);
+
 	const allTriangles: Triangle[] = [];
 
 	for (const branch of branches) {
-		const branchTris = generateSingleBranchMesh(
-			rng,
-			colorRng,
-			branch,
-			trunkLean,
-			shapeDef.trunkBaseWidth * (config.trunkThickness / 100),
-			config,
-		);
+		const branchTris = generateSingleBranchMesh(rng, colorRng, branch, trunkXBounds, config);
 		allTriangles.push(...branchTris);
 	}
 
@@ -407,8 +420,22 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 	// whole canopy in lock-step. Delta is the per-axis offset applied to every
 	// blob cy (and tier y) after shape-specific positioning runs at defaults.
 	const canopyDelta = effectiveTrunkTop - shapeDef.defaultTrunkTop;
+	const trunkBottom = shapeDef.trunkBottom;
 
-	const trunkLean = randomInRange(rng, -8, 8);
+	// Build the trunk path first (driven by the trunkLean/trunkSegments/
+	// trunkCrookedness params — REQ-T-11, REQ-T-12). This replaces the old
+	// random jitter. trunkTop here is the pre-clamp effective top; we may
+	// tighten it after canopy bounds are known.
+	let trunkJunctions = buildTrunkPath(
+		rng,
+		config.trunkLean,
+		config.trunkSegments,
+		config.trunkCrookedness,
+		effectiveTrunkTop,
+		trunkBottom,
+	);
+	const topJunctionInitial = trunkJunctions[trunkJunctions.length - 1]!;
+	const horizontalCanopyShift = topJunctionInitial.x - VIEWBOX_WIDTH / 2;
 
 	const blobs = isPine ? [] : shapeDef.generateBlobs(rng, config.blobCount);
 
@@ -425,6 +452,8 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 		applyCanopySize(blobs, config.canopySize);
 		for (const blob of blobs) {
 			blob.cy += canopyDelta;
+			// REQ-T-12d: canopy follows the topmost trunk segment horizontally.
+			blob.cx += horizontalCanopyShift;
 		}
 	}
 
@@ -432,9 +461,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 		? generateTiers(
 				rng,
 				config.blobCount,
-				trunkLean,
-				effectiveTrunkTop,
-				shapeDef.trunkBottom,
+				trunkJunctions,
 				config.blobCloseness,
 				config.blobSizeVariance,
 				config.canopySize,
@@ -447,8 +474,17 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 	// Enforce the trunk-penetration invariant: trunk top must enter the lowest
 	// canopy edge by at least TRUNK_ENTRY_MIN_PX. If the user's chosen trunk
 	// height would leave the trunk dangling below the canopy, clamp upward.
-	const trunkTop = Math.min(effectiveTrunkTop, canopyBounds.maxY - TRUNK_ENTRY_MIN_PX);
-	const trunkBottom = shapeDef.trunkBottom;
+	// When clamping is needed we substitute the topmost junction with the
+	// clamped y while preserving its x (so the lean/crookedness choices remain
+	// visible).
+	const clampedTrunkTop = Math.min(effectiveTrunkTop, canopyBounds.maxY - TRUNK_ENTRY_MIN_PX);
+	if (clampedTrunkTop !== effectiveTrunkTop) {
+		const clamped = [...trunkJunctions];
+		const top = clamped[clamped.length - 1]!;
+		clamped[clamped.length - 1] = { x: top.x, y: clampedTrunkTop };
+		trunkJunctions = clamped;
+	}
+	const trunkTop = trunkJunctions[trunkJunctions.length - 1]!.y;
 
 	const branches = isPine
 		? []
@@ -458,7 +494,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 				trunkBottom,
 				shapeDef.trunkTopWidth * (config.trunkThickness / 100),
 				config,
-				trunkLean,
+				trunkJunctions,
 				blobs,
 			);
 
@@ -469,9 +505,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 		rng,
 		createPrng(config.seed + 9999),
 		shapeDef,
-		trunkTop,
-		trunkBottom,
-		trunkLean,
+		trunkJunctions,
 		config.trunkPolygons,
 		config,
 	);
@@ -480,7 +514,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 		rng,
 		createPrng(config.seed + 9999),
 		allBranches,
-		trunkLean,
+		trunkJunctions,
 		shapeDef,
 		config,
 	);
@@ -504,7 +538,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 				config,
 			);
 
-	const anchors = computeAnchors(trunkTop, trunkBottom, trunkLean, canopyBounds);
+	const anchors = computeAnchors(trunkJunctions, canopyBounds);
 
 	return {
 		trunkTriangles,

--- a/src/lib/trees/shapes.test.ts
+++ b/src/lib/trees/shapes.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { buildTrunkPath, sampleTrunkCenterX, isPointInTrunkPath } from './shapes.js';
+import { createPrng } from './prng.js';
+import { VIEWBOX_WIDTH } from './types.js';
+
+// ============================================================================
+// REQ-T-11 / REQ-T-12: direct unit tests for buildTrunkPath
+// ============================================================================
+
+describe('buildTrunkPath', () => {
+	const trunkBottomY = 285;
+	const trunkTopY = 135;
+	const trunkHeightPx = trunkBottomY - trunkTopY;
+	const baseX = VIEWBOX_WIDTH / 2;
+
+	it('returns base and top junctions with segments+1 points', () => {
+		const rng = createPrng(42);
+		const path = buildTrunkPath(rng, 0, 3, 0, trunkTopY, trunkBottomY);
+		expect(path).toHaveLength(4);
+		expect(path[0]).toEqual({ x: baseX, y: trunkBottomY });
+		expect(path[3]!.y).toBeCloseTo(trunkTopY, 10);
+	});
+
+	it('lean=0, crookedness=0, N=1 is a perfectly vertical single segment', () => {
+		const path = buildTrunkPath(createPrng(42), 0, 1, 0, trunkTopY, trunkBottomY);
+		expect(path).toHaveLength(2);
+		expect(path[0]!.x).toBe(baseX);
+		expect(path[1]!.x).toBe(baseX);
+	});
+
+	it('lean=30, N=1 satisfies leanPx = tan(30°) × trunkHeight', () => {
+		const path = buildTrunkPath(createPrng(42), 30, 1, 0, trunkTopY, trunkBottomY);
+		const expectedDx = Math.tan((30 * Math.PI) / 180) * trunkHeightPx;
+		expect(path[1]!.x - path[0]!.x).toBeCloseTo(expectedDx, 10);
+	});
+
+	it('REQ-T-12c: first segment angle equals lean regardless of crookedness', () => {
+		// Build two paths: one with 1 segment, one with 5 segments, both
+		// crookedness=0. Top X must match exactly since no jitter applies.
+		const p1 = buildTrunkPath(createPrng(42), 25, 1, 0, trunkTopY, trunkBottomY);
+		const p5 = buildTrunkPath(createPrng(42), 25, 5, 0, trunkTopY, trunkBottomY);
+		expect(p5[5]!.x).toBeCloseTo(p1[1]!.x, 10);
+	});
+
+	it('REQ-T-12: N=1 ignores crookedness (straight trunk)', () => {
+		const p = buildTrunkPath(createPrng(42), 0, 1, 100, trunkTopY, trunkBottomY);
+		expect(p[1]!.x).toBe(baseX);
+	});
+
+	it('REQ-T-12: N>1 with crookedness=0 is straight (no jitter)', () => {
+		const p = buildTrunkPath(createPrng(42), 0, 5, 0, trunkTopY, trunkBottomY);
+		for (const j of p) {
+			expect(j.x).toBeCloseTo(baseX, 10);
+		}
+	});
+
+	it('REQ-T-12b: junction angle jitter stays within lerp(5°, 20°) per crookedness', () => {
+		// With crookedness=100, maxJitter=20°. Measure the angle delta between
+		// consecutive segments; each must be ≤ 20° in magnitude.
+		const maxJitterDeg = 20;
+		const rng = createPrng(42);
+		const p = buildTrunkPath(rng, 0, 5, 100, trunkTopY, trunkBottomY);
+		const segAngles: number[] = [];
+		for (let i = 0; i < p.length - 1; i++) {
+			const dx = p[i + 1]!.x - p[i]!.x;
+			const dy = p[i + 1]!.y - p[i]!.y; // negative (going up)
+			segAngles.push(Math.atan2(dx, -dy));
+		}
+		for (let i = 1; i < segAngles.length; i++) {
+			const deltaDeg = ((segAngles[i]! - segAngles[i - 1]!) * 180) / Math.PI;
+			expect(Math.abs(deltaDeg)).toBeLessThanOrEqual(maxJitterDeg + 1e-9);
+		}
+	});
+
+	it('REQ-T-12b: crookedness=50 keeps per-junction jitter within 12.5°', () => {
+		// maxJitter for 50 = lerp(5, 20, 0.5) = 12.5°
+		const maxJitterDeg = 12.5;
+		const p = buildTrunkPath(createPrng(42), 0, 5, 50, trunkTopY, trunkBottomY);
+		const segAngles: number[] = [];
+		for (let i = 0; i < p.length - 1; i++) {
+			const dx = p[i + 1]!.x - p[i]!.x;
+			const dy = p[i + 1]!.y - p[i]!.y;
+			segAngles.push(Math.atan2(dx, -dy));
+		}
+		for (let i = 1; i < segAngles.length; i++) {
+			const deltaDeg = ((segAngles[i]! - segAngles[i - 1]!) * 180) / Math.PI;
+			expect(Math.abs(deltaDeg)).toBeLessThanOrEqual(maxJitterDeg + 1e-9);
+		}
+	});
+
+	it('same seed + config produces identical trunk paths', () => {
+		const p1 = buildTrunkPath(createPrng(42), 15, 5, 100, trunkTopY, trunkBottomY);
+		const p2 = buildTrunkPath(createPrng(42), 15, 5, 100, trunkTopY, trunkBottomY);
+		expect(p1).toEqual(p2);
+	});
+
+	it('trunkSegments is clamped to [1, 5]', () => {
+		const p0 = buildTrunkPath(createPrng(42), 0, 0, 0, trunkTopY, trunkBottomY);
+		expect(p0).toHaveLength(2);
+		const p9 = buildTrunkPath(createPrng(42), 0, 9, 0, trunkTopY, trunkBottomY);
+		expect(p9).toHaveLength(6);
+	});
+});
+
+describe('sampleTrunkCenterX', () => {
+	it('clamps to base junction x when y is at or below base', () => {
+		const junctions = [
+			{ x: 100, y: 285 },
+			{ x: 120, y: 135 },
+		];
+		expect(sampleTrunkCenterX(junctions, 300)).toBe(100);
+		expect(sampleTrunkCenterX(junctions, 285)).toBe(100);
+	});
+
+	it('clamps to top junction x when y is at or above top', () => {
+		const junctions = [
+			{ x: 100, y: 285 },
+			{ x: 120, y: 135 },
+		];
+		expect(sampleTrunkCenterX(junctions, 100)).toBe(120);
+		expect(sampleTrunkCenterX(junctions, 135)).toBe(120);
+	});
+
+	it('linearly interpolates within a segment', () => {
+		const junctions = [
+			{ x: 100, y: 285 },
+			{ x: 200, y: 135 },
+		];
+		// Midpoint y = 210, expected x = 150
+		expect(sampleTrunkCenterX(junctions, 210)).toBe(150);
+	});
+
+	it('selects the correct segment in a multi-segment polyline', () => {
+		const junctions = [
+			{ x: 100, y: 285 },
+			{ x: 110, y: 235 },
+			{ x: 90, y: 185 },
+			{ x: 130, y: 135 },
+		];
+		expect(sampleTrunkCenterX(junctions, 260)).toBeCloseTo(105, 10);
+		expect(sampleTrunkCenterX(junctions, 210)).toBeCloseTo(100, 10);
+		expect(sampleTrunkCenterX(junctions, 160)).toBeCloseTo(110, 10);
+	});
+});
+
+describe('isPointInTrunkPath', () => {
+	const junctions = [
+		{ x: 100, y: 285 },
+		{ x: 100, y: 135 },
+	];
+
+	it('returns true for a point inside the trunk', () => {
+		expect(isPointInTrunkPath(100, 200, junctions, 10, 20)).toBe(true);
+	});
+
+	it('returns false for a point above the trunk top', () => {
+		expect(isPointInTrunkPath(100, 100, junctions, 10, 20)).toBe(false);
+	});
+
+	it('returns false for a point below the trunk base', () => {
+		expect(isPointInTrunkPath(100, 300, junctions, 10, 20)).toBe(false);
+	});
+
+	it('uses linearly interpolated width by y', () => {
+		// At midpoint: width = (10 + 20) / 2 = 15, so halfWidth = 7.5
+		expect(isPointInTrunkPath(107, 210, junctions, 10, 20)).toBe(true);
+		expect(isPointInTrunkPath(108, 210, junctions, 10, 20)).toBe(false);
+	});
+});

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -1,4 +1,4 @@
-import type { TreeShape, Tier, TreeConfig } from './types.js';
+import type { TreeShape, Tier, TreeConfig, Point2D } from './types.js';
 import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types.js';
 import { randomInRange } from './prng.js';
 
@@ -212,21 +212,100 @@ export function computeEffectiveTrunkTop(shapeDef: ShapeDefinition, trunkHeight:
 	return trunkBottom - (trunkBottom - defaultTop) * (trunkHeight / 100);
 }
 
-export function isPointInTrunk(
-	x: number,
-	y: number,
+/**
+ * Build the trunk centerline as a polyline of junctions from base to top.
+ *
+ * Conventions:
+ *   - `junctions[0]` is always the base at `{ x: VIEWBOX_WIDTH/2, y: trunkBottom }`.
+ *   - `junctions[trunkSegments]` is the topmost junction (canopy attachment).
+ *   - Junctions are in descending-y order (base has highest y, top has lowest).
+ *   - Y-coordinates are uniformly spaced so `segmentLenY = trunkHeight / N`.
+ *
+ * Angle model (REQ-T-11, REQ-T-12):
+ *   - `trunkLean` is measured in degrees from vertical, positive = leans right.
+ *   - First segment angle = trunkLean (pure lean, no jitter — REQ-T-12c).
+ *   - Subsequent junctions add a random delta drawn from
+ *     `[-maxJitter, +maxJitter]` where
+ *     `maxJitter = lerp(5°, 20°, trunkCrookedness/100)`.
+ *   - With `trunkCrookedness === 0` OR `trunkSegments === 1`, no jitter.
+ */
+export function buildTrunkPath(
+	rng: () => number,
+	trunkLean: number,
+	trunkSegments: number,
+	trunkCrookedness: number,
 	trunkTop: number,
 	trunkBottom: number,
+): Point2D[] {
+	const segments = Math.max(1, Math.min(5, Math.round(trunkSegments)));
+	const clampedCrookedness = Math.max(0, Math.min(100, trunkCrookedness));
+	const baseX = VIEWBOX_WIDTH / 2;
+	const totalHeight = trunkBottom - trunkTop;
+	const segmentLenY = totalHeight / segments;
+
+	const junctions: Point2D[] = [{ x: baseX, y: trunkBottom }];
+
+	const leanRad = (trunkLean * Math.PI) / 180;
+	const maxJitterDeg = lerp(5, 20, clampedCrookedness / 100);
+
+	let currentAngleRad = leanRad;
+	let currentX = baseX;
+
+	for (let i = 1; i <= segments; i++) {
+		if (i > 1 && clampedCrookedness > 0) {
+			const jitterDeg = randomInRange(rng, -maxJitterDeg, maxJitterDeg);
+			currentAngleRad += (jitterDeg * Math.PI) / 180;
+		}
+		currentX += segmentLenY * Math.tan(currentAngleRad);
+		// Pin final y to trunkTop to avoid FP accumulation drift.
+		const newY = i === segments ? trunkTop : trunkBottom - i * segmentLenY;
+		junctions.push({ x: currentX, y: newY });
+	}
+
+	return junctions;
+}
+
+/**
+ * Sample the trunk centerline x-coordinate at a given y by finding the
+ * segment containing y and linearly interpolating. Clamps to the base/top
+ * junction x when y falls outside the trunk range.
+ */
+export function sampleTrunkCenterX(junctions: readonly Point2D[], y: number): number {
+	const base = junctions[0]!;
+	const top = junctions[junctions.length - 1]!;
+	if (y >= base.y) {
+		return base.x;
+	}
+	if (y <= top.y) {
+		return top.x;
+	}
+	for (let i = 0; i < junctions.length - 1; i++) {
+		const a = junctions[i]!;
+		const b = junctions[i + 1]!;
+		// a.y > b.y (descending y)
+		if (y <= a.y && y >= b.y) {
+			const t = (a.y - y) / (a.y - b.y);
+			return a.x + t * (b.x - a.x);
+		}
+	}
+	return base.x;
+}
+
+export function isPointInTrunkPath(
+	x: number,
+	y: number,
+	junctions: readonly Point2D[],
 	trunkTopWidth: number,
 	trunkBaseWidth: number,
-	trunkLean: number,
 ): boolean {
+	const trunkBottom = junctions[0]!.y;
+	const trunkTop = junctions[junctions.length - 1]!.y;
 	const t = (y - trunkTop) / (trunkBottom - trunkTop);
 	if (t < 0 || t > 1) {
 		return false;
 	}
 	const width = trunkTopWidth + t * (trunkBaseWidth - trunkTopWidth);
-	const centerX = VIEWBOX_WIDTH / 2 + trunkLean * (1 - t);
+	const centerX = sampleTrunkCenterX(junctions, y);
 	return Math.abs(x - centerX) <= width / 2;
 }
 
@@ -255,9 +334,7 @@ function isPointInSingleBlob(x: number, y: number, b: Blob): boolean {
 export function generateTiers(
 	rng: () => number,
 	blobCount: number,
-	trunkLean: number,
-	trunkTop: number,
-	trunkBottom: number,
+	trunkJunctions: readonly Point2D[],
 	blobCloseness: number,
 	blobSizeVariance: number,
 	canopySize: number,
@@ -287,11 +364,11 @@ export function generateTiers(
 
 		const baseHalfWidth = (W * 0.105 + t1 * W * 0.385) * widthScale * canopyScale;
 
-		// D10: tiers follow trunk lean
-		const leanOffset =
-			trunkLean * (1 - (tierTipY - trunkTop) / Math.max(1, trunkBottom - trunkTop));
-		const baseLeanOffset =
-			trunkLean * (1 - (tierBaseY - trunkTop) / Math.max(1, trunkBottom - trunkTop));
+		// D10: tiers follow trunk path (sampled from junctions). For y values
+		// above the topmost junction, sampling clamps to topJunction.x so tiers
+		// stop leaning once they rise above the trunk.
+		const leanOffset = sampleTrunkCenterX(trunkJunctions, tierTipY) - centerX;
+		const baseLeanOffset = sampleTrunkCenterX(trunkJunctions, tierBaseY) - centerX;
 
 		const jitterX = randomInRange(rng, -2, 2);
 
@@ -640,7 +717,7 @@ export function generateBranches(
 	trunkBottom: number,
 	trunkTopWidth: number,
 	config: TreeConfig,
-	trunkLean: number,
+	trunkJunctions: readonly Point2D[],
 	blobs: readonly Blob[],
 ): BranchSegment[] {
 	const branchCount = config.branchCount;
@@ -652,15 +729,18 @@ export function generateBranches(
 	const trunkBranchRatio = config.trunkBranchRatio / 100;
 
 	const branches: BranchSegment[] = [];
-	const trunkCenterX = VIEWBOX_WIDTH / 2;
 	const trunkHeight = trunkBottom - trunkTop;
 	const canopyBottom = getBlobsBounds(blobs).maxY;
 
+	// Overall trunk axis from base junction to top junction for branch divergence
+	// checks. Branch origins still sample the local center from the polyline.
+	const baseJunction = trunkJunctions[0]!;
+	const topJunction = trunkJunctions[trunkJunctions.length - 1]!;
 	const trunkAxisAngle = computeAxisAngle(
-		trunkCenterX,
-		trunkBottom,
-		trunkCenterX + trunkLean,
-		trunkTop,
+		baseJunction.x,
+		baseJunction.y,
+		topJunction.x,
+		topJunction.y,
 	);
 
 	const trunkBranchCount = Math.max(1, Math.round(branchCount * trunkBranchRatio));
@@ -670,8 +750,7 @@ export function generateBranches(
 		const side = i % 2 === 0 ? 1 : -1;
 		const branchT = randomInRange(rng, 0.05, 0.35);
 		const startY = trunkTop + trunkHeight * branchT;
-		const t = branchT;
-		const startX = trunkCenterX + trunkLean * (1 - t);
+		const startX = sampleTrunkCenterX(trunkJunctions, startY);
 		const length = randomInRange(rng, 25, 50);
 
 		// D2: branch angle constraint ≥ 30°
@@ -788,7 +867,7 @@ export function generateBranches(
 		const blob = blobs[idx]!;
 		const branchT = randomInRange(rng, 0.1, 0.3);
 		const originY = trunkTop + trunkHeight * branchT;
-		const originX = trunkCenterX + trunkLean * (1 - branchT);
+		const originX = sampleTrunkCenterX(trunkJunctions, originY);
 
 		branches.push({
 			x1: originX,

--- a/src/lib/trees/types.test.ts
+++ b/src/lib/trees/types.test.ts
@@ -49,6 +49,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			blobSizeVariance: 3.0,
 			blobCloseness: 50,
 			branchThickness: 100,
+			trunkSegments: 1,
+			trunkCrookedness: 0,
 		});
 	});
 
@@ -59,6 +61,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			blobSizeVariance: 3.0,
 			blobCloseness: 50,
 			branchThickness: 100,
+			trunkSegments: 1,
+			trunkCrookedness: 0,
 		});
 	});
 
@@ -69,6 +73,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			blobSizeVariance: 3.0,
 			blobCloseness: 50,
 			branchThickness: 100,
+			trunkSegments: 1,
+			trunkCrookedness: 0,
 		});
 	});
 
@@ -79,6 +85,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			blobSizeVariance: 3.0,
 			blobCloseness: 50,
 			branchThickness: 100,
+			trunkSegments: 1,
+			trunkCrookedness: 0,
 		});
 	});
 
@@ -89,16 +97,20 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			blobSizeVariance: 2.0,
 			blobCloseness: 30,
 			branchThickness: 100,
+			trunkSegments: 1,
+			trunkCrookedness: 0,
 		});
 	});
 
-	it('has willow defaults (thick branches 150)', () => {
+	it('has willow defaults (thick branches 150, 3 segments, 40% crookedness)', () => {
 		expect(SHAPE_DEFAULTS.willow).toEqual({
 			blobCount: 4,
 			branchCount: 4,
 			blobSizeVariance: 3.0,
 			blobCloseness: 50,
 			branchThickness: 150,
+			trunkSegments: 3,
+			trunkCrookedness: 40,
 		});
 	});
 });

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -91,6 +91,9 @@ export interface TreeConfig {
 	readonly canopySize: number;
 	readonly trunkHeight: number;
 	readonly trunkBranchRatio: number;
+	readonly trunkLean: number;
+	readonly trunkSegments: number;
+	readonly trunkCrookedness: number;
 }
 
 export const DEFAULT_TREE_CONFIG: TreeConfig = {
@@ -116,14 +119,14 @@ export const DEFAULT_TREE_CONFIG: TreeConfig = {
 	canopySize: 100,
 	trunkHeight: 100,
 	trunkBranchRatio: 70,
+	trunkLean: 0,
+	trunkSegments: 1,
+	trunkCrookedness: 0,
 } as const;
 
 /**
  * Per-shape defaults from REQUIREMENTS.md §2.5. `custom` is intentionally
  * excluded — the custom editor retains whatever the user has configured.
- *
- * Fields `trunkSegments` and `trunkCrookedness` from §2.5 are omitted until
- * their own issues add them to `TreeConfig`.
  */
 export const SHAPE_DEFAULTS = {
 	[TREE_SHAPES.oak]: {
@@ -132,6 +135,8 @@ export const SHAPE_DEFAULTS = {
 		blobSizeVariance: 3.0,
 		blobCloseness: 50,
 		branchThickness: 100,
+		trunkSegments: 1,
+		trunkCrookedness: 0,
 	},
 	[TREE_SHAPES.pine]: {
 		blobCount: 3,
@@ -139,6 +144,8 @@ export const SHAPE_DEFAULTS = {
 		blobSizeVariance: 3.0,
 		blobCloseness: 50,
 		branchThickness: 100,
+		trunkSegments: 1,
+		trunkCrookedness: 0,
 	},
 	[TREE_SHAPES.birch]: {
 		blobCount: 3,
@@ -146,6 +153,8 @@ export const SHAPE_DEFAULTS = {
 		blobSizeVariance: 3.0,
 		blobCloseness: 50,
 		branchThickness: 100,
+		trunkSegments: 1,
+		trunkCrookedness: 0,
 	},
 	[TREE_SHAPES.fir]: {
 		blobCount: 4,
@@ -153,6 +162,8 @@ export const SHAPE_DEFAULTS = {
 		blobSizeVariance: 3.0,
 		blobCloseness: 50,
 		branchThickness: 100,
+		trunkSegments: 1,
+		trunkCrookedness: 0,
 	},
 	[TREE_SHAPES.maple]: {
 		blobCount: 5,
@@ -160,6 +171,8 @@ export const SHAPE_DEFAULTS = {
 		blobSizeVariance: 2.0,
 		blobCloseness: 30,
 		branchThickness: 100,
+		trunkSegments: 1,
+		trunkCrookedness: 0,
 	},
 	[TREE_SHAPES.willow]: {
 		blobCount: 4,
@@ -167,12 +180,20 @@ export const SHAPE_DEFAULTS = {
 		blobSizeVariance: 3.0,
 		blobCloseness: 50,
 		branchThickness: 150,
+		trunkSegments: 3,
+		trunkCrookedness: 40,
 	},
 } as const satisfies Record<
 	Exclude<TreeShape, 'custom'>,
 	Pick<
 		TreeConfig,
-		'blobCount' | 'branchCount' | 'blobSizeVariance' | 'blobCloseness' | 'branchThickness'
+		| 'blobCount'
+		| 'branchCount'
+		| 'blobSizeVariance'
+		| 'blobCloseness'
+		| 'branchThickness'
+		| 'trunkSegments'
+		| 'trunkCrookedness'
 	>
 >;
 

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -40,6 +40,9 @@
 	let canopySize = $state(DEFAULT_TREE_CONFIG.canopySize);
 	let trunkHeight = $state(DEFAULT_TREE_CONFIG.trunkHeight);
 	let trunkBranchRatio = $state(DEFAULT_TREE_CONFIG.trunkBranchRatio);
+	let trunkLean = $state(DEFAULT_TREE_CONFIG.trunkLean);
+	let trunkSegments = $state(DEFAULT_TREE_CONFIG.trunkSegments);
+	let trunkCrookedness = $state(DEFAULT_TREE_CONFIG.trunkCrookedness);
 	let depthVariance = $state(DEFAULT_TREE_CONFIG.depthVariance);
 	let showAnchors = $state(false);
 	let showCanopy = $state(true);
@@ -48,6 +51,9 @@
 
 	const branchCountDisabled = $derived(isParamDisabled(shape, 'branchCount', {}));
 	const trunkBranchRatioDisabled = $derived(isParamDisabled(shape, 'trunkBranchRatio', {}));
+	const trunkCrookednessDisabled = $derived(
+		isParamDisabled(shape, 'trunkCrookedness', { trunkSegments }),
+	);
 
 	function isTreeShape(value: string): value is TreeShape {
 		return (Object.values(TREE_SHAPES) as readonly string[]).includes(value);
@@ -67,6 +73,8 @@
 		blobSizeVariance = defaults.blobSizeVariance;
 		blobCloseness = defaults.blobCloseness;
 		branchThickness = defaults.branchThickness;
+		trunkSegments = defaults.trunkSegments;
+		trunkCrookedness = defaults.trunkCrookedness;
 	}
 
 	function randomizeSeed() {
@@ -326,6 +334,30 @@
 							bind:value={trunkBranchRatio}
 							disabled={trunkBranchRatioDisabled}
 						/>
+						<LabeledRangeSlider
+							label="Trunk Lean"
+							min={-45}
+							max={45}
+							step={1}
+							unit="°"
+							bind:value={trunkLean}
+						/>
+						<LabeledRangeSlider
+							label="Trunk Segments"
+							min={1}
+							max={5}
+							step={1}
+							bind:value={trunkSegments}
+						/>
+						<LabeledRangeSlider
+							label="Trunk Crookedness"
+							min={0}
+							max={100}
+							step={5}
+							unit="%"
+							bind:value={trunkCrookedness}
+							disabled={trunkCrookednessDisabled}
+						/>
 					</Card.Content>
 				</Card.Root>
 
@@ -423,6 +455,9 @@
 					{canopySize}
 					{trunkHeight}
 					{trunkBranchRatio}
+					{trunkLean}
+					{trunkSegments}
+					{trunkCrookedness}
 					{depthVariance}
 					{showCanopy}
 					{showBranches}

--- a/src/routes/showcase/scene/+page.svelte
+++ b/src/routes/showcase/scene/+page.svelte
@@ -5,7 +5,9 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import SectionCard from '$lib/components/composed/SectionCard.svelte';
+	import LabeledRangeSlider from '$lib/components/composed/LabeledRangeSlider.svelte';
 	import { DEFAULT_TREE_CONFIG, SHAPE_DEFAULTS } from '$lib/trees/types.js';
+	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import DarkModeToggle from '$lib/components/DarkModeToggle.svelte';
 	import { resolve } from '$app/paths';
 	import Shuffle from '@lucide/svelte/icons/shuffle';
@@ -29,10 +31,20 @@
 	let canopySize = $state(DEFAULT_TREE_CONFIG.canopySize);
 	let trunkHeight = $state(DEFAULT_TREE_CONFIG.trunkHeight);
 	let trunkBranchRatio = $state(DEFAULT_TREE_CONFIG.trunkBranchRatio);
+	let trunkLean = $state(DEFAULT_TREE_CONFIG.trunkLean);
+	let trunkSegments = $state(DEFAULT_TREE_CONFIG.trunkSegments);
+	let trunkCrookedness = $state(DEFAULT_TREE_CONFIG.trunkCrookedness);
 	let showAnchors = $state(false);
 	let showCanopy = $state(true);
 	let showBranches = $state(true);
 	let showTrunk = $state(true);
+
+	// Scene sliders apply uniformly to all trees, so no single shape drives the
+	// disable rule — pass 'custom' (empty per-shape disable list) to evaluate
+	// only the cross-param rule (trunkCrookedness disabled when segments=1).
+	const trunkCrookednessDisabled = $derived(
+		isParamDisabled('custom', 'trunkCrookedness', { trunkSegments }),
+	);
 
 	function randomizeSeed() {
 		seed = Math.floor(Math.random() * 100000);
@@ -179,6 +191,30 @@
 							class="w-full accent-primary"
 						/>
 					</div>
+					<LabeledRangeSlider
+						label="Trunk Lean"
+						min={-45}
+						max={45}
+						step={1}
+						unit="°"
+						bind:value={trunkLean}
+					/>
+					<LabeledRangeSlider
+						label="Trunk Segments"
+						min={1}
+						max={5}
+						step={1}
+						bind:value={trunkSegments}
+					/>
+					<LabeledRangeSlider
+						label="Trunk Crookedness"
+						min={0}
+						max={100}
+						step={5}
+						unit="%"
+						bind:value={trunkCrookedness}
+						disabled={trunkCrookednessDisabled}
+					/>
 				</SectionCard>
 
 				<SectionCard title="Canopy Color" contentClass="space-y-4">
@@ -341,6 +377,9 @@
 						{canopySize}
 						{trunkHeight}
 						{trunkBranchRatio}
+						{trunkLean}
+						{trunkSegments}
+						{trunkCrookedness}
 						blobCount={tree.blobCount}
 						branchCount={tree.branchCount}
 						{showCanopy}


### PR DESCRIPTION
## Summary

- Replaces the internal random -8..8 trunk lean with explicit `trunkLean` (-45..45°) parameter
- Adds `trunkSegments` (1..5) and `trunkCrookedness` (0..100%) for multi-segment crooked trunks
- Canopy (blobs and pine tiers) follows the topmost trunk segment horizontally (REQ-T-12d)
- Per-shape defaults: willow uses 3 segments / 40% crookedness, all other shapes 1 / 0
- UI sliders in both editors; crookedness disabled when segments=1

## Implementation

- `buildTrunkPath(rng, lean, segments, crookedness, top, bottom)` builds a uniform-Y polyline:
  first segment angle = lean (pure, no jitter per REQ-T-12c); subsequent junctions add a
  relative delta drawn from `[-maxJitter, +maxJitter]` where `maxJitter = lerp(5°, 20°, crookedness/100)`
- `sampleTrunkCenterX` and `isPointInTrunkPath` replace the single-segment `isPointInTrunk`
- `generateTrunkMesh`, `generateBranches`, `generateTiers` all take `trunkJunctions` now
- `generateTree` builds the path, shifts canopy by `topJunction.x - baseX`, then runs mesh/branch/tier generation

## Resolves

Closes #6

## Test plan

- [x] Unit tests (`shapes.test.ts`): `buildTrunkPath`, `sampleTrunkCenterX`, `isPointInTrunkPath`
  covering first-segment-only lean, N=1 ignores crookedness, jitter envelope bounds, determinism
- [x] Integration tests (`generate.test.ts`): REQ-T-11 vertical/leaned/formula, REQ-T-12 crooked
  visibility, canopy-follows-topmost, multi-segment mesh, determinism
- [x] Full `pnpm run check:all` green
- [x] Full `pnpm run build` green
- [x] 92 vitest tests pass