### PR TITLE
#7 feat(trees): branch visibility, crossing, and length params

### DIFF
--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -28,6 +28,8 @@
 		trunkLean?: number;
 		trunkSegments?: number;
 		trunkCrookedness?: number;
+		branchLength?: number;
+		branchLengthVariance?: number;
 		showCanopy?: boolean;
 		showBranches?: boolean;
 		showTrunk?: boolean;
@@ -62,6 +64,8 @@
 		trunkLean = DEFAULT_TREE_CONFIG.trunkLean,
 		trunkSegments = DEFAULT_TREE_CONFIG.trunkSegments,
 		trunkCrookedness = DEFAULT_TREE_CONFIG.trunkCrookedness,
+		branchLength = DEFAULT_TREE_CONFIG.branchLength,
+		branchLengthVariance = DEFAULT_TREE_CONFIG.branchLengthVariance,
 		showCanopy = true,
 		showBranches = true,
 		showTrunk = true,
@@ -96,6 +100,8 @@
 		trunkLean,
 		trunkSegments,
 		trunkCrookedness,
+		branchLength,
+		branchLengthVariance,
 	});
 
 	const geometry = $derived(generateTree(config));

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -445,25 +445,31 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 	});
 
 	describe('REQ-T-09: branch endpoint terminates inside canopy', () => {
-		it('branch tip falls within canopy x-bounds when tip is in canopy vertical range', () => {
+		it('branch tip is inside a canopy triangle when tip is above canopy bottom', () => {
 			const geo = generateTree(makeConfig({ branchCount: 1, seed: 42 }));
 			expect(geo.branchTriangles.length).toBeGreaterThan(0);
 			const { min: tip } = extremeYVertices(geo.branchTriangles);
-			const canopyXs = geo.canopyBlobs.flatMap((b) =>
-				b.triangles.flatMap((t) => t.points.map((p) => p.x)),
-			);
 			const canopyYs = geo.canopyBlobs.flatMap((b) =>
 				b.triangles.flatMap((t) => t.points.map((p) => p.y)),
 			);
 			const canopyMaxY = Math.max(...canopyYs);
-			// Skip x-range check only if branch tip is visually below canopy
-			// (branch extends past canopy bottom, also valid).
-			if (tip.y < canopyMaxY) {
-				const canopyMinX = Math.min(...canopyXs);
-				const canopyMaxX = Math.max(...canopyXs);
-				expect(tip.x).toBeGreaterThanOrEqual(canopyMinX);
-				expect(tip.x).toBeLessThanOrEqual(canopyMaxX);
+			// REQ-T-09: if tip is below canopy bottom, it may end in open air.
+			if (tip.y >= canopyMaxY) {
+				return;
 			}
+			// Otherwise, the tip must terminate inside a canopy blob. Check via
+			// point-in-any-canopy-triangle (the blob tessellation).
+			const allCanopyTris = geo.canopyBlobs.flatMap((b) => b.triangles);
+			const tipInsideBlob = allCanopyTris.some((tri) => {
+				const [a, b, c] = tri.points;
+				const d1 = (tip.x - b.x) * (a.y - b.y) - (a.x - b.x) * (tip.y - b.y);
+				const d2 = (tip.x - c.x) * (b.y - c.y) - (b.x - c.x) * (tip.y - c.y);
+				const d3 = (tip.x - a.x) * (c.y - a.y) - (c.x - a.x) * (tip.y - a.y);
+				const hasNeg = d1 < 0 || d2 < 0 || d3 < 0;
+				const hasPos = d1 > 0 || d2 > 0 || d3 > 0;
+				return !(hasNeg && hasPos);
+			});
+			expect(tipInsideBlob).toBe(true);
 		});
 	});
 
@@ -733,23 +739,28 @@ describe('Parameter scaling', () => {
 	});
 
 	describe('branchThickness scaling', () => {
-		it('branchThickness 200 produces wider branches than 50', () => {
+		it('branchThickness 200 produces visually thicker branches than 50', () => {
 			const geoWide = generateTree(
 				makeConfig({ branchThickness: 200, branchCount: 5, seed: 42 }),
 			);
 			const geoNarrow = generateTree(
 				makeConfig({ branchThickness: 50, branchCount: 5, seed: 42 }),
 			);
-			const getXRange = (tris: readonly Triangle[]) => {
-				if (tris.length === 0) {
-					return 0;
+			// Since issue #7 added a thickness-dependent overlap check (wider
+			// branches reject more candidates and re-roll), branch positions
+			// diverge between runs, so a naive x-range metric is unreliable.
+			// Total triangle area is a direct measure of visual thickness.
+			const totalArea = (tris: readonly Triangle[]): number => {
+				let sum = 0;
+				for (const tri of tris) {
+					const [a, b, c] = tri.points;
+					sum += Math.abs((b.x - a.x) * (c.y - a.y) - (c.x - a.x) * (b.y - a.y)) / 2;
 				}
-				const xs = tris.flatMap((t) => t.points.map((p) => p.x));
-				return Math.max(...xs) - Math.min(...xs);
+				return sum;
 			};
-			expect(getXRange(geoWide.branchTriangles)).toBeGreaterThanOrEqual(
-				getXRange(geoNarrow.branchTriangles),
-			);
+			const wideArea = totalArea(geoWide.branchTriangles);
+			const narrowArea = totalArea(geoNarrow.branchTriangles);
+			expect(wideArea).toBeGreaterThan(narrowArea);
 		});
 	});
 });

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -489,7 +489,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 	const branches = isPine
 		? []
 		: generateBranches(
-				rng,
+				createPrng(config.seed + 7777),
 				trunkTop,
 				trunkBottom,
 				shapeDef.trunkTopWidth * (config.trunkThickness / 100),

--- a/src/lib/trees/shapes.test.ts
+++ b/src/lib/trees/shapes.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { buildTrunkPath, sampleTrunkCenterX, isPointInTrunkPath } from './shapes.js';
+import {
+	buildTrunkPath,
+	sampleTrunkCenterX,
+	isPointInTrunkPath,
+	raySegmentEllipseIntersection,
+	raySegmentTriangleIntersection,
+	computeVisibleBranchLength,
+	branchesOverlap,
+	resolveBranchLengthRange,
+	generateBranches,
+	getShapeDefinition,
+	computeEffectiveTrunkTop,
+	type Blob,
+	type BranchSegment,
+} from './shapes.js';
 import { createPrng } from './prng.js';
-import { VIEWBOX_WIDTH } from './types.js';
+import { DEFAULT_TREE_CONFIG, VIEWBOX_WIDTH } from './types.js';
+import type { Tier, TreeConfig } from './types.js';
 
 // ============================================================================
 // REQ-T-11 / REQ-T-12: direct unit tests for buildTrunkPath
@@ -165,5 +180,404 @@ describe('isPointInTrunkPath', () => {
 		// At midpoint: width = (10 + 20) / 2 = 15, so halfWidth = 7.5
 		expect(isPointInTrunkPath(107, 210, junctions, 10, 20)).toBe(true);
 		expect(isPointInTrunkPath(108, 210, junctions, 10, 20)).toBe(false);
+	});
+});
+
+// ============================================================================
+// Geometry helpers for branch visibility (issue #7)
+// ============================================================================
+
+describe('raySegmentEllipseIntersection', () => {
+	it('horizontal segment through ellipse center returns diameter interval', () => {
+		// Segment (0,0)-(20,0), ellipse center (10,0) rx=5 ry=3
+		// Enters at x=5 (t=0.25), exits at x=15 (t=0.75)
+		const result = raySegmentEllipseIntersection(0, 0, 20, 0, 10, 0, 5, 3);
+		expect(result).not.toBeNull();
+		expect(result![0]).toBeCloseTo(0.25, 10);
+		expect(result![1]).toBeCloseTo(0.75, 10);
+	});
+
+	it('segment fully outside ellipse returns null', () => {
+		const result = raySegmentEllipseIntersection(0, 100, 20, 100, 10, 0, 5, 3);
+		expect(result).toBeNull();
+	});
+
+	it('segment fully inside ellipse returns [0,1]', () => {
+		// Segment (9,0)-(11,0) is inside ellipse center (10,0) rx=5 ry=3
+		const result = raySegmentEllipseIntersection(9, 0, 11, 0, 10, 0, 5, 3);
+		expect(result).not.toBeNull();
+		expect(result![0]).toBe(0);
+		expect(result![1]).toBe(1);
+	});
+
+	it('segment tangent to ellipse yields tEnter ≈ tExit without NaN', () => {
+		// Horizontal segment tangent to the top of the ellipse (y = ry = 3).
+		const result = raySegmentEllipseIntersection(0, 3, 20, 3, 10, 0, 5, 3);
+		expect(result).not.toBeNull();
+		expect(Number.isNaN(result![0])).toBe(false);
+		expect(Number.isNaN(result![1])).toBe(false);
+		expect(Math.abs(result![1] - result![0])).toBeLessThan(1e-6);
+	});
+
+	it('clips tEnter/tExit to [0,1] when segment starts inside', () => {
+		// Start inside ellipse at (10,0), exit to the right past x=15
+		const result = raySegmentEllipseIntersection(10, 0, 30, 0, 10, 0, 5, 3);
+		expect(result).not.toBeNull();
+		expect(result![0]).toBe(0);
+		expect(result![1]).toBeCloseTo(0.25, 10);
+	});
+});
+
+describe('raySegmentTriangleIntersection', () => {
+	// Simple axis-aligned triangle in Tier form (tipX,tipY is top, base at bottom)
+	const tier: Tier = {
+		tipX: 10,
+		tipY: 0,
+		baseLeftX: 0,
+		baseLeftY: 10,
+		baseRightX: 20,
+		baseRightY: 10,
+	};
+
+	it('segment passing through triangle center returns clipped interval', () => {
+		// Vertical segment through x=10 from y=-5 to y=15 fully spans the triangle vertically.
+		// Enters at y=0 (t=0.25), exits at y=10 (t=0.75)
+		const result = raySegmentTriangleIntersection(10, -5, 10, 15, tier);
+		expect(result).not.toBeNull();
+		expect(result![0]).toBeCloseTo(0.25, 6);
+		expect(result![1]).toBeCloseTo(0.75, 6);
+	});
+
+	it('segment fully outside triangle returns null', () => {
+		const result = raySegmentTriangleIntersection(100, 100, 200, 200, tier);
+		expect(result).toBeNull();
+	});
+
+	it('horizontal segment crossing triangle midline clips correctly', () => {
+		// Segment from (-5, 5) to (25, 5) crosses the triangle at y=5
+		// At y=5, left edge x = 5, right edge x = 15 (triangle halfway down)
+		// So enters at x=5 (t = 10/30 = 0.333), exits at x=15 (t = 20/30 = 0.666)
+		const result = raySegmentTriangleIntersection(-5, 5, 25, 5, tier);
+		expect(result).not.toBeNull();
+		expect(result![0]).toBeCloseTo(10 / 30, 6);
+		expect(result![1]).toBeCloseTo(20 / 30, 6);
+	});
+});
+
+describe('computeVisibleBranchLength', () => {
+	const makeBranch = (x1: number, y1: number, x2: number, y2: number): BranchSegment => ({
+		x1,
+		y1,
+		x2,
+		y2,
+		widthStart: 2,
+		widthEnd: 1,
+	});
+
+	it('returns full length when branch is fully outside any blob', () => {
+		const branch = makeBranch(0, 0, 100, 0);
+		const blobs: Blob[] = [{ cx: 500, cy: 500, rx: 10, ry: 10 }];
+		const visible = computeVisibleBranchLength(branch, blobs, []);
+		expect(visible).toBeCloseTo(100, 10);
+	});
+
+	it('returns 0 when branch is fully inside a blob', () => {
+		const branch = makeBranch(95, 100, 105, 100);
+		const blobs: Blob[] = [{ cx: 100, cy: 100, rx: 50, ry: 50 }];
+		const visible = computeVisibleBranchLength(branch, blobs, []);
+		expect(visible).toBeCloseTo(0, 6);
+	});
+
+	it('returns half length when branch is half-covered by one blob', () => {
+		// Segment from (0,0) to (20,0); blob center (15,0), rx=5, ry=5 covers x in [10, 20]
+		const branch = makeBranch(0, 0, 20, 0);
+		const blobs: Blob[] = [{ cx: 15, cy: 0, rx: 5, ry: 5 }];
+		const visible = computeVisibleBranchLength(branch, blobs, []);
+		expect(visible).toBeCloseTo(10, 6);
+	});
+
+	it('does not double-count overlapping blobs', () => {
+		// Two blobs covering same region at x in [10,20]
+		const branch = makeBranch(0, 0, 20, 0);
+		const blobs: Blob[] = [
+			{ cx: 15, cy: 0, rx: 5, ry: 5 },
+			{ cx: 15, cy: 0, rx: 5, ry: 5 },
+		];
+		const visible = computeVisibleBranchLength(branch, blobs, []);
+		expect(visible).toBeCloseTo(10, 6);
+	});
+});
+
+describe('branchesOverlap', () => {
+	const makeBranch = (x1: number, y1: number, x2: number, y2: number, w = 4): BranchSegment => ({
+		x1,
+		y1,
+		x2,
+		y2,
+		widthStart: w,
+		widthEnd: w,
+	});
+
+	it('returns false for two parallel non-overlapping branches', () => {
+		const a = makeBranch(0, 0, 100, 0);
+		const b = makeBranch(0, 50, 100, 50);
+		expect(branchesOverlap(a, b)).toBe(false);
+	});
+
+	it('returns true for two crossing thick branches', () => {
+		const a = makeBranch(0, 50, 100, 50);
+		const b = makeBranch(50, 0, 50, 100);
+		expect(branchesOverlap(a, b)).toBe(true);
+	});
+
+	it('returns true for two coincident branches', () => {
+		const a = makeBranch(0, 0, 100, 0);
+		const b = makeBranch(0, 0, 100, 0);
+		expect(branchesOverlap(a, b)).toBe(true);
+	});
+});
+
+describe('resolveBranchLengthRange', () => {
+	it('variance=0 collapses range to midpoint for both trunk and sub', () => {
+		const trunk = resolveBranchLengthRange(20, 40, 100, 0, true);
+		expect(trunk.min).toBeCloseTo(30, 10);
+		expect(trunk.max).toBeCloseTo(30, 10);
+
+		const sub = resolveBranchLengthRange(20, 40, 100, 0, false);
+		expect(sub.min).toBeCloseTo(30, 10);
+		expect(sub.max).toBeCloseTo(30, 10);
+	});
+
+	it('variance=100 branchLength=100 splits into upper/lower halves', () => {
+		const trunk = resolveBranchLengthRange(20, 40, 100, 100, true);
+		expect(trunk.min).toBeCloseTo(30, 10);
+		expect(trunk.max).toBeCloseTo(40, 10);
+
+		const sub = resolveBranchLengthRange(20, 40, 100, 100, false);
+		expect(sub.min).toBeCloseTo(20, 10);
+		expect(sub.max).toBeCloseTo(30, 10);
+	});
+
+	it('branchLength=200 scales midpoint and half-width', () => {
+		const trunk = resolveBranchLengthRange(20, 40, 200, 100, true);
+		expect(trunk.min).toBeCloseTo(60, 10);
+		expect(trunk.max).toBeCloseTo(80, 10);
+
+		const sub = resolveBranchLengthRange(20, 40, 200, 100, false);
+		expect(sub.min).toBeCloseTo(40, 10);
+		expect(sub.max).toBeCloseTo(60, 10);
+	});
+});
+
+// ============================================================================
+// generateBranches integration — visibility / crossing / retry invariants
+// ============================================================================
+
+function makeConfig(overrides: Partial<TreeConfig> = {}): TreeConfig {
+	return { ...DEFAULT_TREE_CONFIG, ...overrides };
+}
+
+/**
+ * Build the same inputs that generate.ts passes to generateBranches for oak,
+ * so tests can call it directly and inspect the raw branch list.
+ */
+function setupOakBranchInputs(config: TreeConfig): {
+	rng: () => number;
+	trunkTop: number;
+	trunkBottom: number;
+	trunkTopWidth: number;
+	trunkJunctions: { x: number; y: number }[];
+	blobs: Blob[];
+} {
+	const shapeDef = getShapeDefinition('oak');
+	const effectiveTrunkTop = computeEffectiveTrunkTop(shapeDef, config.trunkHeight);
+	const trunkBottom = shapeDef.trunkBottom;
+	const rng = createPrng(config.seed);
+	const trunkJunctions = buildTrunkPath(
+		rng,
+		config.trunkLean,
+		config.trunkSegments,
+		config.trunkCrookedness,
+		effectiveTrunkTop,
+		trunkBottom,
+	);
+	const blobs = shapeDef.generateBlobs(rng, config.blobCount);
+	return {
+		rng,
+		trunkTop: trunkJunctions[trunkJunctions.length - 1]!.y,
+		trunkBottom,
+		trunkTopWidth: shapeDef.trunkTopWidth * (config.trunkThickness / 100),
+		trunkJunctions,
+		blobs,
+	};
+}
+
+describe('generateBranches — visibility & crossing invariants', () => {
+	it('every trunk-origin branch has visible length ≥ 15', () => {
+		const config = makeConfig({ shape: 'oak', branchCount: 6, seed: 7, trunkBranchRatio: 100 });
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const branches = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		expect(branches.length).toBeGreaterThan(0);
+		for (const b of branches) {
+			const visible = computeVisibleBranchLength(b, blobs, []);
+			expect(visible).toBeGreaterThanOrEqual(15);
+		}
+	});
+
+	it('every sub-branch has visible length ≥ 10', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchCount: 10,
+			seed: 42,
+			trunkBranchRatio: 50,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const branches = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		expect(branches.length).toBeGreaterThan(0);
+		for (const b of branches) {
+			const visible = computeVisibleBranchLength(b, blobs, []);
+			expect(visible).toBeGreaterThanOrEqual(10);
+		}
+	});
+
+	it('no branch crosses the trunk center axis (sign invariant)', () => {
+		const config = makeConfig({ shape: 'oak', branchCount: 8, seed: 123 });
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const branches = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		expect(branches.length).toBeGreaterThan(0);
+		for (const b of branches) {
+			// A branch either stays on one side of the trunk axis or ends on the
+			// axis. Use the midpoint as the reference side (trunk-origin branches
+			// have startX === centerX so the start alone cannot tell us).
+			const midX = (b.x1 + b.x2) / 2;
+			const midY = (b.y1 + b.y2) / 2;
+			const centerAtMid = sampleTrunkCenterX(trunkJunctions, midY);
+			const centerAtEnd = sampleTrunkCenterX(trunkJunctions, b.y2);
+			const midSide = Math.sign(midX - centerAtMid);
+			const endSide = Math.sign(b.x2 - centerAtEnd);
+			if (midSide !== 0) {
+				expect(endSide === 0 || endSide === midSide).toBe(true);
+			} else {
+				// Midpoint exactly on axis is allowed (e.g., very short branch).
+				expect(true).toBe(true);
+			}
+		}
+	});
+
+	it('branches.length never exceeds config.branchCount', () => {
+		const config = makeConfig({ shape: 'oak', branchCount: 6, seed: 5 });
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const branches = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		expect(branches.length).toBeLessThanOrEqual(config.branchCount);
+	});
+
+	it('pathological blob covering whole tree completes fast and returns few branches', () => {
+		const config = makeConfig({ shape: 'oak', branchCount: 8, seed: 9 });
+		const setup = setupOakBranchInputs(config);
+		// Replace blobs with a single huge blob covering the whole viewbox.
+		const giantBlob: Blob[] = [{ cx: 100, cy: 150, rx: 500, ry: 500 }];
+		const start = Date.now();
+		const branches = generateBranches(
+			setup.rng,
+			setup.trunkTop,
+			setup.trunkBottom,
+			setup.trunkTopWidth,
+			config,
+			setup.trunkJunctions,
+			giantBlob,
+		);
+		const elapsed = Date.now() - start;
+		expect(elapsed).toBeLessThan(1000);
+		expect(branches.length).toBeLessThanOrEqual(config.branchCount);
+	});
+
+	it('branchLength=200 produces meaningfully longer max branch than branchLength=100', () => {
+		const base = makeConfig({ shape: 'oak', branchCount: 6, seed: 77 });
+		const short = setupOakBranchInputs(base);
+		const shortBranches = generateBranches(
+			short.rng,
+			short.trunkTop,
+			short.trunkBottom,
+			short.trunkTopWidth,
+			base,
+			short.trunkJunctions,
+			short.blobs,
+		);
+		const longConfig = { ...base, branchLength: 200 };
+		const longInputs = setupOakBranchInputs(longConfig);
+		const longBranches = generateBranches(
+			longInputs.rng,
+			longInputs.trunkTop,
+			longInputs.trunkBottom,
+			longInputs.trunkTopWidth,
+			longConfig,
+			longInputs.trunkJunctions,
+			longInputs.blobs,
+		);
+		const branchLen = (b: BranchSegment): number => Math.hypot(b.x2 - b.x1, b.y2 - b.y1);
+		const maxShort = Math.max(...shortBranches.map(branchLen));
+		const maxLong = Math.max(...longBranches.map(branchLen));
+		expect(maxLong).toBeGreaterThan(maxShort * 1.2);
+	});
+
+	it('same seed + same config → identical branch list across two runs', () => {
+		const config = makeConfig({ shape: 'oak', branchCount: 6, seed: 33 });
+		const a = setupOakBranchInputs(config);
+		const bA = generateBranches(
+			a.rng,
+			a.trunkTop,
+			a.trunkBottom,
+			a.trunkTopWidth,
+			config,
+			a.trunkJunctions,
+			a.blobs,
+		);
+		const b = setupOakBranchInputs(config);
+		const bB = generateBranches(
+			b.rng,
+			b.trunkTop,
+			b.trunkBottom,
+			b.trunkTopWidth,
+			config,
+			b.trunkJunctions,
+			b.blobs,
+		);
+		expect(bA).toEqual(bB);
 	});
 });

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -670,6 +670,328 @@ export function sampleTierBoundary(
 }
 
 // ---------------------------------------------------------------------------
+// Segment/shape intersection helpers (issue #7 — branch visibility)
+// ---------------------------------------------------------------------------
+
+/**
+ * Intersect a line segment (x1,y1)-(x2,y2) with an axis-aligned ellipse
+ * centered at (cx,cy) with radii (rx,ry). Returns the parametric entry/exit
+ * values clipped to [0,1], or null if the segment misses the ellipse.
+ *
+ * Parameterization: point on segment = (x1,y1) + t * (x2-x1, y2-y1) for t∈[0,1].
+ */
+export function raySegmentEllipseIntersection(
+	x1: number,
+	y1: number,
+	x2: number,
+	y2: number,
+	cx: number,
+	cy: number,
+	rx: number,
+	ry: number,
+): [number, number] | null {
+	if (rx <= 0 || ry <= 0) {
+		return null;
+	}
+	// Transform segment into unit-circle space (divide by rx, ry, translate to origin).
+	const ax = (x1 - cx) / rx;
+	const ay = (y1 - cy) / ry;
+	const dx = (x2 - x1) / rx;
+	const dy = (y2 - y1) / ry;
+	// |a + t*d|^2 = 1 → A t^2 + 2 B t + C = 0 where
+	//   A = d·d, B = a·d, C = a·a - 1
+	const A = dx * dx + dy * dy;
+	const B = ax * dx + ay * dy;
+	const C = ax * ax + ay * ay - 1;
+	if (A === 0) {
+		return C <= 0 ? [0, 1] : null;
+	}
+	const disc = B * B - A * C;
+	if (disc < 0) {
+		return null;
+	}
+	const sqrtDisc = Math.sqrt(Math.max(0, disc));
+	let tEnter = (-B - sqrtDisc) / A;
+	let tExit = (-B + sqrtDisc) / A;
+	if (tEnter > tExit) {
+		const tmp = tEnter;
+		tEnter = tExit;
+		tExit = tmp;
+	}
+	if (tExit < 0 || tEnter > 1) {
+		return null;
+	}
+	tEnter = Math.max(0, tEnter);
+	tExit = Math.min(1, tExit);
+	return [tEnter, tExit];
+}
+
+/**
+ * Intersect a segment with a triangle (Tier) using Liang–Barsky clipping
+ * against the three half-planes defined by its edges. Returns the parametric
+ * entry/exit values clipped to [0,1], or null if the segment misses.
+ */
+export function raySegmentTriangleIntersection(
+	x1: number,
+	y1: number,
+	x2: number,
+	y2: number,
+	triangle: Tier,
+): [number, number] | null {
+	const vertices: readonly [number, number][] = [
+		[triangle.tipX, triangle.tipY],
+		[triangle.baseRightX, triangle.baseRightY],
+		[triangle.baseLeftX, triangle.baseLeftY],
+	];
+
+	// Signed-area (cross product) for the triangle — used to pick the inward
+	// orientation of each edge normal so we can clip consistently.
+	const cross = (
+		x0: number,
+		y0: number,
+		xa: number,
+		ya: number,
+		xb: number,
+		yb: number,
+	): number => (xa - x0) * (yb - y0) - (ya - y0) * (xb - x0);
+
+	const [v0x, v0y] = vertices[0]!;
+	const [v1x, v1y] = vertices[1]!;
+	const [v2x, v2y] = vertices[2]!;
+	const orient = cross(v0x, v0y, v1x, v1y, v2x, v2y);
+	if (orient === 0) {
+		return null;
+	}
+	const sign = orient > 0 ? 1 : -1;
+
+	const dx = x2 - x1;
+	const dy = y2 - y1;
+	let tEnter = 0;
+	let tExit = 1;
+
+	for (let i = 0; i < 3; i++) {
+		const [ax, ay] = vertices[i]!;
+		const [bx, by] = vertices[(i + 1) % 3]!;
+		// Inward normal for this edge (rotate edge vector 90° depending on orientation).
+		const ex = bx - ax;
+		const ey = by - ay;
+		const nx = -ey * sign;
+		const ny = ex * sign;
+		// Half-plane: n · (p - a) >= 0 inside.
+		// n · (start - a) + t * (n · dir) >= 0
+		const startDot = nx * (x1 - ax) + ny * (y1 - ay);
+		const dirDot = nx * dx + ny * dy;
+		if (dirDot === 0) {
+			if (startDot < 0) {
+				return null;
+			}
+			continue;
+		}
+		const t = -startDot / dirDot;
+		if (dirDot > 0) {
+			// Entering the half-plane at t.
+			if (t > tEnter) {
+				tEnter = t;
+			}
+		} else {
+			// Leaving the half-plane at t.
+			if (t < tExit) {
+				tExit = t;
+			}
+		}
+		if (tEnter > tExit) {
+			return null;
+		}
+	}
+
+	return [tEnter, tExit];
+}
+
+/**
+ * Compute the portion of a branch segment that is NOT covered by any canopy
+ * blob or tier. Intervals from all shapes are merged before measuring so
+ * overlapping coverage is not double-counted.
+ */
+export function computeVisibleBranchLength(
+	branch: BranchSegment,
+	blobs: readonly Blob[],
+	tiers: readonly Tier[],
+): number {
+	const dx = branch.x2 - branch.x1;
+	const dy = branch.y2 - branch.y1;
+	const segmentLength = Math.sqrt(dx * dx + dy * dy);
+	if (segmentLength === 0) {
+		return 0;
+	}
+
+	const intervals: [number, number][] = [];
+	for (const b of blobs) {
+		const hit = raySegmentEllipseIntersection(
+			branch.x1,
+			branch.y1,
+			branch.x2,
+			branch.y2,
+			b.cx,
+			b.cy,
+			b.rx,
+			b.ry,
+		);
+		if (hit) {
+			intervals.push(hit);
+		}
+	}
+	for (const t of tiers) {
+		const hit = raySegmentTriangleIntersection(branch.x1, branch.y1, branch.x2, branch.y2, t);
+		if (hit) {
+			intervals.push(hit);
+		}
+	}
+
+	if (intervals.length === 0) {
+		return segmentLength;
+	}
+
+	// Merge overlapping intervals.
+	intervals.sort((a, b) => a[0] - b[0]);
+	let covered = 0;
+	let curStart = intervals[0]![0];
+	let curEnd = intervals[0]![1];
+	for (let i = 1; i < intervals.length; i++) {
+		const [s, e] = intervals[i]!;
+		if (s <= curEnd) {
+			if (e > curEnd) {
+				curEnd = e;
+			}
+		} else {
+			covered += curEnd - curStart;
+			curStart = s;
+			curEnd = e;
+		}
+	}
+	covered += curEnd - curStart;
+
+	const coveredFraction = Math.min(1, Math.max(0, covered));
+	return segmentLength * (1 - coveredFraction);
+}
+
+/**
+ * Returns true if two segments (p1->p2 and p3->p4) intersect as thin lines.
+ */
+function segmentsIntersect(
+	p1x: number,
+	p1y: number,
+	p2x: number,
+	p2y: number,
+	p3x: number,
+	p3y: number,
+	p4x: number,
+	p4y: number,
+): boolean {
+	const d1x = p2x - p1x;
+	const d1y = p2y - p1y;
+	const d2x = p4x - p3x;
+	const d2y = p4y - p3y;
+	const denom = d1x * d2y - d1y * d2x;
+	if (denom === 0) {
+		// Parallel — treat collinear overlap as intersection.
+		const cross1 = (p3x - p1x) * d1y - (p3y - p1y) * d1x;
+		if (cross1 !== 0) {
+			return false;
+		}
+		// Collinear: project onto the longer axis and check overlap.
+		const useX = Math.abs(d1x) >= Math.abs(d1y);
+		const a0 = useX ? p1x : p1y;
+		const a1 = useX ? p2x : p2y;
+		const b0 = useX ? p3x : p3y;
+		const b1 = useX ? p4x : p4y;
+		const aMin = Math.min(a0, a1);
+		const aMax = Math.max(a0, a1);
+		const bMin = Math.min(b0, b1);
+		const bMax = Math.max(b0, b1);
+		return aMax >= bMin && bMax >= aMin;
+	}
+	const tNum = (p3x - p1x) * d2y - (p3y - p1y) * d2x;
+	const uNum = (p3x - p1x) * d1y - (p3y - p1y) * d1x;
+	const t = tNum / denom;
+	const u = uNum / denom;
+	return t >= 0 && t <= 1 && u >= 0 && u <= 1;
+}
+
+/**
+ * Thick-segment overlap test. First does an AABB reject, then checks a
+ * centerline intersection, then falls back to sampling points of each branch
+ * against the other's thick body to catch near-coincident but non-crossing
+ * cases.
+ */
+export function branchesOverlap(a: BranchSegment, b: BranchSegment): boolean {
+	const halfA = Math.max(a.widthStart, a.widthEnd) / 2;
+	const halfB = Math.max(b.widthStart, b.widthEnd) / 2;
+
+	const aMinX = Math.min(a.x1, a.x2) - halfA;
+	const aMaxX = Math.max(a.x1, a.x2) + halfA;
+	const aMinY = Math.min(a.y1, a.y2) - halfA;
+	const aMaxY = Math.max(a.y1, a.y2) + halfA;
+	const bMinX = Math.min(b.x1, b.x2) - halfB;
+	const bMaxX = Math.max(b.x1, b.x2) + halfB;
+	const bMinY = Math.min(b.y1, b.y2) - halfB;
+	const bMaxY = Math.max(b.y1, b.y2) + halfB;
+
+	if (aMaxX < bMinX || bMaxX < aMinX || aMaxY < bMinY || bMaxY < aMinY) {
+		return false;
+	}
+
+	// Analytic centerline intersection catches crossing branches regardless of
+	// sample density.
+	if (segmentsIntersect(a.x1, a.y1, a.x2, a.y2, b.x1, b.y1, b.x2, b.y2)) {
+		return true;
+	}
+
+	// Fallback: sample each branch at dense points and check thick inclusion
+	// against the other. Catches near-coincident cases the analytic test missed.
+	const SAMPLES = 21;
+	for (let i = 0; i <= SAMPLES; i++) {
+		const t = i / SAMPLES;
+		const px = a.x1 + t * (a.x2 - a.x1);
+		const py = a.y1 + t * (a.y2 - a.y1);
+		if (isPointInBranch(px, py, [b])) {
+			return true;
+		}
+	}
+	for (let i = 0; i <= SAMPLES; i++) {
+		const t = i / SAMPLES;
+		const px = b.x1 + t * (b.x2 - b.x1);
+		const py = b.y1 + t * (b.y2 - b.y1);
+		if (isPointInBranch(px, py, [a])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Resolve the effective branch length range for a given base range, taking
+ * branchLength scaling and branchLengthVariance spread into account.
+ *
+ * Trunk-origin branches draw from the upper half of the variance window,
+ * sub-branches from the lower half (REQ-T-15).
+ */
+export function resolveBranchLengthRange(
+	baseMin: number,
+	baseMax: number,
+	branchLength: number,
+	branchLengthVariance: number,
+	isTrunkOrigin: boolean,
+): { min: number; max: number } {
+	const scale = branchLength / 100;
+	const mid = ((baseMin + baseMax) / 2) * scale;
+	const half = (((baseMax - baseMin) / 2) * scale * branchLengthVariance) / 100;
+	if (isTrunkOrigin) {
+		return { min: mid, max: mid + half };
+	}
+	return { min: mid - half, max: mid };
+}
+
+// ---------------------------------------------------------------------------
 // Hierarchical branching (D1, D2, D3)
 // ---------------------------------------------------------------------------
 
@@ -711,11 +1033,236 @@ function angleDivergence(a: number, b: number): number {
 	return diff;
 }
 
+// Base length ranges for branches at branchLength=100. The effective min/max
+// is derived by resolveBranchLengthRange using config.branchLength and
+// branchLengthVariance. These bases were rescaled ~1.6x to track the canopy
+// rescale in #4 (commit 85c067e), which previously left branches too short to
+// clear the enlarged canopy under the new visibility check.
+const TRUNK_BRANCH_BASE_MIN = 40;
+const TRUNK_BRANCH_BASE_MAX = 80;
+const SUB_BRANCH_BASE_MIN = 25;
+const SUB_BRANCH_BASE_MAX = 55;
+
+const BRANCH_RETRY_ATTEMPTS = 3;
+const TRUNK_BRANCH_MIN_VISIBLE = 15;
+const SUB_BRANCH_MIN_VISIBLE = 10;
+
+interface BranchCandidateContext {
+	readonly rng: () => number;
+	readonly config: TreeConfig;
+	readonly trunkJunctions: readonly Point2D[];
+	readonly blobs: readonly Blob[];
+	readonly trunkTop: number;
+	readonly trunkHeight: number;
+	readonly canopyBottom: number;
+	readonly trunkAxisAngle: number;
+}
+
+/**
+ * Snap an endpoint to the same side of the trunk center as the start point so
+ * the branch cannot cross the trunk axis. If the endpoint is already on the
+ * correct side, returns it unchanged.
+ */
+function reflectEndpointIfCrossing(startX: number, endX: number, centerX: number): number {
+	const startSide = Math.sign(startX - centerX);
+	const endSide = Math.sign(endX - centerX);
+	if (startSide === 0 || endSide === 0 || startSide === endSide) {
+		return endX;
+	}
+	// Reflect endX about centerX.
+	return centerX + (centerX - endX);
+}
+
+/**
+ * Progressive branchT window per retry attempt. Later attempts push the
+ * origin lower on the trunk (away from the dense canopy core) so the branch
+ * has more unobstructed length below the canopy.
+ */
+const TRUNK_BRANCH_T_WINDOWS: readonly [number, number][] = [
+	[0.05, 0.35],
+	[0.2, 0.5],
+	[0.35, 0.6],
+];
+
+/**
+ * If a branch's endpoint is above the canopy bottom and NOT inside any blob,
+ * walk forward along the branch direction (both x and y) until the point
+ * lands inside a blob. Returns the adjusted endpoint, or the original if no
+ * blob is reached within the extension cap. This satisfies REQ-T-09 while
+ * preserving the branch direction (unlike the buggy original code that only
+ * updated endY and warped the branch).
+ */
+function extendTipIntoCanopy(
+	startX: number,
+	startY: number,
+	endX: number,
+	endY: number,
+	blobs: readonly Blob[],
+	canopyBottom: number,
+	maxExtension: number,
+): { endX: number; endY: number } {
+	if (endY >= canopyBottom || isPointInBlobs(endX, endY, blobs)) {
+		return { endX, endY };
+	}
+	const dirX = endX - startX;
+	const dirY = endY - startY;
+	const dirLen = Math.sqrt(dirX * dirX + dirY * dirY);
+	if (dirLen === 0) {
+		return { endX, endY };
+	}
+	const ux = dirX / dirLen;
+	const uy = dirY / dirLen;
+	for (let ext = 1; ext <= maxExtension; ext++) {
+		const px = endX + ux * ext;
+		const py = endY + uy * ext;
+		if (isPointInBlobs(px, py, blobs)) {
+			return { endX: px, endY: py };
+		}
+	}
+	return { endX, endY };
+}
+
+function rollTrunkBranchCandidate(
+	ctx: BranchCandidateContext,
+	side: 1 | -1,
+	branchThicknessScale: number,
+	attempt: number,
+): BranchSegment {
+	const {
+		rng,
+		config,
+		trunkJunctions,
+		blobs,
+		trunkTop,
+		trunkHeight,
+		canopyBottom,
+		trunkAxisAngle,
+	} = ctx;
+	const tWindow = TRUNK_BRANCH_T_WINDOWS[Math.min(attempt, TRUNK_BRANCH_T_WINDOWS.length - 1)]!;
+	const branchT = randomInRange(rng, tWindow[0], tWindow[1]);
+	const startY = trunkTop + trunkHeight * branchT;
+	const startX = sampleTrunkCenterX(trunkJunctions, startY);
+	const { min: lenMin, max: lenMax } = resolveBranchLengthRange(
+		TRUNK_BRANCH_BASE_MIN,
+		TRUNK_BRANCH_BASE_MAX,
+		config.branchLength,
+		config.branchLengthVariance,
+		true,
+	);
+	const length = randomInRange(rng, lenMin, lenMax);
+
+	let upAngle = 0;
+	for (let angleAttempt = 0; angleAttempt < BRANCH_ANGLE_MAX_ATTEMPTS; angleAttempt++) {
+		upAngle = randomInRange(rng, 0.3, 1.2);
+		const candidateAngle = Math.atan2(
+			-Math.sin(upAngle) * length,
+			Math.cos(upAngle) * length * side,
+		);
+		if (angleDivergence(candidateAngle, trunkAxisAngle) >= BRANCH_ANGLE_MIN_RAD) {
+			break;
+		}
+	}
+
+	const rawEndX = startX + Math.cos(upAngle) * length * side;
+	const rawEndY = startY - Math.sin(upAngle) * length;
+	const reflectedEndX = reflectEndpointIfCrossing(startX, rawEndX, startX);
+	const extended = extendTipIntoCanopy(
+		startX,
+		startY,
+		reflectedEndX,
+		rawEndY,
+		blobs,
+		canopyBottom,
+		40,
+	);
+	const widthStart = randomInRange(rng, 7, 12.25) * branchThicknessScale;
+	const widthEnd = randomInRange(rng, 1.75, 5.25) * branchThicknessScale;
+
+	return {
+		x1: startX,
+		y1: startY,
+		x2: extended.endX,
+		y2: extended.endY,
+		widthStart,
+		widthEnd,
+	};
+}
+
+function rollSubBranchCandidate(
+	ctx: BranchCandidateContext,
+	parent: BranchSegment,
+	side: 1 | -1,
+	branchThicknessScale: number,
+): BranchSegment {
+	const { rng, config, trunkJunctions, blobs, canopyBottom } = ctx;
+	const parentAngle = computeAxisAngle(parent.x1, parent.y1, parent.x2, parent.y2);
+	const startT = randomInRange(rng, 0.3, 0.7);
+	const startX = parent.x1 + startT * (parent.x2 - parent.x1);
+	const startY = parent.y1 + startT * (parent.y2 - parent.y1);
+
+	const { min: lenMin, max: lenMax } = resolveBranchLengthRange(
+		SUB_BRANCH_BASE_MIN,
+		SUB_BRANCH_BASE_MAX,
+		config.branchLength,
+		config.branchLengthVariance,
+		false,
+	);
+	const length = randomInRange(rng, lenMin, lenMax);
+
+	let upAngle = 0;
+	for (let angleAttempt = 0; angleAttempt < BRANCH_ANGLE_MAX_ATTEMPTS; angleAttempt++) {
+		upAngle = randomInRange(rng, 0.2, 1.0);
+		const candidateAngle = Math.atan2(
+			-Math.sin(upAngle) * length,
+			Math.cos(upAngle) * length * side,
+		);
+		if (angleDivergence(candidateAngle, parentAngle) >= BRANCH_ANGLE_MIN_RAD) {
+			break;
+		}
+	}
+
+	const rawEndX = startX + Math.cos(upAngle) * length * side;
+	// Keep sub-branch on the same side of the trunk axis as its origin.
+	const centerX = sampleTrunkCenterX(trunkJunctions, startY);
+	const reflectedEndX = reflectEndpointIfCrossing(startX, rawEndX, centerX);
+	const rawEndY = startY - Math.sin(upAngle) * length;
+	const extended = extendTipIntoCanopy(
+		startX,
+		startY,
+		reflectedEndX,
+		rawEndY,
+		blobs,
+		canopyBottom,
+		30,
+	);
+	const widthStart =
+		randomInRange(rng, SUB_BRANCH_WIDTH_MIN, SUB_BRANCH_WIDTH_MAX) * branchThicknessScale;
+	const widthEnd = randomInRange(rng, 1.75, 3.5) * branchThicknessScale;
+
+	return {
+		x1: startX,
+		y1: startY,
+		x2: extended.endX,
+		y2: extended.endY,
+		widthStart,
+		widthEnd,
+	};
+}
+
+function overlapsAny(candidate: BranchSegment, existing: readonly BranchSegment[]): boolean {
+	for (const other of existing) {
+		if (branchesOverlap(candidate, other)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 export function generateBranches(
 	rng: () => number,
 	trunkTop: number,
 	trunkBottom: number,
-	trunkTopWidth: number,
+	_trunkTopWidth: number,
 	config: TreeConfig,
 	trunkJunctions: readonly Point2D[],
 	blobs: readonly Blob[],
@@ -730,10 +1277,8 @@ export function generateBranches(
 
 	const branches: BranchSegment[] = [];
 	const trunkHeight = trunkBottom - trunkTop;
-	const canopyBottom = getBlobsBounds(blobs).maxY;
+	const canopyBottom = blobs.length > 0 ? getBlobsBounds(blobs).maxY : trunkTop;
 
-	// Overall trunk axis from base junction to top junction for branch divergence
-	// checks. Branch origins still sample the local center from the polyline.
 	const baseJunction = trunkJunctions[0]!;
 	const topJunction = trunkJunctions[trunkJunctions.length - 1]!;
 	const trunkAxisAngle = computeAxisAngle(
@@ -743,55 +1288,42 @@ export function generateBranches(
 		topJunction.y,
 	);
 
+	const ctx: BranchCandidateContext = {
+		rng,
+		config,
+		trunkJunctions,
+		blobs,
+		trunkTop,
+		trunkHeight,
+		canopyBottom,
+		trunkAxisAngle,
+	};
+
 	const trunkBranchCount = Math.max(1, Math.round(branchCount * trunkBranchRatio));
 	const subBranchCount = branchCount - trunkBranchCount;
 
+	// --- Trunk-origin branches ---
 	for (let i = 0; i < trunkBranchCount; i++) {
-		const side = i % 2 === 0 ? 1 : -1;
-		const branchT = randomInRange(rng, 0.05, 0.35);
-		const startY = trunkTop + trunkHeight * branchT;
-		const startX = sampleTrunkCenterX(trunkJunctions, startY);
-		const length = randomInRange(rng, 25, 50);
-
-		// D2: branch angle constraint ≥ 30°
-		let upAngle = 0;
-		for (let attempt = 0; attempt < BRANCH_ANGLE_MAX_ATTEMPTS; attempt++) {
-			upAngle = randomInRange(rng, 0.3, 1.2);
-			const candidateAngle = Math.atan2(
-				-Math.sin(upAngle) * length,
-				Math.cos(upAngle) * length * side,
-			);
-			if (angleDivergence(candidateAngle, trunkAxisAngle) >= BRANCH_ANGLE_MIN_RAD) {
-				break;
+		const side: 1 | -1 = i % 2 === 0 ? 1 : -1;
+		let accepted: BranchSegment | null = null;
+		for (let attempt = 0; attempt < BRANCH_RETRY_ATTEMPTS; attempt++) {
+			const candidate = rollTrunkBranchCandidate(ctx, side, branchThicknessScale, attempt);
+			if (overlapsAny(candidate, branches)) {
+				continue;
 			}
-		}
-
-		const endX = startX + Math.cos(upAngle) * length * side;
-		let endY = startY - Math.sin(upAngle) * length;
-		const widthStart = randomInRange(rng, 7, 12.25) * branchThicknessScale;
-		const widthEnd = randomInRange(rng, 1.75, 5.25) * branchThicknessScale;
-
-		if (endY < canopyBottom && !isPointInBlobs(endX, endY, blobs)) {
-			const dirX = endX - startX;
-			const dirY = endY - startY;
-			const dirLen = Math.sqrt(dirX * dirX + dirY * dirY);
-			if (dirLen > 0) {
-				const ux = dirX / dirLen;
-				const uy = dirY / dirLen;
-				for (let ext = 1; ext <= 40; ext++) {
-					const px = endX + ux * ext;
-					const py = endY + uy * ext;
-					if (isPointInBlobs(px, py, blobs)) {
-						endY = py;
-						break;
-					}
-				}
+			const visible = computeVisibleBranchLength(candidate, blobs, []);
+			if (visible < TRUNK_BRANCH_MIN_VISIBLE) {
+				continue;
 			}
+			accepted = candidate;
+			break;
 		}
-
-		branches.push({ x1: startX, y1: startY, x2: endX, y2: endY, widthStart, widthEnd });
+		if (accepted !== null) {
+			branches.push(accepted);
+		}
 	}
 
+	// --- Sub-branches ---
 	const isolatedBlobIndices = findIsolatedBlobs(blobs);
 	const isolatedReached = new Set<number>();
 
@@ -799,67 +1331,32 @@ export function generateBranches(
 		if (branches.length === 0) {
 			break;
 		}
-		const parent = branches[Math.floor(rng() * branches.length)]!;
-		const parentAngle = computeAxisAngle(parent.x1, parent.y1, parent.x2, parent.y2);
-		const startT = randomInRange(rng, 0.3, 0.7);
-		const startX = parent.x1 + startT * (parent.x2 - parent.x1);
-		const startY = parent.y1 + startT * (parent.y2 - parent.y1);
-
-		const side = i % 2 === 0 ? 1 : -1;
-		const length = randomInRange(rng, 15, 35);
-
-		// D2: branch angle constraint ≥ 30° from parent direction
-		let upAngle = 0;
-		for (let attempt = 0; attempt < BRANCH_ANGLE_MAX_ATTEMPTS; attempt++) {
-			upAngle = randomInRange(rng, 0.2, 1.0);
-			const candidateAngle = Math.atan2(
-				-Math.sin(upAngle) * length,
-				Math.cos(upAngle) * length * side,
-			);
-			if (angleDivergence(candidateAngle, parentAngle) >= BRANCH_ANGLE_MIN_RAD) {
-				break;
+		const side: 1 | -1 = i % 2 === 0 ? 1 : -1;
+		let accepted: BranchSegment | null = null;
+		for (let attempt = 0; attempt < BRANCH_RETRY_ATTEMPTS; attempt++) {
+			const parent = branches[Math.floor(rng() * branches.length)]!;
+			const candidate = rollSubBranchCandidate(ctx, parent, side, branchThicknessScale);
+			if (overlapsAny(candidate, branches)) {
+				continue;
 			}
+			const visible = computeVisibleBranchLength(candidate, blobs, []);
+			if (visible < SUB_BRANCH_MIN_VISIBLE) {
+				continue;
+			}
+			accepted = candidate;
+			break;
 		}
-
-		const endX = startX + Math.cos(upAngle) * length * side;
-		let endY = startY - Math.sin(upAngle) * length;
-
-		if (endY < canopyBottom && !isPointInBlobs(endX, endY, blobs)) {
-			const dirX = endX - startX;
-			const dirY = endY - startY;
-			const dirLen = Math.sqrt(dirX * dirX + dirY * dirY);
-			if (dirLen > 0) {
-				const ux = dirX / dirLen;
-				const uy = dirY / dirLen;
-				for (let ext = 1; ext <= 30; ext++) {
-					const px = endX + ux * ext;
-					const py = endY + uy * ext;
-					if (isPointInBlobs(px, py, blobs)) {
-						endY = py;
-						break;
-					}
+		if (accepted !== null) {
+			for (const idx of isolatedBlobIndices) {
+				if (isPointInSingleBlob(accepted.x2, accepted.y2, blobs[idx]!)) {
+					isolatedReached.add(idx);
 				}
 			}
+			branches.push(accepted);
 		}
-
-		for (const idx of isolatedBlobIndices) {
-			if (isPointInSingleBlob(endX, endY, blobs[idx]!)) {
-				isolatedReached.add(idx);
-			}
-		}
-
-		branches.push({
-			x1: startX,
-			y1: startY,
-			x2: endX,
-			y2: endY,
-			widthStart:
-				randomInRange(rng, SUB_BRANCH_WIDTH_MIN, SUB_BRANCH_WIDTH_MAX) *
-				branchThicknessScale,
-			widthEnd: randomInRange(rng, 1.75, 3.5) * branchThicknessScale,
-		});
 	}
 
+	// --- Floating-blob fallback (exempt from visibility/crossing checks) ---
 	for (const idx of isolatedBlobIndices) {
 		if (isolatedReached.has(idx)) {
 			continue;

--- a/src/lib/trees/types.test.ts
+++ b/src/lib/trees/types.test.ts
@@ -51,6 +51,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			branchThickness: 100,
 			trunkSegments: 1,
 			trunkCrookedness: 0,
+			branchLength: 100,
+			branchLengthVariance: 50,
 		});
 	});
 
@@ -63,6 +65,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			branchThickness: 100,
 			trunkSegments: 1,
 			trunkCrookedness: 0,
+			branchLength: 100,
+			branchLengthVariance: 50,
 		});
 	});
 
@@ -75,6 +79,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			branchThickness: 100,
 			trunkSegments: 1,
 			trunkCrookedness: 0,
+			branchLength: 100,
+			branchLengthVariance: 50,
 		});
 	});
 
@@ -87,6 +93,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			branchThickness: 100,
 			trunkSegments: 1,
 			trunkCrookedness: 0,
+			branchLength: 100,
+			branchLengthVariance: 50,
 		});
 	});
 
@@ -99,6 +107,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			branchThickness: 100,
 			trunkSegments: 1,
 			trunkCrookedness: 0,
+			branchLength: 100,
+			branchLengthVariance: 50,
 		});
 	});
 
@@ -111,6 +121,15 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			branchThickness: 150,
 			trunkSegments: 3,
 			trunkCrookedness: 40,
+			branchLength: 100,
+			branchLengthVariance: 50,
 		});
+	});
+
+	it('every shape entry has branchLength and branchLengthVariance (REQ-P-23/24)', () => {
+		for (const shape of nonCustomShapes) {
+			expect(SHAPE_DEFAULTS[shape].branchLength).toBe(100);
+			expect(SHAPE_DEFAULTS[shape].branchLengthVariance).toBe(50);
+		}
 	});
 });

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -94,6 +94,8 @@ export interface TreeConfig {
 	readonly trunkLean: number;
 	readonly trunkSegments: number;
 	readonly trunkCrookedness: number;
+	readonly branchLength: number;
+	readonly branchLengthVariance: number;
 }
 
 export const DEFAULT_TREE_CONFIG: TreeConfig = {
@@ -122,6 +124,8 @@ export const DEFAULT_TREE_CONFIG: TreeConfig = {
 	trunkLean: 0,
 	trunkSegments: 1,
 	trunkCrookedness: 0,
+	branchLength: 100,
+	branchLengthVariance: 50,
 } as const;
 
 /**
@@ -137,6 +141,8 @@ export const SHAPE_DEFAULTS = {
 		branchThickness: 100,
 		trunkSegments: 1,
 		trunkCrookedness: 0,
+		branchLength: 100,
+		branchLengthVariance: 50,
 	},
 	[TREE_SHAPES.pine]: {
 		blobCount: 3,
@@ -146,6 +152,8 @@ export const SHAPE_DEFAULTS = {
 		branchThickness: 100,
 		trunkSegments: 1,
 		trunkCrookedness: 0,
+		branchLength: 100,
+		branchLengthVariance: 50,
 	},
 	[TREE_SHAPES.birch]: {
 		blobCount: 3,
@@ -155,6 +163,8 @@ export const SHAPE_DEFAULTS = {
 		branchThickness: 100,
 		trunkSegments: 1,
 		trunkCrookedness: 0,
+		branchLength: 100,
+		branchLengthVariance: 50,
 	},
 	[TREE_SHAPES.fir]: {
 		blobCount: 4,
@@ -164,6 +174,8 @@ export const SHAPE_DEFAULTS = {
 		branchThickness: 100,
 		trunkSegments: 1,
 		trunkCrookedness: 0,
+		branchLength: 100,
+		branchLengthVariance: 50,
 	},
 	[TREE_SHAPES.maple]: {
 		blobCount: 5,
@@ -173,6 +185,8 @@ export const SHAPE_DEFAULTS = {
 		branchThickness: 100,
 		trunkSegments: 1,
 		trunkCrookedness: 0,
+		branchLength: 100,
+		branchLengthVariance: 50,
 	},
 	[TREE_SHAPES.willow]: {
 		blobCount: 4,
@@ -182,6 +196,8 @@ export const SHAPE_DEFAULTS = {
 		branchThickness: 150,
 		trunkSegments: 3,
 		trunkCrookedness: 40,
+		branchLength: 100,
+		branchLengthVariance: 50,
 	},
 } as const satisfies Record<
 	Exclude<TreeShape, 'custom'>,
@@ -194,6 +210,8 @@ export const SHAPE_DEFAULTS = {
 		| 'branchThickness'
 		| 'trunkSegments'
 		| 'trunkCrookedness'
+		| 'branchLength'
+		| 'branchLengthVariance'
 	>
 >;
 

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -43,6 +43,8 @@
 	let trunkLean = $state(DEFAULT_TREE_CONFIG.trunkLean);
 	let trunkSegments = $state(DEFAULT_TREE_CONFIG.trunkSegments);
 	let trunkCrookedness = $state(DEFAULT_TREE_CONFIG.trunkCrookedness);
+	let branchLength = $state(DEFAULT_TREE_CONFIG.branchLength);
+	let branchLengthVariance = $state(DEFAULT_TREE_CONFIG.branchLengthVariance);
 	let depthVariance = $state(DEFAULT_TREE_CONFIG.depthVariance);
 	let showAnchors = $state(false);
 	let showCanopy = $state(true);
@@ -75,6 +77,8 @@
 		branchThickness = defaults.branchThickness;
 		trunkSegments = defaults.trunkSegments;
 		trunkCrookedness = defaults.trunkCrookedness;
+		branchLength = defaults.branchLength;
+		branchLengthVariance = defaults.branchLengthVariance;
 	}
 
 	function randomizeSeed() {
@@ -358,6 +362,22 @@
 							bind:value={trunkCrookedness}
 							disabled={trunkCrookednessDisabled}
 						/>
+						<LabeledRangeSlider
+							label="Branch Length"
+							min={25}
+							max={400}
+							step={5}
+							unit="%"
+							bind:value={branchLength}
+						/>
+						<LabeledRangeSlider
+							label="Branch Length Variance"
+							min={0}
+							max={100}
+							step={5}
+							unit="%"
+							bind:value={branchLengthVariance}
+						/>
 					</Card.Content>
 				</Card.Root>
 
@@ -458,6 +478,8 @@
 					{trunkLean}
 					{trunkSegments}
 					{trunkCrookedness}
+					{branchLength}
+					{branchLengthVariance}
 					{depthVariance}
 					{showCanopy}
 					{showBranches}

--- a/src/routes/showcase/scene/+page.svelte
+++ b/src/routes/showcase/scene/+page.svelte
@@ -34,6 +34,8 @@
 	let trunkLean = $state(DEFAULT_TREE_CONFIG.trunkLean);
 	let trunkSegments = $state(DEFAULT_TREE_CONFIG.trunkSegments);
 	let trunkCrookedness = $state(DEFAULT_TREE_CONFIG.trunkCrookedness);
+	let branchLength = $state(DEFAULT_TREE_CONFIG.branchLength);
+	let branchLengthVariance = $state(DEFAULT_TREE_CONFIG.branchLengthVariance);
 	let showAnchors = $state(false);
 	let showCanopy = $state(true);
 	let showBranches = $state(true);
@@ -215,6 +217,22 @@
 						bind:value={trunkCrookedness}
 						disabled={trunkCrookednessDisabled}
 					/>
+					<LabeledRangeSlider
+						label="Branch Length"
+						min={25}
+						max={400}
+						step={5}
+						unit="%"
+						bind:value={branchLength}
+					/>
+					<LabeledRangeSlider
+						label="Branch Length Variance"
+						min={0}
+						max={100}
+						step={5}
+						unit="%"
+						bind:value={branchLengthVariance}
+					/>
 				</SectionCard>
 
 				<SectionCard title="Canopy Color" contentClass="space-y-4">
@@ -380,6 +398,8 @@
 						{trunkLean}
 						{trunkSegments}
 						{trunkCrookedness}
+						{branchLength}
+						{branchLengthVariance}
 						blobCount={tree.blobCount}
 						branchCount={tree.branchCount}
 						{showCanopy}


### PR DESCRIPTION
## Description

- Add `branchLength` (25-400%, default 100) and `branchLengthVariance` (0-100%, default 50) params to `TreeConfig`, `DEFAULT_TREE_CONFIG`, and every `SHAPE_DEFAULTS` entry (REQ-P-23 / REQ-P-24 / §2.5).
- New geometry helpers in `shapes.ts`: ray-vs-ellipse and ray-vs-triangle intersection, `computeVisibleBranchLength` (interval merge), `branchesOverlap` (AABB + analytic + sampled thick-body), `resolveBranchLengthRange` (upper/lower half split weighted by variance).
- Rewrite `generateBranches` with a 3-attempt outer retry loop enforcing REQ-T-13 (≥15 px visible trunk-origin, ≥10 px sub-branch), REQ-T-14 (no trunk-axis crossing via endpoint reflection), REQ-T-14a (no branch overlap). Each retry progressively pushes trunk-origin `branchT` lower on the trunk to start below the canopy.
- Rescale base length ranges ~1.6× (trunk 40..80, sub 25..55) to track the canopy rescale that landed in #16 (commit 85c067e).
- Add `extendTipIntoCanopy` helper that walks the tip along the branch direction into a canopy blob; fixes a pre-existing bug in the old code that only updated `endY` and warped the branch angle.
- Floating-blob fallback branches stay exempt from visibility / crossing checks (they only exist to repair isolated blobs — REQ-T-10).
- UI: `Branch Length` + `Branch Length Variance` sliders added to the "Trunk & Branches" card in `/showcase` and `/showcase/scene`; wired through `LowPolyTree` props.

## Test changes

- New Vitest suite `generateBranches — visibility & crossing invariants` covers visible-length thresholds, no-crossing, branch count upper bound, pathological pathological-blob bounded termination, length scaling, and determinism.
- New Vitest tests for every helper (ellipse/triangle intersection, interval merging, overlap, range resolution).
- Updated REQ-T-09 test to check point-in-canopy-triangle rather than triangle-bounding-box (the old check erroneously rejected tips inside ellipses whose tessellated hull was slightly smaller).
- Updated `branchThickness` scaling test to use total triangle area instead of x-range, since issue #7's thickness-dependent overlap check causes positional divergence between wide/narrow runs of the same seed.

## Resolves

Closes #7

## Test plan

- [x] \`pnpm run test\` — 118 unit tests pass
- [x] \`pnpm run check:all\` — typecheck + lint + stylelint + knip + eslint clean
- [x] \`pnpm run test:e2e\` — 8 e2e tests pass