### PR TITLE
#11 feat(auth): BetterAuth Google + GitHub + Passkey

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,13 @@ DATABASE_URL="postgres://root:mysecretpassword@localhost:5432/local"
 # Auth (generate with: openssl rand -base64 32)
 AUTH_SECRET=""
 
-# App URL (used for OAuth redirects and email links)
+# App URL (used for OAuth redirects and passkey rpID)
 ORIGIN="http://localhost:5173"
 
 # Google OAuth (optional - auth works without these)
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
+
+# GitHub OAuth (optional - auth works without these)
+GITHUB_CLIENT_ID=""
+GITHUB_CLIENT_SECRET=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
             - run: pnpm run check:all
             - run: pnpm run test -- --coverage
             - run: pnpm exec playwright install --with-deps chromium
-            - name: Create .dev.vars for e2e preview server
+            - name: Create .env and .dev.vars for e2e build + preview server
               run: |
-                  echo "DATABASE_URL=postgresql://test:test@localhost:5432/test" > .dev.vars
-                  echo "AUTH_SECRET=ci-test-secret-not-for-production" >> .dev.vars
+                  echo "DATABASE_URL=postgresql://test:test@localhost:5432/test" > .env
+                  echo "AUTH_SECRET=ci-test-secret-not-for-production" >> .env
+                  cp .env .dev.vars
             - run: pnpm run test:e2e

--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ src/
   hooks.ts                 # Client hooks (i18n URL rerouting)
   hooks.server.ts          # Server hooks (i18n middleware + auth session)
   lib/
-    auth_client.ts         # BetterAuth client (for use in components)
+    auth/
+      client.ts            # BetterAuth client (for use in components)
     index.ts               # $lib public exports
     assets/                # Static assets (favicon, etc.)
     paraglide/             # Generated i18n runtime (gitignored)

--- a/drizzle/0000_free_speed_demon.sql
+++ b/drizzle/0000_free_speed_demon.sql
@@ -1,0 +1,65 @@
+CREATE TABLE "account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp with time zone,
+	"refresh_token_expires_at" timestamp with time zone,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "passkey" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"public_key" text NOT NULL,
+	"user_id" text NOT NULL,
+	"credential_id" text NOT NULL,
+	"counter" integer NOT NULL,
+	"device_type" text NOT NULL,
+	"backed_up" boolean NOT NULL,
+	"transports" text,
+	"created_at" timestamp with time zone,
+	"aaguid" text
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	CONSTRAINT "session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean DEFAULT false NOT NULL,
+	"image" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "verification" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "passkey" ADD CONSTRAINT "passkey_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -3,7 +3,7 @@ import type { KnipConfig } from 'knip';
 const config: KnipConfig = {
 	entry: [
 		'src/hooks.ts',
-		'src/lib/auth_client.ts',
+		'src/lib/auth/client.ts',
 		'src/lib/reactivity/*.svelte.ts',
 		'src/lib/context/*.context.svelte.ts',
 		'src/lib/components/ui/*/index.ts',

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"build:storybook": "svelte-kit sync && storybook build"
 	},
 	"dependencies": {
+		"@better-auth/passkey": "~1.4.22",
 		"@node-rs/argon2": "^2.0.2",
 		"better-auth": "~1.4.22",
 		"delaunator": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@better-auth/passkey':
+        specifier: ~1.4.22
+        version: 1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.22(@prisma/client@5.22.0)(@sveltejs/kit@2.56.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.2)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260405.1)(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.55.2)(vitest@4.1.3))(better-call@1.1.8(zod@4.3.6))(nanostores@1.2.0)
       '@node-rs/argon2':
         specifier: ^2.0.2
         version: 2.0.2
@@ -383,6 +386,16 @@ packages:
       better-call: 1.1.8
       jose: ^6.1.0
       kysely: ^0.28.5
+      nanostores: ^1.0.1
+
+  '@better-auth/passkey@1.4.22':
+    resolution: {integrity: sha512-wWXOCkF0MauMW3wfND5vNF9Dn9n8nfHV5k6F9qv9DWt9GrdzTWbV6dviXubDahMyVSiX3OrkupUBTRRT+dENlg==}
+    peerDependencies:
+      '@better-auth/core': 1.4.22
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      better-auth: 1.4.22
+      better-call: 1.1.8
       nanostores: ^1.0.1
 
   '@better-auth/telemetry@1.4.22':
@@ -1188,6 +1201,9 @@ packages:
   '@fontsource-variable/noto-sans@5.2.10':
     resolution: {integrity: sha512-wyFgKkFu7jki5kEL8qv7avjQ8rxHX0J/nhLWvbR9T0hOH1HRKZEvb9EW9lMjZfWHHfEzKkYf5J+NadwgCS7TXA==}
 
+  '@hexagon/base64@1.1.28':
+    resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1382,6 +1398,9 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@levischuck/tiny-cbor@0.2.11':
+    resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
   '@lix-js/sdk@0.4.9':
     resolution: {integrity: sha512-30mDkXpx704359oRrJI42bjfCspCiaMItngVBbPkiTGypS7xX4jYbHWQkXI8XuJ7VDB69D0MsVU6xfrBAIrM4A==}
@@ -1860,6 +1879,43 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@peculiar/asn1-android@2.6.0':
+    resolution: {integrity: sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==}
+
+  '@peculiar/asn1-cms@2.6.1':
+    resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
+
+  '@peculiar/asn1-csr@2.6.1':
+    resolution: {integrity: sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==}
+
+  '@peculiar/asn1-ecc@2.6.1':
+    resolution: {integrity: sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==}
+
+  '@peculiar/asn1-pfx@2.6.1':
+    resolution: {integrity: sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==}
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    resolution: {integrity: sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==}
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    resolution: {integrity: sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==}
+
+  '@peculiar/asn1-rsa@2.6.1':
+    resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
+
+  '@peculiar/asn1-schema@2.6.0':
+    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    resolution: {integrity: sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==}
+
+  '@peculiar/asn1-x509@2.6.1':
+    resolution: {integrity: sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
@@ -2010,6 +2066,13 @@ packages:
     resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
+
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
+
+  '@simplewebauthn/server@13.3.0':
+    resolution: {integrity: sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==}
+    engines: {node: '>=20.0.0'}
 
   '@sinclair/typebox@0.31.28':
     resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
@@ -2506,6 +2569,10 @@ packages:
 
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
+  asn1js@3.0.7:
+    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
+    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -4079,6 +4146,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   qified@0.9.1:
     resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==}
     engines: {node: '>=20'}
@@ -4124,6 +4198,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   regexp-to-ast@0.5.0:
     resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
@@ -4516,6 +4593,9 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4523,6 +4603,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -5152,6 +5236,18 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
+  '@better-auth/passkey@1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.22(@prisma/client@5.22.0)(@sveltejs/kit@2.56.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.2)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260405.1)(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.55.2)(vitest@4.1.3))(better-call@1.1.8(zod@4.3.6))(nanostores@1.2.0)':
+    dependencies:
+      '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@simplewebauthn/browser': 13.3.0
+      '@simplewebauthn/server': 13.3.0
+      better-auth: 1.4.22(@prisma/client@5.22.0)(@sveltejs/kit@2.56.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.2)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260405.1)(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.55.2)(vitest@4.1.3)
+      better-call: 1.1.8(zod@4.3.6)
+      nanostores: 1.2.0
+      zod: 4.3.6
+
   '@better-auth/telemetry@1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))':
     dependencies:
       '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
@@ -5644,6 +5740,8 @@ snapshots:
 
   '@fontsource-variable/noto-sans@5.2.10': {}
 
+  '@hexagon/base64@1.1.28': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5812,6 +5910,8 @@ snapshots:
       keyv: 5.6.0
 
   '@keyv/serialize@1.1.1': {}
+
+  '@levischuck/tiny-cbor@0.2.11': {}
 
   '@lix-js/sdk@0.4.9':
     dependencies:
@@ -6124,6 +6224,102 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.59.0':
     optional: true
 
+  '@peculiar/asn1-android@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-cms@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pfx': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.6.0':
+    dependencies:
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-csr': 2.6.1
+      '@peculiar/asn1-ecc': 2.6.1
+      '@peculiar/asn1-pkcs9': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
@@ -6218,6 +6414,19 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
+
+  '@simplewebauthn/browser@13.3.0': {}
+
+  '@simplewebauthn/server@13.3.0':
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.11
+      '@peculiar/asn1-android': 2.6.0
+      '@peculiar/asn1-ecc': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/x509': 1.14.3
 
   '@sinclair/typebox@0.31.28': {}
 
@@ -6796,6 +7005,12 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-timsort@1.0.3: {}
+
+  asn1js@3.0.7:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -8225,6 +8440,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   qified@0.9.1:
     dependencies:
       hookified: 2.1.1
@@ -8274,6 +8495,8 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  reflect-metadata@0.2.2: {}
 
   regexp-to-ast@0.5.0: {}
 
@@ -8751,6 +8974,8 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -8759,6 +8984,10 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,13 +1,13 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
-import type { User, Session } from 'better-auth/minimal';
+import type { User, Session } from 'better-auth';
 
 declare global {
 	namespace App {
 		// interface Error {}
 		interface Locals {
-			user?: User;
-			session?: Session;
+			user: User | null;
+			session: Session | null;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -21,10 +21,8 @@ const paraglideHandle: Handle = ({ event, resolve }) =>
 const authHandle: Handle = async ({ event, resolve }) => {
 	const sessionData = await auth.api.getSession({ headers: event.request.headers });
 
-	if (sessionData) {
-		event.locals.session = sessionData.session;
-		event.locals.user = sessionData.user;
-	}
+	event.locals.session = sessionData?.session ?? null;
+	event.locals.user = sessionData?.user ?? null;
 
 	return svelteKitHandler({ event, resolve, auth, building });
 };

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,0 +1,6 @@
+import { createAuthClient } from 'better-auth/svelte';
+import { passkeyClient } from '@better-auth/passkey/client';
+
+export const authClient = createAuthClient({
+	plugins: [passkeyClient()],
+});

--- a/src/lib/auth_client.ts
+++ b/src/lib/auth_client.ts
@@ -1,3 +1,0 @@
-import { createAuthClient } from 'better-auth/svelte';
-
-export const authClient = createAuthClient();

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,48 +1,48 @@
 import { betterAuth } from 'better-auth/minimal';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { sveltekitCookies } from 'better-auth/svelte-kit';
+import { passkey } from '@better-auth/passkey';
 import { env } from '$env/dynamic/private';
 import { getRequestEvent } from '$app/server';
 import { db } from './db/index.js';
+import * as schema from './db/schema.js';
+
+if (env.AUTH_SECRET === undefined || env.AUTH_SECRET === '') {
+	throw new Error('AUTH_SECRET environment variable is required');
+}
+
+const ORIGIN = env.ORIGIN ?? 'http://localhost:5173';
+const RP_ID = new URL(ORIGIN).hostname;
+
+function buildSocialProvider<Name extends string>(
+	name: Name,
+	clientId: string | undefined,
+	clientSecret: string | undefined,
+): Record<Name, { clientId: string; clientSecret: string }> | Record<string, never> {
+	if (
+		clientId === undefined ||
+		clientId === '' ||
+		clientSecret === undefined ||
+		clientSecret === ''
+	) {
+		return {};
+	}
+	return { [name]: { clientId, clientSecret } } as Record<
+		Name,
+		{ clientId: string; clientSecret: string }
+	>;
+}
 
 export const auth = betterAuth({
-	baseURL: env.ORIGIN ?? 'http://localhost:5173',
+	baseURL: ORIGIN,
 	secret: env.AUTH_SECRET,
 
-	database: drizzleAdapter(db, { provider: 'pg' }),
+	database: drizzleAdapter(db, { provider: 'pg', schema }),
 
-	emailAndPassword: {
-		enabled: true,
-		minPasswordLength: 8,
-		maxPasswordLength: 128,
-		autoSignIn: true,
-		requireEmailVerification: false, // set to true in production
-		resetPasswordTokenExpiresIn: 3600,
-		sendResetPassword: async ({ user, url }) => {
-			// TODO: replace with your email service (e.g. Resend, SendGrid, Postmark)
-			console.log(`[Auth] Password reset for ${user.email}: ${url}`);
-		},
+	socialProviders: {
+		...buildSocialProvider('google', env.GOOGLE_CLIENT_ID, env.GOOGLE_CLIENT_SECRET),
+		...buildSocialProvider('github', env.GITHUB_CLIENT_ID, env.GITHUB_CLIENT_SECRET),
 	},
-
-	emailVerification: {
-		sendOnSignUp: false, // set to true in production
-		autoSignInAfterVerification: true,
-		expiresIn: 3600,
-		sendVerificationEmail: async ({ user, url }) => {
-			// TODO: replace with your email service
-			console.log(`[Auth] Verification email for ${user.email}: ${url}`);
-		},
-	},
-
-	socialProviders:
-		env.GOOGLE_CLIENT_ID !== undefined && env.GOOGLE_CLIENT_SECRET !== undefined
-			? {
-					google: {
-						clientId: env.GOOGLE_CLIENT_ID,
-						clientSecret: env.GOOGLE_CLIENT_SECRET,
-					},
-				}
-			: {},
 
 	session: {
 		cookieCache: {
@@ -51,5 +51,12 @@ export const auth = betterAuth({
 		},
 	},
 
-	plugins: [sveltekitCookies(getRequestEvent)],
+	plugins: [
+		passkey({
+			rpID: RP_ID,
+			rpName: 'Low-Poly 2D Trees',
+			origin: ORIGIN,
+		}),
+		sveltekitCookies(getRequestEvent), // must be last
+	],
 });

--- a/src/lib/server/db/auth.schema.ts
+++ b/src/lib/server/db/auth.schema.ts
@@ -1,4 +1,4 @@
-import { boolean, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { boolean, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 export const user = pgTable('user', {
 	id: text('id').primaryKey(),
@@ -48,4 +48,20 @@ export const verification = pgTable('verification', {
 	expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
 	createdAt: timestamp('created_at', { withTimezone: true }),
 	updatedAt: timestamp('updated_at', { withTimezone: true }),
+});
+
+export const passkey = pgTable('passkey', {
+	id: text('id').primaryKey(),
+	name: text('name'),
+	publicKey: text('public_key').notNull(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => user.id, { onDelete: 'cascade' }),
+	credentialID: text('credential_id').notNull(),
+	counter: integer('counter').notNull(),
+	deviceType: text('device_type').notNull(),
+	backedUp: boolean('backed_up').notNull(),
+	transports: text('transports'),
+	createdAt: timestamp('created_at', { withTimezone: true }),
+	aaguid: text('aaguid'),
 });

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { authClient } from '$lib/auth/client.js';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+
+	type SocialProvider = 'google' | 'github';
+	type PendingProvider = SocialProvider | 'passkey';
+
+	const PROVIDER_LABEL = {
+		google: 'Google',
+		github: 'GitHub',
+		passkey: 'Passkey',
+	} as const satisfies Record<PendingProvider, string>;
+
+	let errorMessage = $state<string | null>(null);
+	let pendingProvider = $state<PendingProvider | null>(null);
+
+	async function signInWithSocial(provider: SocialProvider) {
+		errorMessage = null;
+		pendingProvider = provider;
+		const result = await authClient.signIn.social({ provider, callbackURL: '/' });
+		if (result.error) {
+			errorMessage = result.error.message ?? `${PROVIDER_LABEL[provider]} sign-in failed.`;
+			pendingProvider = null;
+		}
+	}
+
+	async function signInWithPasskey() {
+		errorMessage = null;
+		pendingProvider = 'passkey';
+		const result = await authClient.signIn.passkey();
+		if (result?.error) {
+			errorMessage = result.error.message ?? `${PROVIDER_LABEL.passkey} sign-in failed.`;
+			pendingProvider = null;
+			return;
+		}
+		await goto(resolve('/'));
+	}
+</script>
+
+<svelte:head>
+	<title>Sign in</title>
+</svelte:head>
+
+<main
+	class="bg-background text-foreground flex min-h-screen items-center justify-center px-6 py-12"
+>
+	<section class="w-full max-w-sm space-y-6">
+		<header class="space-y-2 text-center">
+			<h1 class="text-3xl font-bold tracking-tight">Sign in</h1>
+			<p class="text-muted-foreground text-sm">
+				Continue with Google, GitHub, or a passkey. Your first successful sign-in creates
+				your account automatically.
+			</p>
+		</header>
+
+		<div class="flex flex-col gap-3">
+			<Button
+				data-testid="sign-in-google"
+				disabled={pendingProvider !== null}
+				onclick={() => signInWithSocial('google')}
+			>
+				Continue with Google
+			</Button>
+			<Button
+				data-testid="sign-in-github"
+				disabled={pendingProvider !== null}
+				onclick={() => signInWithSocial('github')}
+			>
+				Continue with GitHub
+			</Button>
+			<Button
+				data-testid="sign-in-passkey"
+				variant="outline"
+				disabled={pendingProvider !== null}
+				onclick={signInWithPasskey}
+			>
+				Continue with Passkey
+			</Button>
+		</div>
+
+		{#if errorMessage}
+			<p role="alert" class="text-destructive text-center text-sm">{errorMessage}</p>
+		{/if}
+	</section>
+</main>

--- a/src/routes/auth/sign-out/+server.ts
+++ b/src/routes/auth/sign-out/+server.ts
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit';
+import { auth } from '$lib/server/auth.js';
+import type { RequestHandler } from './$types.js';
+
+export const POST: RequestHandler = async ({ request }) => {
+	await auth.api.signOut({ headers: request.headers });
+	redirect(303, '/');
+};

--- a/src/routes/auth/sign-out/server.test.ts
+++ b/src/routes/auth/sign-out/server.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { signOutMock } = vi.hoisted(() => ({ signOutMock: vi.fn() }));
+vi.mock('$lib/server/auth.js', () => ({
+	auth: {
+		api: {
+			signOut: signOutMock,
+		},
+	},
+}));
+
+// @sveltejs/kit's redirect throws a Redirect object; importing from the package
+// avoids reimplementing the sentinel type.
+import { POST } from './+server.js';
+
+function makeEvent(headers: Headers): Parameters<typeof POST>[0] {
+	const request = new Request('http://localhost/auth/sign-out', {
+		method: 'POST',
+		headers,
+	});
+	return { request } as Parameters<typeof POST>[0];
+}
+
+describe('POST /auth/sign-out', () => {
+	beforeEach(() => {
+		signOutMock.mockReset();
+		signOutMock.mockResolvedValue({ success: true });
+	});
+
+	it('calls auth.api.signOut with the request headers', async () => {
+		const headers = new Headers({ cookie: 'test-session=abc' });
+		await expect(POST(makeEvent(headers))).rejects.toMatchObject({
+			status: 303,
+			location: '/',
+		});
+		expect(signOutMock).toHaveBeenCalledWith({ headers });
+	});
+
+	it('redirects to / after sign-out', async () => {
+		const headers = new Headers();
+		await expect(POST(makeEvent(headers))).rejects.toMatchObject({
+			status: 303,
+			location: '/',
+		});
+	});
+});

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('/auth page', () => {
+	test('renders heading and explainer copy', async ({ page }) => {
+		await page.goto('/auth');
+		await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+		await expect(page.getByText(/Continue with Google, GitHub, or a passkey/i)).toBeVisible();
+	});
+
+	test('renders all three provider buttons', async ({ page }) => {
+		await page.goto('/auth');
+		await expect(page.getByTestId('sign-in-google')).toBeVisible();
+		await expect(page.getByTestId('sign-in-github')).toBeVisible();
+		await expect(page.getByTestId('sign-in-passkey')).toBeVisible();
+		await expect(page.getByTestId('sign-in-google')).toHaveText(/Continue with Google/);
+		await expect(page.getByTestId('sign-in-github')).toHaveText(/Continue with GitHub/);
+		await expect(page.getByTestId('sign-in-passkey')).toHaveText(/Continue with Passkey/);
+	});
+});


### PR DESCRIPTION
## Description

- Add BetterAuth integration with Google OAuth, GitHub OAuth, and Passkey (WebAuthn) providers — email+password is out of scope per issue decisions
- New `/auth` page with three provider buttons + `/auth/sign-out` POST endpoint
- Drizzle schema extended with `passkey` table; first migration `drizzle/0000_free_speed_demon.sql` committed
- `src/lib/auth/client.ts` (moved from `src/lib/auth_client.ts`) now wires `passkeyClient()`
- `App.Locals` typed as `| null` per spec; hooks assign null when no session
- `AUTH_SECRET` guarded at module load; empty env strings for OAuth client IDs/secrets now treated as unconfigured (silences the pre-existing warning on local/CI preview)

## Resolves

Closes #11

## Testing

- [x] `pnpm run check:all` — clean
- [x] `pnpm run test` — 120 tests pass (includes new `src/routes/auth/sign-out/server.test.ts` with mocked `auth.api.signOut`)
- [x] `pnpm run test:e2e` — 10 tests pass (includes `tests/e2e/auth.spec.ts` verifying /auth heading, explainer, and all three provider buttons render)