### PR TITLE
#8 feat(trees): fir/maple/willow + teardrop boundary + oak/birch fixes

### DIFF
--- a/src/lib/trees/boundaries.test.ts
+++ b/src/lib/trees/boundaries.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { BOUNDARIES, BOUNDARY_KINDS, circleBoundary, teardropBoundary } from './boundaries.js';
+import { createPrng } from './prng.js';
+
+describe('boundaries — registry', () => {
+	it('exposes circle and teardrop boundary kinds', () => {
+		expect(BOUNDARY_KINDS.circle).toBe('circle');
+		expect(BOUNDARY_KINDS.teardrop).toBe('teardrop');
+	});
+
+	it('BOUNDARIES maps every kind to the correct shape impl', () => {
+		expect(BOUNDARIES[BOUNDARY_KINDS.circle]).toBe(circleBoundary);
+		expect(BOUNDARIES[BOUNDARY_KINDS.teardrop]).toBe(teardropBoundary);
+	});
+
+	it('circle boundary kind is circle', () => {
+		expect(circleBoundary.kind).toBe(BOUNDARY_KINDS.circle);
+	});
+
+	it('teardrop boundary kind is teardrop', () => {
+		expect(teardropBoundary.kind).toBe(BOUNDARY_KINDS.teardrop);
+	});
+});
+
+describe('circleBoundary.contains', () => {
+	const cx = 50;
+	const cy = 60;
+	const rx = 20;
+	const ry = 10;
+
+	it('returns true at the center', () => {
+		expect(circleBoundary.contains(cx, cy, cx, cy, rx, ry, 0)).toBe(true);
+	});
+
+	it('returns true at (cx+rx-epsilon, cy)', () => {
+		expect(circleBoundary.contains(cx + rx - 0.01, cy, cx, cy, rx, ry, 0)).toBe(true);
+	});
+
+	it('returns false outside the ellipse bounding box', () => {
+		expect(circleBoundary.contains(cx + rx + 1, cy, cx, cy, rx, ry, 0)).toBe(false);
+		expect(circleBoundary.contains(cx, cy + ry + 1, cx, cy, rx, ry, 0)).toBe(false);
+	});
+
+	it('matches the inlined ellipse formula on random probes', () => {
+		const rng = createPrng(99);
+		for (let i = 0; i < 200; i++) {
+			const px = cx - rx * 2 + rng() * rx * 4;
+			const py = cy - ry * 2 + rng() * ry * 4;
+			const dx = (px - cx) / rx;
+			const dy = (py - cy) / ry;
+			const expected = dx * dx + dy * dy <= 1;
+			expect(circleBoundary.contains(px, py, cx, cy, rx, ry, 0)).toBe(expected);
+		}
+	});
+});
+
+describe('teardropBoundary.contains', () => {
+	const cx = 100;
+	const cy = 150;
+	const rx = 30;
+	const ry = 40;
+
+	it('returns true at the center', () => {
+		expect(teardropBoundary.contains(cx, cy, cx, cy, rx, ry, 0)).toBe(true);
+	});
+
+	it('returns true near the round bottom (cx, cy + 0.99*ry)', () => {
+		expect(teardropBoundary.contains(cx, cy + 0.99 * ry, cx, cy, rx, ry, 0)).toBe(true);
+	});
+
+	it('returns true just inside the pointy top (cx, cy - 0.99*ry)', () => {
+		expect(teardropBoundary.contains(cx, cy - 0.99 * ry, cx, cy, rx, ry, 0)).toBe(true);
+	});
+
+	it('returns false outside the pinched top (cx + rx/2, cy - 0.9*ry)', () => {
+		expect(teardropBoundary.contains(cx + rx / 2, cy - 0.9 * ry, cx, cy, rx, ry, 0)).toBe(
+			false,
+		);
+	});
+
+	it('returns false outside the bounding box vertically', () => {
+		expect(teardropBoundary.contains(cx, cy - ry * 1.1, cx, cy, rx, ry, 0)).toBe(false);
+		expect(teardropBoundary.contains(cx, cy + ry * 1.1, cx, cy, rx, ry, 0)).toBe(false);
+	});
+
+	it('rotation=90°: the unrotated (cx, cy - ry + epsilon) maps to (cx + ry - epsilon, cy)', () => {
+		// With 90° rotation, the pointy top (which was at negative y) rotates to the
+		// positive x direction. A point slightly inside the pointy top — unrotated
+		// at (cx, cy - 0.99*ry) — must therefore be inside after rotation when
+		// queried at the corresponding rotated location.
+		const epsilon = 0.99;
+		// Apply the 90° CCW rotation to (0, -epsilon*ry): (x', y') = (epsilon*ry, 0)
+		const rotatedPx = cx + epsilon * ry;
+		const rotatedPy = cy;
+		expect(teardropBoundary.contains(rotatedPx, rotatedPy, cx, cy, rx, ry, 90)).toBe(true);
+	});
+
+	it('rotation=180°: the unrotated round bottom moves to the top', () => {
+		const epsilon = 0.99;
+		// The round bottom at (cx, cy + epsilon*ry) rotates to (cx, cy - epsilon*ry).
+		expect(teardropBoundary.contains(cx, cy - epsilon * ry, cx, cy, rx, ry, 180)).toBe(true);
+	});
+});
+
+describe('teardropBoundary.sample', () => {
+	const cx = 80;
+	const cy = 120;
+	const rx = 25;
+	const ry = 50;
+
+	it('returns the requested number of points', () => {
+		const rng = createPrng(7);
+		const pts = teardropBoundary.sample(cx, cy, rx, ry, 24, rng, 0);
+		expect(pts).toHaveLength(24);
+	});
+
+	it('every sampled point lies inside the teardrop (within small epsilon)', () => {
+		const rng = createPrng(11);
+		const pts = teardropBoundary.sample(cx, cy, rx, ry, 32, rng, 0);
+		for (const p of pts) {
+			expect(teardropBoundary.contains(p.x, p.y, cx, cy, rx, ry, 0)).toBe(true);
+		}
+	});
+
+	it('is deterministic under the same seeded rng', () => {
+		const ptsA = teardropBoundary.sample(cx, cy, rx, ry, 16, createPrng(42), 0);
+		const ptsB = teardropBoundary.sample(cx, cy, rx, ry, 16, createPrng(42), 0);
+		expect(ptsA).toEqual(ptsB);
+	});
+});
+
+describe('circleBoundary.sample', () => {
+	const cx = 60;
+	const cy = 70;
+	const rx = 15;
+	const ry = 20;
+
+	it('returns the requested number of points', () => {
+		const pts = circleBoundary.sample(cx, cy, rx, ry, 20, createPrng(2), 0);
+		expect(pts).toHaveLength(20);
+	});
+
+	it('is deterministic under the same seeded rng', () => {
+		const a = circleBoundary.sample(cx, cy, rx, ry, 20, createPrng(3), 0);
+		const b = circleBoundary.sample(cx, cy, rx, ry, 20, createPrng(3), 0);
+		expect(a).toEqual(b);
+	});
+});

--- a/src/lib/trees/boundaries.ts
+++ b/src/lib/trees/boundaries.ts
@@ -1,0 +1,331 @@
+import { randomInRange } from './prng.js';
+
+// ---------------------------------------------------------------------------
+// Boundary kinds and shape abstraction
+// ---------------------------------------------------------------------------
+
+export const BOUNDARY_KINDS = {
+	circle: 'circle',
+	teardrop: 'teardrop',
+} as const;
+
+export type BoundaryKind = (typeof BOUNDARY_KINDS)[keyof typeof BOUNDARY_KINDS];
+
+interface BoundaryPoint {
+	readonly x: number;
+	readonly y: number;
+}
+
+/**
+ * A parametric canopy-blob boundary shape. The same interface is used for
+ * both axis-aligned ellipses ("circle") and rotated teardrops, so the canopy
+ * triangulation pipeline can dispatch on `blob.boundary` without caring about
+ * per-shape geometry.
+ *
+ * The point-in-shape and sampling routines work in local (cx, cy, rx, ry)
+ * coordinates plus a rotation angle in degrees. Rotation is applied around
+ * (cx, cy).
+ */
+interface BoundaryShape {
+	readonly kind: BoundaryKind;
+	contains(
+		px: number,
+		py: number,
+		cx: number,
+		cy: number,
+		rx: number,
+		ry: number,
+		rotationDeg: number,
+	): boolean;
+	sample(
+		cx: number,
+		cy: number,
+		rx: number,
+		ry: number,
+		count: number,
+		rng: () => number,
+		rotationDeg: number,
+	): BoundaryPoint[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const CIRCLE_RADIAL_JITTER_FACTOR = 0.15;
+const CIRCLE_ANGLE_JITTER_RAD = (40 * Math.PI) / 180;
+const TEARDROP_RADIAL_JITTER_FACTOR = 0.08;
+const TEARDROP_POINT_EXPONENT = 0.6;
+const TEARDROP_MAX_SAMPLE_REJECTIONS = 8;
+
+// ---------------------------------------------------------------------------
+// Rotation helpers
+// ---------------------------------------------------------------------------
+
+function rotatePointAroundCenter(
+	px: number,
+	py: number,
+	cx: number,
+	cy: number,
+	rotationDeg: number,
+): BoundaryPoint {
+	if (rotationDeg === 0) {
+		return { x: px, y: py };
+	}
+	const theta = (rotationDeg * Math.PI) / 180;
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+	const dx = px - cx;
+	const dy = py - cy;
+	return {
+		x: cx + dx * cosT - dy * sinT,
+		y: cy + dx * sinT + dy * cosT,
+	};
+}
+
+function inverseRotateToLocal(
+	px: number,
+	py: number,
+	cx: number,
+	cy: number,
+	rotationDeg: number,
+): { xLocal: number; yLocal: number } {
+	if (rotationDeg === 0) {
+		return { xLocal: px - cx, yLocal: py - cy };
+	}
+	const theta = (-rotationDeg * Math.PI) / 180;
+	const cosT = Math.cos(theta);
+	const sinT = Math.sin(theta);
+	const dx = px - cx;
+	const dy = py - cy;
+	return {
+		xLocal: dx * cosT - dy * sinT,
+		yLocal: dx * sinT + dy * cosT,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Circle (axis-aligned ellipse) boundary
+// ---------------------------------------------------------------------------
+
+export const circleBoundary: BoundaryShape = {
+	kind: BOUNDARY_KINDS.circle,
+	contains(px, py, cx, cy, rx, ry, rotationDeg) {
+		const { xLocal, yLocal } = inverseRotateToLocal(px, py, cx, cy, rotationDeg);
+		const nx = xLocal / rx;
+		const ny = yLocal / ry;
+		return nx * nx + ny * ny <= 1;
+	},
+	sample(cx, cy, rx, ry, count, rng, rotationDeg) {
+		const points: BoundaryPoint[] = [];
+		for (let i = 0; i < count; i++) {
+			const baseAngle = (i / count) * Math.PI * 2;
+			const angleJitter = (rng() - 0.5) * CIRCLE_ANGLE_JITTER_RAD;
+			const angle = baseAngle + angleJitter;
+			const radialJitter = 1.0 + (rng() - 0.5) * 2 * CIRCLE_RADIAL_JITTER_FACTOR;
+			const xLocal = Math.cos(angle) * rx * radialJitter;
+			const yLocal = Math.sin(angle) * ry * radialJitter;
+			const rotated = rotatePointAroundCenter(cx + xLocal, cy + yLocal, cx, cy, rotationDeg);
+			points.push(rotated);
+		}
+		return points;
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Teardrop boundary
+// ---------------------------------------------------------------------------
+//
+// Parametric definition (local space, center at origin, pointy end up):
+//   t ∈ [-1, 1], t = -1 at pointy top, t = +1 at round bottom
+//   yLocal(t) = ry * t
+//   xLocal(t) =  rx * √(1 - t²) * (1 + t)^0.6   for t < 0
+//   xLocal(t) =  rx * √(1 - t²)                  for t ≥ 0
+//
+// The (1 + t)^0.6 factor pinches the top-half x-extent toward zero as t → -1,
+// creating the teardrop tip. Rotation is applied after generating the
+// local-space point.
+// ---------------------------------------------------------------------------
+
+function teardropXHalfWidth(tParam: number): number {
+	const ellipseFactor = Math.sqrt(Math.max(0, 1 - tParam * tParam));
+	if (tParam < 0) {
+		return ellipseFactor * Math.pow(1 + tParam, TEARDROP_POINT_EXPONENT);
+	}
+	return ellipseFactor;
+}
+
+export const teardropBoundary: BoundaryShape = {
+	kind: BOUNDARY_KINDS.teardrop,
+	contains(px, py, cx, cy, rx, ry, rotationDeg) {
+		const { xLocal, yLocal } = inverseRotateToLocal(px, py, cx, cy, rotationDeg);
+		const tParam = yLocal / ry;
+		if (tParam < -1 || tParam > 1) {
+			return false;
+		}
+		const halfWidth = teardropXHalfWidth(tParam);
+		if (halfWidth <= 0) {
+			return Math.abs(xLocal) < 1e-9;
+		}
+		const nx = xLocal / (rx * halfWidth);
+		return nx * nx <= 1;
+	},
+	sample(cx, cy, rx, ry, count, rng, rotationDeg) {
+		const points: BoundaryPoint[] = [];
+		if (count <= 0) {
+			return points;
+		}
+		// Half the samples ride the left edge, half the right edge, sweeping
+		// t from -1 (pointy top) to +1 (round bottom). Jitter is applied radially
+		// on the half-width so samples cannot escape the shape.
+		const halfCount = Math.max(1, Math.floor(count / 2));
+		const otherCount = count - halfCount;
+		const pushEdgeSamples = (edgeCount: number, sideSign: 1 | -1): void => {
+			for (let i = 0; i < edgeCount; i++) {
+				// Distribute t values across [-1, 1]. Avoid the exact endpoints so
+				// the pointy top is not duplicated from both edges.
+				const denom = edgeCount + 1;
+				const tParam = -1 + ((i + 1) / denom) * 2;
+				// Rejection-free radial jitter: scale the offset from the axis by
+				// a factor in [1 - j, 1], where j is the jitter fraction. This keeps
+				// every sample strictly inside the teardrop.
+				const jitterScale = 1 - rng() * TEARDROP_RADIAL_JITTER_FACTOR;
+				const halfWidth = teardropXHalfWidth(tParam) * jitterScale;
+				const xLocal = sideSign * rx * halfWidth;
+				const yLocal = ry * tParam;
+				const rotated = rotatePointAroundCenter(
+					cx + xLocal,
+					cy + yLocal,
+					cx,
+					cy,
+					rotationDeg,
+				);
+				points.push(rotated);
+			}
+		};
+		pushEdgeSamples(halfCount, 1);
+		pushEdgeSamples(otherCount, -1);
+		// Final safety pass: rejection-regenerate any point that happens to fall
+		// outside (should not happen with the rejection-free formula, but guards
+		// against floating-point edge cases near the pointy tip).
+		for (let i = 0; i < points.length; i++) {
+			let attempts = 0;
+			while (
+				attempts < TEARDROP_MAX_SAMPLE_REJECTIONS &&
+				!teardropBoundary.contains(points[i]!.x, points[i]!.y, cx, cy, rx, ry, rotationDeg)
+			) {
+				attempts++;
+				// Pull the point slightly toward the center until it lands inside.
+				const tParam = randomInRange(rng, -0.9, 0.9);
+				const halfWidth = teardropXHalfWidth(tParam) * 0.8;
+				const sideSign = rng() < 0.5 ? -1 : 1;
+				const xLocal = sideSign * rx * halfWidth;
+				const yLocal = ry * tParam;
+				points[i] = rotatePointAroundCenter(cx + xLocal, cy + yLocal, cx, cy, rotationDeg);
+			}
+		}
+		return points;
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export const BOUNDARIES = {
+	[BOUNDARY_KINDS.circle]: circleBoundary,
+	[BOUNDARY_KINDS.teardrop]: teardropBoundary,
+} as const satisfies Record<BoundaryKind, BoundaryShape>;
+
+// ---------------------------------------------------------------------------
+// Acute-angle smoothing post-pass (REQ-C-12)
+// ---------------------------------------------------------------------------
+//
+// Some canopy silhouettes (oak/birch/maple/willow) look best when sharp
+// concavities along the sampled boundary are pulled back toward the shape
+// edge. The pass walks the boundary looking for triples (prev, curr, next)
+// whose interior angle at `curr` is below the acute threshold, then relocates
+// `curr` onto the ellipse ring midway between prev and next.
+//
+// Teardrop boundaries must NOT be smoothed — rounding the pointy tip would
+// destroy the silhouette. Callers gate this helper on `blob.boundary ===
+// BOUNDARY_KINDS.circle` in generate.ts.
+// ---------------------------------------------------------------------------
+
+const ACUTE_ANGLE_THRESHOLD_RAD = Math.PI / 2;
+const ACUTE_ANGLE_MAX_PASSES = 3;
+
+function angleBetweenBoundaryPoints(
+	ax: number,
+	ay: number,
+	bx: number,
+	by: number,
+	cx: number,
+	cy: number,
+): number {
+	const bax = ax - bx;
+	const bay = ay - by;
+	const bcx = cx - bx;
+	const bcy = cy - by;
+	const dot = bax * bcx + bay * bcy;
+	const magBA = Math.sqrt(bax * bax + bay * bay);
+	const magBC = Math.sqrt(bcx * bcx + bcy * bcy);
+	if (magBA === 0 || magBC === 0) {
+		return Math.PI;
+	}
+	return Math.acos(Math.max(-1, Math.min(1, dot / (magBA * magBC))));
+}
+
+/**
+ * Pull acute-angle vertices on a circle-boundary sample back to the ellipse
+ * ring so the canopy silhouette reads as rounded rather than spiky. Returns a
+ * new array of points; the input is not mutated.
+ *
+ * The returned points are a mix of relocated and original entries. Must only
+ * be called for circle boundaries — teardrop shapes would lose their tip.
+ */
+export function smoothAcuteBoundaryAngles(
+	points: readonly BoundaryPoint[],
+	cx: number,
+	cy: number,
+	rx: number,
+	ry: number,
+): BoundaryPoint[] {
+	const result: { x: number; y: number }[] = points.map((p) => ({ x: p.x, y: p.y }));
+	if (result.length < 3) {
+		return result;
+	}
+	const avgR = (rx + ry) / 2;
+	let changed = true;
+	let passes = 0;
+
+	while (changed && passes < ACUTE_ANGLE_MAX_PASSES) {
+		changed = false;
+		passes++;
+
+		for (let i = result.length - 1; i >= 0; i--) {
+			if (result.length < 3) {
+				break;
+			}
+			const prev = result[(i - 1 + result.length) % result.length]!;
+			const curr = result[i]!;
+			const next = result[(i + 1) % result.length]!;
+
+			const ang = angleBetweenBoundaryPoints(prev.x, prev.y, curr.x, curr.y, next.x, next.y);
+			if (ang < ACUTE_ANGLE_THRESHOLD_RAD) {
+				const mx = (prev.x + next.x) / 2;
+				const my = (prev.y + next.y) / 2;
+				const ddx = mx - cx;
+				const ddy = my - cy;
+				const dist = Math.sqrt(ddx * ddx + ddy * ddy);
+				if (dist > 0) {
+					curr.x = cx + (ddx / dist) * avgR;
+					curr.y = cy + (ddy / dist) * avgR;
+					changed = true;
+				}
+			}
+		}
+	}
+
+	return result;
+}

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -764,3 +764,147 @@ describe('Parameter scaling', () => {
 		});
 	});
 });
+
+// ============================================================================
+// Issue #8: new tree shapes smoke tests
+// ============================================================================
+
+describe('Issue #8: new tree shapes (fir/maple/willow)', () => {
+	const newShapes = ['fir', 'maple', 'willow'] as const;
+
+	it.each(newShapes)('%s generates trunk and canopy triangles at seed 42', (shape) => {
+		const geo = generateTree(makeConfig({ shape, seed: 42 }));
+		expect(geo.trunkTriangles.length).toBeGreaterThan(0);
+		expect(geo.canopyBlobs.length).toBeGreaterThan(0);
+		const canopyTriTotal = geo.canopyBlobs.reduce((n, b) => n + b.triangles.length, 0);
+		expect(canopyTriTotal).toBeGreaterThan(0);
+	});
+
+	it.each(newShapes)('%s emits only valid hex colors', (shape) => {
+		const geo = generateTree(makeConfig({ shape, seed: 42 }));
+		for (const tri of allTriangles(geo)) {
+			expect(tri.color).toMatch(/^#[0-9a-f]{6}$/);
+		}
+	});
+
+	it.each(newShapes)('%s is deterministic across runs', (shape) => {
+		const cfg = makeConfig({ shape, seed: 42 });
+		const a = generateTree(cfg);
+		const b = generateTree(cfg);
+		expect(a).toEqual(b);
+	});
+
+	it('fir renders without NaN triangle vertices', () => {
+		const geo = generateTree(makeConfig({ shape: 'fir', seed: 42 }));
+		for (const blob of geo.canopyBlobs) {
+			for (const tri of blob.triangles) {
+				for (const p of tri.points) {
+					expect(Number.isNaN(p.x)).toBe(false);
+					expect(Number.isNaN(p.y)).toBe(false);
+				}
+			}
+		}
+	});
+
+	it.each(newShapes)(
+		'%s: trunk top enters the sampled canopy (sampled penetration ≥ 5 px)',
+		(shape) => {
+			// The analytical clamp enforces 15 px penetration against
+			// getBlobsBounds (cy+ry). Sampled canopy vertices can drift up to
+			// ~10 px inward from the analytical edge due to circle blob radial
+			// jitter (RADIAL_JITTER_FACTOR=0.15 × ry). A 5 px sampled
+			// penetration threshold captures the visible trunk-into-canopy
+			// invariant without being so tight it fails on large-ry blobs.
+			for (const trunkHeight of [50, 100, 150]) {
+				const geo = generateTree(makeConfig({ shape, trunkHeight, seed: 42 }));
+				const canopyMaxY = Math.max(
+					...geo.canopyBlobs.flatMap((b) =>
+						b.triangles.flatMap((t) => t.points.map((p) => p.y)),
+					),
+				);
+				expect(geo.anchors.trunkTop.y + 5).toBeLessThanOrEqual(canopyMaxY);
+			}
+		},
+	);
+
+	// Maple emits exactly one branch per canopy blob (issue #8 spec). We can't
+	// read structured branch segments back from the triangle mesh, so we
+	// validate reach via bounding-box containment: for each canopy blob, assert
+	// that at least one branch triangle vertex lies inside its axis-aligned
+	// bounding box. Branches terminate at the blob center, so the tip vertex of
+	// the outgoing branch quad mesh must live inside each blob's bbox.
+	it.each([3, 5, 7])(
+		'maple with blobCount=%i emits a branch reaching every canopy blob',
+		(blobCount) => {
+			const geo = generateTree(
+				makeConfig({ shape: 'maple', seed: 42, blobCount, branchThickness: 100 }),
+			);
+			expect(geo.canopyBlobs.length).toBe(blobCount);
+			expect(geo.branchTriangles.length).toBeGreaterThan(0);
+
+			for (const blob of geo.canopyBlobs) {
+				let minX = Infinity;
+				let minY = Infinity;
+				let maxX = -Infinity;
+				let maxY = -Infinity;
+				for (const tri of blob.triangles) {
+					for (const p of tri.points) {
+						if (p.x < minX) {
+							minX = p.x;
+						}
+						if (p.y < minY) {
+							minY = p.y;
+						}
+						if (p.x > maxX) {
+							maxX = p.x;
+						}
+						if (p.y > maxY) {
+							maxY = p.y;
+						}
+					}
+				}
+				const reached = geo.branchTriangles.some((tri) =>
+					tri.points.some(
+						(p) => p.x >= minX && p.x <= maxX && p.y >= minY && p.y <= maxY,
+					),
+				);
+				expect(reached).toBe(true);
+			}
+		},
+	);
+
+	it('fir (branchCount=0) produces zero branch triangles', () => {
+		const geo = generateTree(
+			makeConfig({ shape: 'fir', seed: 42, branchCount: 0, blobCount: 4 }),
+		);
+		expect(geo.branchTriangles.length).toBe(0);
+	});
+
+	// REQ-C-12: acute-angle smoothing applies to oak, birch, maple AND willow.
+	// The visual effect isn't quantitatively asserted here (it mutates boundary
+	// vertices by a few pixels at most), so this is a smoke test that maple
+	// still emits canopy triangles with the smoothing flag enabled. Failures
+	// here would indicate the post-pass crashes or drops all boundary points.
+	it('maple with acute-angle smoothing enabled still produces canopy triangles', () => {
+		const geo = generateTree(makeConfig({ shape: 'maple', seed: 42, blobCount: 5 }));
+		const canopyTriTotal = geo.canopyBlobs.reduce((n, b) => n + b.triangles.length, 0);
+		expect(canopyTriTotal).toBeGreaterThan(0);
+		for (const blob of geo.canopyBlobs) {
+			expect(blob.triangles.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('willow multi-segment trunk renders without crashing at defaults', () => {
+		const geo = generateTree(
+			makeConfig({
+				shape: 'willow',
+				seed: 42,
+				trunkSegments: 3,
+				trunkCrookedness: 40,
+				branchCount: 4,
+			}),
+		);
+		expect(geo.trunkTriangles.length).toBeGreaterThan(0);
+		expect(geo.branchTriangles.length).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -7,6 +7,7 @@ import type {
 	TreeAnchors,
 	BlobGeometry,
 	Tier,
+	TreeShape,
 } from './types.js';
 import { GEOMETRY_GROUPS, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, TREE_SHAPES } from './types.js';
 import { createPrng, poissonSample, randomInRange } from './prng.js';
@@ -17,7 +18,6 @@ import {
 	isPointInBranch,
 	generateBranches,
 	getBlobsBounds,
-	sampleBlobBoundary,
 	sampleTierBoundary,
 	assignBlobDepths,
 	applyBlobSizeVariance,
@@ -30,10 +30,26 @@ import {
 	buildTrunkPath,
 	sampleTrunkCenterX,
 	TRUNK_ENTRY_MIN_PX,
+	TRUNK_BRANCH_WIDTH_START_MIN,
+	TRUNK_BRANCH_WIDTH_START_MAX,
+	TRUNK_BRANCH_WIDTH_END_MIN,
+	TRUNK_BRANCH_WIDTH_END_MAX,
 	type Blob,
 	type BranchSegment,
 } from './shapes.js';
+import { BOUNDARIES, BOUNDARY_KINDS, smoothAcuteBoundaryAngles } from './boundaries.js';
 import { computeCanopyColor, computeTrunkColor } from './lighting.js';
+
+// REQ-C-12: shapes whose circle-boundary blobs should have acute concavities
+// pulled back to the ellipse ring for a rounder silhouette. Teardrop blobs are
+// gated out per-blob below so fir can be listed here safely if ever needed;
+// currently fir relies on its teardrop tip and has no circle smoothing.
+const SHAPES_WITH_ACUTE_SMOOTHING = new Set<TreeShape>([
+	TREE_SHAPES.oak,
+	TREE_SHAPES.birch,
+	TREE_SHAPES.maple,
+	TREE_SHAPES.willow,
+]);
 
 function triangulatePoints(
 	points: readonly { x: number; y: number }[],
@@ -266,7 +282,7 @@ function generateBlobCanopy(
 	colorRng: () => number,
 	blobs: readonly Blob[],
 	canopyBudget: number,
-	smoothAcuteAngles: boolean,
+	smoothAcuteAnglesForCircles: boolean,
 	config: TreeConfig,
 ): BlobGeometry[] {
 	const totalArea = blobs.reduce((sum, b) => sum + b.rx * b.ry, 0);
@@ -281,7 +297,24 @@ function generateBlobCanopy(
 		const blobBudget = Math.max(4, Math.round(canopyBudget * polygonShare));
 
 		const boundaryCount = Math.max(6, Math.floor(blobBudget * 0.15));
-		const boundaryPoints = sampleBlobBoundary(blob, boundaryCount, rng, smoothAcuteAngles);
+		const rawBoundaryPoints = BOUNDARIES[blob.boundary].sample(
+			blob.cx,
+			blob.cy,
+			blob.rx,
+			blob.ry,
+			boundaryCount,
+			rng,
+			blob.rotationDeg ?? 0,
+		);
+		// Teardrop blobs must never be acute-angle smoothed: the smoother would
+		// round off the pointy top, destroying the teardrop silhouette. Gate the
+		// smoothing per-blob on the boundary kind so shapes containing a mix of
+		// boundary types (fir: teardrop + circles) can opt in at shape level
+		// without affecting the teardrop.
+		const shouldSmooth = smoothAcuteAnglesForCircles && blob.boundary === BOUNDARY_KINDS.circle;
+		const boundaryPoints = shouldSmooth
+			? smoothAcuteBoundaryAngles(rawBoundaryPoints, blob.cx, blob.cy, blob.rx, blob.ry)
+			: rawBoundaryPoints;
 
 		const interiorCount = Math.max(3, blobBudget - boundaryCount);
 		const blobBounds = {
@@ -294,26 +327,38 @@ function generateBlobCanopy(
 			(blobBounds.maxX - blobBounds.minX) * (blobBounds.maxY - blobBounds.minY);
 		const minDist = Math.max(2, Math.sqrt(blobBoxArea / interiorCount) * 0.5);
 
+		const boundaryShape = BOUNDARIES[blob.boundary];
 		const interiorPoints = poissonSample(
 			rng,
 			interiorCount,
 			blobBounds,
-			(x, y) => {
-				const dx = (x - blob.cx) / blob.rx;
-				const dy = (y - blob.cy) / blob.ry;
-				return dx * dx + dy * dy <= 1;
-			},
+			(x, y) =>
+				boundaryShape.contains(
+					x,
+					y,
+					blob.cx,
+					blob.cy,
+					blob.rx,
+					blob.ry,
+					blob.rotationDeg ?? 0,
+				),
 			minDist,
 		);
 
 		const allPoints = [...boundaryPoints, ...interiorPoints];
 		const rawTris = triangulatePoints(allPoints);
 		const filtered = rawTris.filter((tri) =>
-			isTriangleInsideRegion(tri, (x, y) => {
-				const dx = (x - blob.cx) / blob.rx;
-				const dy = (y - blob.cy) / blob.ry;
-				return dx * dx + dy * dy <= 1;
-			}),
+			isTriangleInsideRegion(tri, (x, y) =>
+				boundaryShape.contains(
+					x,
+					y,
+					blob.cx,
+					blob.cy,
+					blob.rx,
+					blob.ry,
+					blob.rotationDeg ?? 0,
+				),
+			),
 		);
 
 		const coloredTris: Triangle[] = filtered.map((tri) => ({
@@ -407,6 +452,47 @@ function generateTierCanopy(
 }
 
 // ---------------------------------------------------------------------------
+// Maple per-blob branches (issue #8)
+// ---------------------------------------------------------------------------
+//
+// Maple emits exactly one branch per canopy blob, originating from the trunk
+// just below the canopy bottom and terminating at the blob center. This
+// replaces the generic trunk/sub-branch algorithm for maple because the
+// blob-per-branch correspondence is intrinsic to the shape. The user-visible
+// branchCount slider stays on the UI but is ignored for maple — one branch
+// per blob is the intentional spec.
+
+function generateMapleBranches(
+	rng: () => number,
+	trunkJunctions: readonly Point2D[],
+	blobs: readonly Blob[],
+	config: TreeConfig,
+	canopyBottom: number,
+): BranchSegment[] {
+	const branchThicknessScale = config.branchThickness / 100;
+	const segments: BranchSegment[] = [];
+	for (const blob of blobs) {
+		const originY = canopyBottom - randomInRange(rng, 5, 15);
+		const originX = sampleTrunkCenterX(trunkJunctions, originY);
+		const widthStart =
+			randomInRange(rng, TRUNK_BRANCH_WIDTH_START_MIN, TRUNK_BRANCH_WIDTH_START_MAX) *
+			branchThicknessScale;
+		const widthEnd =
+			randomInRange(rng, TRUNK_BRANCH_WIDTH_END_MIN, TRUNK_BRANCH_WIDTH_END_MAX) *
+			branchThicknessScale;
+		segments.push({
+			x1: originX,
+			y1: originY,
+			x2: blob.cx,
+			y2: blob.cy,
+			widthStart,
+			widthEnd,
+		});
+	}
+	return segments;
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -486,17 +572,36 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 	}
 	const trunkTop = trunkJunctions[trunkJunctions.length - 1]!.y;
 
-	const branches = isPine
-		? []
-		: generateBranches(
-				createPrng(config.seed + 7777),
-				trunkTop,
-				trunkBottom,
-				shapeDef.trunkTopWidth * (config.trunkThickness / 100),
-				config,
-				trunkJunctions,
-				blobs,
-			);
+	// Branch generation dispatch:
+	//   - pine has no branches
+	//   - maple emits one branch per canopy blob (issue #8) using
+	//     generateMapleBranches — this replaces the generic algorithm because
+	//     every blob needs a dedicated branch from the trunk. The user-visible
+	//     branchCount slider is intentionally ignored for maple (spec).
+	//   - all other shapes use the generic generateBranches entry point.
+	// The maple branch rng uses the same seed offset (+7777) as the generic
+	// branch path so determinism holds across shape switches.
+	let branches: BranchSegment[];
+	if (isPine) {
+		branches = [];
+	} else if (config.shape === TREE_SHAPES.maple) {
+		const mapleRng = createPrng(config.seed + 7777);
+		// Reuse the already-computed canopyBounds (getBlobsBounds result from
+		// above) rather than recomputing. For maple this is always the blob
+		// bounds path (pine is excluded by the outer branch).
+		const canopyBottomY = blobs.length > 0 ? canopyBounds.maxY : trunkTop;
+		branches = generateMapleBranches(mapleRng, trunkJunctions, blobs, config, canopyBottomY);
+	} else {
+		branches = generateBranches(
+			createPrng(config.seed + 7777),
+			trunkTop,
+			trunkBottom,
+			shapeDef.trunkTopWidth * (config.trunkThickness / 100),
+			config,
+			trunkJunctions,
+			blobs,
+		);
+	}
 
 	const extraBranches = isPine ? [] : validateNoFloatingBlobs(blobs, branches);
 	const allBranches = [...branches, ...extraBranches];
@@ -519,8 +624,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 		config,
 	);
 
-	const smoothAcuteAngles =
-		config.shape === TREE_SHAPES.oak || config.shape === TREE_SHAPES.birch;
+	const smoothAcuteAngles = SHAPES_WITH_ACUTE_SMOOTHING.has(config.shape);
 	const canopyBlobs = isPine
 		? generateTierCanopy(
 				rng,

--- a/src/lib/trees/shapes.test.ts
+++ b/src/lib/trees/shapes.test.ts
@@ -14,6 +14,7 @@ import {
 	type Blob,
 	type BranchSegment,
 } from './shapes.js';
+import { BOUNDARY_KINDS } from './boundaries.js';
 import { createPrng } from './prng.js';
 import { DEFAULT_TREE_CONFIG, VIEWBOX_WIDTH } from './types.js';
 import type { Tier, TreeConfig } from './types.js';
@@ -276,14 +277,18 @@ describe('computeVisibleBranchLength', () => {
 
 	it('returns full length when branch is fully outside any blob', () => {
 		const branch = makeBranch(0, 0, 100, 0);
-		const blobs: Blob[] = [{ cx: 500, cy: 500, rx: 10, ry: 10 }];
+		const blobs: Blob[] = [
+			{ cx: 500, cy: 500, rx: 10, ry: 10, boundary: BOUNDARY_KINDS.circle },
+		];
 		const visible = computeVisibleBranchLength(branch, blobs, []);
 		expect(visible).toBeCloseTo(100, 10);
 	});
 
 	it('returns 0 when branch is fully inside a blob', () => {
 		const branch = makeBranch(95, 100, 105, 100);
-		const blobs: Blob[] = [{ cx: 100, cy: 100, rx: 50, ry: 50 }];
+		const blobs: Blob[] = [
+			{ cx: 100, cy: 100, rx: 50, ry: 50, boundary: BOUNDARY_KINDS.circle },
+		];
 		const visible = computeVisibleBranchLength(branch, blobs, []);
 		expect(visible).toBeCloseTo(0, 6);
 	});
@@ -291,7 +296,7 @@ describe('computeVisibleBranchLength', () => {
 	it('returns half length when branch is half-covered by one blob', () => {
 		// Segment from (0,0) to (20,0); blob center (15,0), rx=5, ry=5 covers x in [10, 20]
 		const branch = makeBranch(0, 0, 20, 0);
-		const blobs: Blob[] = [{ cx: 15, cy: 0, rx: 5, ry: 5 }];
+		const blobs: Blob[] = [{ cx: 15, cy: 0, rx: 5, ry: 5, boundary: BOUNDARY_KINDS.circle }];
 		const visible = computeVisibleBranchLength(branch, blobs, []);
 		expect(visible).toBeCloseTo(10, 6);
 	});
@@ -300,8 +305,8 @@ describe('computeVisibleBranchLength', () => {
 		// Two blobs covering same region at x in [10,20]
 		const branch = makeBranch(0, 0, 20, 0);
 		const blobs: Blob[] = [
-			{ cx: 15, cy: 0, rx: 5, ry: 5 },
-			{ cx: 15, cy: 0, rx: 5, ry: 5 },
+			{ cx: 15, cy: 0, rx: 5, ry: 5, boundary: BOUNDARY_KINDS.circle },
+			{ cx: 15, cy: 0, rx: 5, ry: 5, boundary: BOUNDARY_KINDS.circle },
 		];
 		const visible = computeVisibleBranchLength(branch, blobs, []);
 		expect(visible).toBeCloseTo(10, 6);
@@ -511,7 +516,9 @@ describe('generateBranches — visibility & crossing invariants', () => {
 		const config = makeConfig({ shape: 'oak', branchCount: 8, seed: 9 });
 		const setup = setupOakBranchInputs(config);
 		// Replace blobs with a single huge blob covering the whole viewbox.
-		const giantBlob: Blob[] = [{ cx: 100, cy: 150, rx: 500, ry: 500 }];
+		const giantBlob: Blob[] = [
+			{ cx: 100, cy: 150, rx: 500, ry: 500, boundary: BOUNDARY_KINDS.circle },
+		];
 		const start = Date.now();
 		const branches = generateBranches(
 			setup.rng,
@@ -579,5 +586,246 @@ describe('generateBranches — visibility & crossing invariants', () => {
 			b.blobs,
 		);
 		expect(bA).toEqual(bB);
+	});
+});
+
+// ============================================================================
+// REQ-C-18: oak non-primary blobs distributed radially (full 360°)
+// ============================================================================
+
+describe('REQ-C-18: oak radial blob distribution', () => {
+	const shapeDef = getShapeDefinition('oak');
+	const W = VIEWBOX_WIDTH;
+	const minAxisDistance = W * 0.15;
+
+	it('at most one blob sits on the trunk axis (the primary anchor)', () => {
+		// REQ-C-18: non-primary blobs are pushed at least 0.15·W off-axis.
+		// The primary blob is kept anchored on the axis. Because
+		// ensureLargestBlobInBottomHalf may swap array positions, we check the
+		// overall count of axis-hugging blobs rather than index 1..N.
+		for (let seed = 1; seed <= 40; seed++) {
+			const rng = createPrng(seed);
+			const blobs = shapeDef.generateBlobs(rng, 6);
+			expect(blobs.length).toBe(6);
+			const onAxisCount = blobs.filter(
+				(b) => Math.abs(b.cx - W / 2) < minAxisDistance - 1e-9,
+			).length;
+			expect(onAxisCount).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it('across multiple seeds, at least one non-primary blob lies above the primary (cy<primary.cy)', () => {
+		// Full 360° sampling must allow blobs above the primary; the old
+		// half-axis distribution only placed them in a 180° arc below.
+		let sawAbove = false;
+		for (let seed = 1; seed <= 60 && !sawAbove; seed++) {
+			const rng = createPrng(seed);
+			const blobs = shapeDef.generateBlobs(rng, 6);
+			const primary = blobs[0]!;
+			for (let i = 1; i < blobs.length; i++) {
+				if (blobs[i]!.cy < primary.cy) {
+					sawAbove = true;
+					break;
+				}
+			}
+		}
+		expect(sawAbove).toBe(true);
+	});
+
+	it('primary blob stays anchored on the trunk axis', () => {
+		const rng = createPrng(42);
+		const blobs = shapeDef.generateBlobs(rng, 5);
+		expect(blobs[0]!.cx).toBe(W / 2);
+	});
+
+	it('non-primary blobs land on both sides of the trunk across seeds', () => {
+		let sawLeft = false;
+		let sawRight = false;
+		for (let seed = 1; seed <= 40 && !(sawLeft && sawRight); seed++) {
+			const rng = createPrng(seed);
+			const blobs = shapeDef.generateBlobs(rng, 6);
+			for (let i = 1; i < blobs.length; i++) {
+				if (blobs[i]!.cx < W / 2) {
+					sawLeft = true;
+				}
+				if (blobs[i]!.cx > W / 2) {
+					sawRight = true;
+				}
+			}
+		}
+		expect(sawLeft && sawRight).toBe(true);
+	});
+
+	it('every blob carries boundary=circle', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 5);
+		for (const b of blobs) {
+			expect(b.boundary).toBe(BOUNDARY_KINDS.circle);
+		}
+	});
+});
+
+// ============================================================================
+// REQ-C-19: birch canopy rx doubled (W*0.12 .. W*0.24)
+// ============================================================================
+
+describe('REQ-C-19: birch canopy rx range', () => {
+	const shapeDef = getShapeDefinition('birch');
+	const W = VIEWBOX_WIDTH;
+
+	it('birch blobs at seed 42 include at least one rx ≥ W*0.12', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 5);
+		const hasMinRx = blobs.some((b) => b.rx >= W * 0.12 - 1e-9);
+		expect(hasMinRx).toBe(true);
+	});
+
+	it('all birch blobs have rx within [W*0.12, W*0.24]', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 5);
+		for (const b of blobs) {
+			expect(b.rx).toBeGreaterThanOrEqual(W * 0.12 - 1e-9);
+			expect(b.rx).toBeLessThanOrEqual(W * 0.24 + 1e-9);
+		}
+	});
+
+	it('across many seeds, max rx approaches W*0.24', () => {
+		let maxRx = -Infinity;
+		for (let seed = 1; seed <= 100; seed++) {
+			const blobs = shapeDef.generateBlobs(createPrng(seed), 5);
+			for (const b of blobs) {
+				if (b.rx > maxRx) {
+					maxRx = b.rx;
+				}
+			}
+		}
+		expect(maxRx).toBeGreaterThan(W * 0.22);
+	});
+});
+
+// ============================================================================
+// REQ-C-20: fir canopy — teardrop top + circle bottom blobs
+// ============================================================================
+
+describe('REQ-C-20: fir canopy blobs', () => {
+	const shapeDef = getShapeDefinition('fir');
+	const W = VIEWBOX_WIDTH;
+
+	it('fir generates exactly 4 blobs at seed 42 / blobCount 4', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 4);
+		expect(blobs.length).toBe(4);
+	});
+
+	it('fir canopy includes at least one teardrop boundary blob', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 4);
+		const teardrops = blobs.filter((b) => b.boundary === BOUNDARY_KINDS.teardrop);
+		expect(teardrops.length).toBeGreaterThanOrEqual(1);
+	});
+
+	// REQ-C-20: the teardrop must live at index 0 AND be the topmost (smallest cy)
+	// blob across every seed. Earlier code ran ensureLargestBlobInBottomHalf on
+	// fir, which could swap a bottom circle to index 0 when its rx*ry exceeded
+	// the teardrop's, pushing the teardrop down and breaking the cone
+	// silhouette. Skipping the helper for fir is the structural fix; these
+	// assertions protect against the regression on multiple seeds.
+	it.each([1, 42, 100, 999])(
+		'fir seed %i: blobs[0] is the teardrop and sits at the topmost cy',
+		(seed) => {
+			const blobs = shapeDef.generateBlobs(createPrng(seed), 4);
+			expect(blobs[0]!.boundary).toBe(BOUNDARY_KINDS.teardrop);
+			const minCy = Math.min(...blobs.map((b) => b.cy));
+			expect(blobs[0]!.cy).toBe(minCy);
+		},
+	);
+
+	it('fir bottom 3 circles share similar cy (within ±25 px)', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 4);
+		const circles = blobs.filter((b) => b.boundary === BOUNDARY_KINDS.circle);
+		expect(circles.length).toBe(3);
+		const meanCy = circles.reduce((sum, b) => sum + b.cy, 0) / circles.length;
+		for (const c of circles) {
+			expect(Math.abs(c.cy - meanCy)).toBeLessThanOrEqual(25);
+		}
+	});
+
+	it('fir bottom circles straddle the trunk axis (one left, one right)', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 4);
+		const circles = blobs.filter((b) => b.boundary === BOUNDARY_KINDS.circle);
+		const leftExists = circles.some((b) => b.cx < W / 2);
+		const rightExists = circles.some((b) => b.cx > W / 2);
+		expect(leftExists && rightExists).toBe(true);
+	});
+
+	it('fir is deterministic across runs', () => {
+		const a = shapeDef.generateBlobs(createPrng(42), 4);
+		const b = shapeDef.generateBlobs(createPrng(42), 4);
+		expect(a).toEqual(b);
+	});
+});
+
+// ============================================================================
+// REQ-C-21: maple canopy — 5 blobs in a 180° arc above the trunk
+// ============================================================================
+
+describe('REQ-C-21: maple canopy arc layout', () => {
+	const shapeDef = getShapeDefinition('maple');
+	const W = VIEWBOX_WIDTH;
+
+	it('maple at seed 42 with blobCount=5 produces exactly 5 blobs', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 5);
+		expect(blobs.length).toBe(5);
+	});
+
+	it('maple blobs span at least 0.30·W horizontally (full arc)', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 5);
+		const minCx = Math.min(...blobs.map((b) => b.cx));
+		const maxCx = Math.max(...blobs.map((b) => b.cx));
+		expect(minCx).toBeLessThan(W / 2 - 0.15 * W);
+		expect(maxCx).toBeGreaterThan(W / 2 + 0.15 * W);
+	});
+
+	it('every maple blob uses circle boundary', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 5);
+		for (const b of blobs) {
+			expect(b.boundary).toBe(BOUNDARY_KINDS.circle);
+		}
+	});
+
+	it('maple is deterministic', () => {
+		const a = shapeDef.generateBlobs(createPrng(42), 5);
+		const b = shapeDef.generateBlobs(createPrng(42), 5);
+		expect(a).toEqual(b);
+	});
+});
+
+// ============================================================================
+// REQ-C-22: willow canopy — reuses oak radial with scaled secondary blobs
+// ============================================================================
+
+describe('REQ-C-22: willow canopy', () => {
+	const shapeDef = getShapeDefinition('willow');
+
+	it('willow default (blobCount 4) produces 4 blobs', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 4);
+		expect(blobs.length).toBe(4);
+	});
+
+	it('willow primary blob is larger than every secondary blob', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 4);
+		const primaryArea = blobs[0]!.rx * blobs[0]!.ry;
+		for (let i = 1; i < blobs.length; i++) {
+			const secondaryArea = blobs[i]!.rx * blobs[i]!.ry;
+			expect(primaryArea).toBeGreaterThan(secondaryArea);
+		}
+	});
+
+	it('every willow blob uses circle boundary', () => {
+		const blobs = shapeDef.generateBlobs(createPrng(42), 4);
+		for (const b of blobs) {
+			expect(b.boundary).toBe(BOUNDARY_KINDS.circle);
+		}
+	});
+
+	it('willow is deterministic', () => {
+		const a = shapeDef.generateBlobs(createPrng(42), 4);
+		const b = shapeDef.generateBlobs(createPrng(42), 4);
+		expect(a).toEqual(b);
 	});
 });

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -1,6 +1,7 @@
 import type { TreeShape, Tier, TreeConfig, Point2D } from './types.js';
 import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types.js';
 import { randomInRange } from './prng.js';
+import { BOUNDARIES, BOUNDARY_KINDS, type BoundaryKind } from './boundaries.js';
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -11,6 +12,18 @@ export interface Blob {
 	cy: number;
 	rx: number;
 	ry: number;
+	/**
+	 * Per-blob boundary shape discriminator. Circle (axis-aligned ellipse) is
+	 * the default for oak/birch/willow/maple/etc. Teardrop is used for the top
+	 * blob of fir-style cone canopies. See boundaries.ts for the registry.
+	 */
+	boundary: BoundaryKind;
+	/**
+	 * Rotation applied to the boundary shape around (cx, cy), in degrees.
+	 * Ignored for axis-aligned circle boundaries; required for teardrop blobs
+	 * that need to point in a non-default direction.
+	 */
+	rotationDeg?: number;
 }
 
 export interface BranchSegment {
@@ -30,11 +43,17 @@ const W = VIEWBOX_WIDTH;
 const H = VIEWBOX_HEIGHT;
 
 export const TRUNK_ENTRY_MIN_PX = 15;
-const RADIAL_JITTER_FACTOR = 0.15;
-const ACUTE_ANGLE_THRESHOLD_RAD = Math.PI / 2;
 // Sub-branch widths pre-scaled by 1.75 (issue #4 base rescale).
 const SUB_BRANCH_WIDTH_MIN = 3.5;
 const SUB_BRANCH_WIDTH_MAX = 7;
+// Trunk-origin branch widths pre-scaled by 1.75 (issue #4 base rescale).
+// Shared by rollTrunkBranchCandidate (generic algorithm) and
+// generateMapleBranches (maple per-blob branches) so both paths produce
+// visually consistent branch proportions.
+export const TRUNK_BRANCH_WIDTH_START_MIN = 7;
+export const TRUNK_BRANCH_WIDTH_START_MAX = 12.25;
+export const TRUNK_BRANCH_WIDTH_END_MIN = 1.75;
+export const TRUNK_BRANCH_WIDTH_END_MAX = 5.25;
 const BRANCH_ANGLE_MIN_RAD = (30 * Math.PI) / 180;
 const BRANCH_ANGLE_MAX_ATTEMPTS = 20;
 
@@ -83,32 +102,197 @@ function ensureLargestBlobInBottomHalf(blobs: Blob[]): void {
 	}
 }
 
+const OAK_NON_PRIMARY_MIN_AXIS_DISTANCE_FACTOR = 0.15;
+const OAK_NON_PRIMARY_ANGLE_MAX_ATTEMPTS = 5;
+const WILLOW_NON_PRIMARY_SCALE_FACTOR = 0.85;
+
 function generateOakBlobs(rng: () => number, blobCount: number): Blob[] {
 	const blobs: Blob[] = [];
 	const centerX = W / 2;
 	const canopyCenterY = H * 0.3;
 	const spreadRadius = W * 0.22;
+	const minAxisDistance = W * OAK_NON_PRIMARY_MIN_AXIS_DISTANCE_FACTOR;
 
-	// D9: blob 0 on trunk axis
+	// D9: primary blob anchored on the trunk axis.
 	if (blobCount >= 1) {
 		const rx = randomInRange(rng, W * 0.2275, W * 0.385);
 		const ry = randomInRange(rng, H * 0.14, H * 0.2625);
-		blobs.push({ cx: centerX, cy: canopyCenterY, rx, ry });
+		blobs.push({
+			cx: centerX,
+			cy: canopyCenterY,
+			rx,
+			ry,
+			boundary: BOUNDARY_KINDS.circle,
+		});
 	}
 
-	// D9: remaining blobs balanced left/right
-	for (let i = 1; i < blobCount; i++) {
-		const side = i % 2 === 0 ? 1 : -1;
-		const dist = randomInRange(rng, spreadRadius * 0.3, spreadRadius * 0.9);
-		const angleJitter = randomInRange(rng, -0.5, 0.5);
-		const angle = (Math.PI / 4) * Math.ceil(i / 2) + angleJitter;
-		const cx = centerX + Math.cos(angle) * dist * side;
-		const cy = canopyCenterY + Math.sin(angle) * dist * 0.5 * (rng() > 0.5 ? -1 : 1);
-		const rx = randomInRange(rng, W * 0.2275, W * 0.385);
-		const ry = randomInRange(rng, H * 0.14, H * 0.2625);
-		blobs.push({ cx, cy, rx, ry });
+	// REQ-C-18: non-primary blobs distributed radially around the primary
+	// blob in the full 360° range, with a minimum distance from the trunk
+	// axis enforced so they never stack directly above the trunk.
+	const primary = blobs[0];
+	if (primary !== undefined) {
+		for (let i = 1; i < blobCount; i++) {
+			let acceptedCx = primary.cx;
+			let acceptedCy = primary.cy;
+			let attempts = 0;
+			while (attempts < OAK_NON_PRIMARY_ANGLE_MAX_ATTEMPTS) {
+				const angle = rng() * Math.PI * 2;
+				const dist = randomInRange(rng, spreadRadius * 0.3, spreadRadius * 0.9);
+				const cx = primary.cx + Math.cos(angle) * dist;
+				const cy = primary.cy + Math.sin(angle) * dist;
+				if (Math.abs(cx - centerX) >= minAxisDistance) {
+					acceptedCx = cx;
+					acceptedCy = cy;
+					break;
+				}
+				attempts++;
+				acceptedCx = cx;
+				acceptedCy = cy;
+			}
+			if (Math.abs(acceptedCx - centerX) < minAxisDistance) {
+				const sign = acceptedCx >= centerX ? 1 : -1;
+				acceptedCx = centerX + sign * minAxisDistance;
+			}
+			const rx = randomInRange(rng, W * 0.2275, W * 0.385);
+			const ry = randomInRange(rng, H * 0.14, H * 0.2625);
+			blobs.push({
+				cx: acceptedCx,
+				cy: acceptedCy,
+				rx,
+				ry,
+				boundary: BOUNDARY_KINDS.circle,
+			});
+		}
 	}
 	ensureLargestBlobInBottomHalf(blobs);
+	return blobs;
+}
+
+/**
+ * Fir canopy (issue #8): pointy conical silhouette. Top blob is a rotated
+ * teardrop pointing up; bottom row is three circles straddling the trunk.
+ * Extra blobs beyond the 4th are radially scattered around the center-bottom
+ * circle so higher blobCount still has something to triangulate.
+ */
+function generateFirBlobs(rng: () => number, blobCount: number): Blob[] {
+	const blobs: Blob[] = [];
+	const centerX = W / 2;
+
+	// Top teardrop blob — axis-aligned with pointy end up (rotationDeg=0).
+	if (blobCount >= 1) {
+		blobs.push({
+			cx: centerX,
+			cy: H * 0.18,
+			rx: W * 0.18,
+			ry: H * 0.28,
+			boundary: BOUNDARY_KINDS.teardrop,
+			rotationDeg: 0,
+		});
+	}
+
+	// Bottom three circles share a cy around H*0.42. Each gets a mild per-blob
+	// cy jitter so the row is not dead straight. Ordering: center → left →
+	// right. Lower blobCount values truncate from the right.
+	const bottomBaseCy = H * 0.42 + randomInRange(rng, -10, 10);
+	const bottomOrder: Array<{ side: 1 | -1 | 0 }> = [{ side: 0 }, { side: -1 }, { side: 1 }];
+	const bottomNeeded = Math.min(3, Math.max(0, blobCount - 1));
+	for (let i = 0; i < bottomNeeded; i++) {
+		const entry = bottomOrder[i]!;
+		let cx = centerX;
+		if (entry.side === 0) {
+			cx = centerX + randomInRange(rng, -3, 3);
+		} else {
+			const dist = randomInRange(rng, W * 0.25, W * 0.4);
+			cx = centerX + entry.side * dist;
+		}
+		const cy = bottomBaseCy + randomInRange(rng, -10, 10);
+		const rx = randomInRange(rng, W * 0.22, W * 0.32);
+		const ry = randomInRange(rng, H * 0.14, H * 0.2);
+		blobs.push({
+			cx,
+			cy,
+			rx,
+			ry,
+			boundary: BOUNDARY_KINDS.circle,
+		});
+	}
+
+	// Extras (blobCount > 4): radial scatter around the center-bottom blob.
+	if (blobCount > 4 && blobs.length >= 2) {
+		const centerBottom = blobs[1]!;
+		const spreadRadius = W * 0.22;
+		for (let i = 4; i < blobCount; i++) {
+			const angle = rng() * Math.PI * 2;
+			const dist = randomInRange(rng, spreadRadius * 0.3, spreadRadius * 0.9);
+			const cx = centerBottom.cx + Math.cos(angle) * dist;
+			const cy = centerBottom.cy + Math.sin(angle) * dist;
+			const rx = randomInRange(rng, W * 0.2, W * 0.3);
+			const ry = randomInRange(rng, H * 0.12, H * 0.18);
+			blobs.push({
+				cx,
+				cy,
+				rx,
+				ry,
+				boundary: BOUNDARY_KINDS.circle,
+			});
+		}
+	}
+
+	// Fir intentionally skips ensureLargestBlobInBottomHalf: the top-is-teardrop
+	// invariant is structural (fir's silhouette depends on the teardrop blob at
+	// index 0), and a bottom circle blob can out-area the teardrop in rx*ry
+	// terms under certain seeds, which would cause the helper to swap the
+	// teardrop down and break the cone. Fir's layout is deterministic-by-
+	// position, so the helper is solving a problem fir doesn't have.
+	return blobs;
+}
+
+/**
+ * Maple canopy (issue #8): blobs distributed along a 180° arc above the
+ * trunk. Each blob is a small circle; the wide horizontal spread is what
+ * gives maple its characteristic crown silhouette. Per-blob branches are
+ * generated separately in generate.ts so every blob can be reached.
+ */
+function generateMapleBlobs(rng: () => number, blobCount: number): Blob[] {
+	const blobs: Blob[] = [];
+	const centerX = W / 2;
+	const arcCenterY = H * 0.42;
+	const arcRadius = W * 0.28;
+
+	for (let i = 0; i < blobCount; i++) {
+		// Distribute angle along the arc from π (left) to 2π (right), walking
+		// the upper semicircle above (arcCenterX, arcCenterY). blobCount===1 is
+		// a single overhead blob.
+		const angle = blobCount === 1 ? 1.5 * Math.PI : Math.PI + (i / (blobCount - 1)) * Math.PI;
+		const cx = centerX + Math.cos(angle) * arcRadius + randomInRange(rng, -3, 3);
+		const cy = arcCenterY + Math.sin(angle) * arcRadius + randomInRange(rng, -3, 3);
+		const rx = randomInRange(rng, W * 0.1, W * 0.15);
+		const ry = randomInRange(rng, H * 0.08, H * 0.12);
+		blobs.push({
+			cx,
+			cy,
+			rx,
+			ry,
+			boundary: BOUNDARY_KINDS.circle,
+		});
+	}
+
+	ensureLargestBlobInBottomHalf(blobs);
+	return blobs;
+}
+
+/**
+ * Willow canopy (issue #8): thin wrapper around oak's radial distribution
+ * that scales non-primary blobs down slightly. The willow character comes
+ * from the multi-segment crooked trunk + 4 thick branches (SHAPE_DEFAULTS
+ * already wires those params), not from the blob shape.
+ */
+function generateWillowBlobs(rng: () => number, blobCount: number): Blob[] {
+	const blobs = generateOakBlobs(rng, blobCount);
+	for (let i = 1; i < blobs.length; i++) {
+		blobs[i]!.rx *= WILLOW_NON_PRIMARY_SCALE_FACTOR;
+		blobs[i]!.ry *= WILLOW_NON_PRIMARY_SCALE_FACTOR;
+	}
 	return blobs;
 }
 
@@ -139,51 +323,63 @@ const shapeDefinitions: Record<TreeShape, ShapeDefinition> = {
 			const centerX = W / 2;
 			const canopyCenterY = H * 0.25;
 
-			// D9: blob 0 on trunk axis
+			// D9: blob 0 on trunk axis.
+			// REQ-C-19: birch canopy is visibly ~2× wider than before; rx range
+			// doubled from (0.105..0.21)·W to (0.12..0.24)·W. ry untouched.
 			if (blobCount >= 1) {
-				const rx = randomInRange(rng, W * 0.105, W * 0.21);
+				const rx = randomInRange(rng, W * 0.12, W * 0.24);
 				const ry = randomInRange(rng, H * 0.21, H * 0.385);
-				blobs.push({ cx: centerX, cy: canopyCenterY, rx, ry });
+				blobs.push({
+					cx: centerX,
+					cy: canopyCenterY,
+					rx,
+					ry,
+					boundary: BOUNDARY_KINDS.circle,
+				});
 			}
 
-			// Birch blobs are tall and narrow, stacked more vertically
+			// Birch blobs are tall and narrow, stacked more vertically.
 			for (let i = 1; i < blobCount; i++) {
 				const side = i % 2 === 0 ? 1 : -1;
 				const verticalOffset = randomInRange(rng, -H * 0.08, H * 0.08);
 				const horizontalOffset = randomInRange(rng, W * 0.02, W * 0.08) * side;
 				const cx = centerX + horizontalOffset;
 				const cy = canopyCenterY + verticalOffset;
-				const rx = randomInRange(rng, W * 0.105, W * 0.21);
+				const rx = randomInRange(rng, W * 0.12, W * 0.24);
 				const ry = randomInRange(rng, H * 0.21, H * 0.385);
-				blobs.push({ cx, cy, rx, ry });
+				blobs.push({
+					cx,
+					cy,
+					rx,
+					ry,
+					boundary: BOUNDARY_KINDS.circle,
+				});
 			}
 			ensureLargestBlobInBottomHalf(blobs);
 			return blobs;
 		},
 	},
-	// Placeholder definitions for shapes whose real generators arrive in issue #8.
-	// Trunk widths rescaled by 1.75 per issue #4. Blob generators reuse oak's
-	// radial distribution until dedicated generators land.
+	// Issue #8 shape generators. Trunk widths rescaled by 1.75 per issue #4.
 	fir: {
 		trunkBaseWidth: 21,
 		trunkTopWidth: 12.25,
 		trunkBottom: H * 0.95,
 		defaultTrunkTop: H * 0.55,
-		generateBlobs: generateOakBlobs,
+		generateBlobs: generateFirBlobs,
 	},
 	maple: {
 		trunkBaseWidth: 28,
 		trunkTopWidth: 17.5,
 		trunkBottom: H * 0.95,
 		defaultTrunkTop: H * 0.45,
-		generateBlobs: generateOakBlobs,
+		generateBlobs: generateMapleBlobs,
 	},
 	willow: {
 		trunkBaseWidth: 28,
 		trunkTopWidth: 17.5,
 		trunkBottom: H * 0.95,
 		defaultTrunkTop: H * 0.45,
-		generateBlobs: generateOakBlobs,
+		generateBlobs: generateWillowBlobs,
 	},
 	custom: {
 		trunkBaseWidth: 28,
@@ -314,17 +510,13 @@ export function isPointInTrunkPath(
 // ---------------------------------------------------------------------------
 
 function isPointInBlobs(x: number, y: number, blobs: readonly Blob[]): boolean {
-	return blobs.some((b) => {
-		const dx = (x - b.cx) / b.rx;
-		const dy = (y - b.cy) / b.ry;
-		return dx * dx + dy * dy <= 1;
-	});
+	return blobs.some((b) =>
+		BOUNDARIES[b.boundary].contains(x, y, b.cx, b.cy, b.rx, b.ry, b.rotationDeg ?? 0),
+	);
 }
 
 function isPointInSingleBlob(x: number, y: number, b: Blob): boolean {
-	const dx = (x - b.cx) / b.rx;
-	const dy = (y - b.cy) / b.ry;
-	return dx * dx + dy * dy <= 1;
+	return BOUNDARIES[b.boundary].contains(x, y, b.cx, b.cy, b.rx, b.ry, b.rotationDeg ?? 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -538,88 +730,6 @@ export function applyCanopySize(blobs: Blob[], canopySize: number): void {
 		blob.rx *= scale;
 		blob.ry *= scale;
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Per-blob boundary sampling
-// ---------------------------------------------------------------------------
-
-function angleBetween(
-	ax: number,
-	ay: number,
-	bx: number,
-	by: number,
-	cx: number,
-	cy: number,
-): number {
-	const bax = ax - bx;
-	const bay = ay - by;
-	const bcx = cx - bx;
-	const bcy = cy - by;
-	const dot = bax * bcx + bay * bcy;
-	const magBA = Math.sqrt(bax * bax + bay * bay);
-	const magBC = Math.sqrt(bcx * bcx + bcy * bcy);
-	if (magBA === 0 || magBC === 0) {
-		return Math.PI;
-	}
-	return Math.acos(Math.max(-1, Math.min(1, dot / (magBA * magBC))));
-}
-
-export function sampleBlobBoundary(
-	blob: Blob,
-	sampleCount: number,
-	rng: () => number,
-	smoothAcuteAngles: boolean,
-): { x: number; y: number }[] {
-	const points: { x: number; y: number }[] = [];
-
-	for (let i = 0; i < sampleCount; i++) {
-		const baseAngle = (i / sampleCount) * Math.PI * 2;
-		const jitter = (rng() - 0.5) * ((40 * Math.PI) / 180);
-		const angle = baseAngle + jitter;
-
-		const radialJitter = 1.0 + (rng() - 0.5) * 2 * RADIAL_JITTER_FACTOR;
-		const px = blob.cx + Math.cos(angle) * blob.rx * radialJitter;
-		const py = blob.cy + Math.sin(angle) * blob.ry * radialJitter;
-		points.push({ x: px, y: py });
-	}
-
-	if (smoothAcuteAngles && points.length >= 3) {
-		let changed = true;
-		let passes = 0;
-		const maxPasses = 3;
-
-		while (changed && passes < maxPasses) {
-			changed = false;
-			passes++;
-
-			for (let i = points.length - 1; i >= 0; i--) {
-				if (points.length < 3) {
-					break;
-				}
-				const prev = points[(i - 1 + points.length) % points.length]!;
-				const curr = points[i]!;
-				const next = points[(i + 1) % points.length]!;
-
-				const ang = angleBetween(prev.x, prev.y, curr.x, curr.y, next.x, next.y);
-				if (ang < ACUTE_ANGLE_THRESHOLD_RAD) {
-					const mx = (prev.x + next.x) / 2;
-					const my = (prev.y + next.y) / 2;
-					const ddx = mx - blob.cx;
-					const ddy = my - blob.cy;
-					const dist = Math.sqrt(ddx * ddx + ddy * ddy);
-					if (dist > 0) {
-						const avgR = (blob.rx + blob.ry) / 2;
-						curr.x = blob.cx + (ddx / dist) * avgR;
-						curr.y = blob.cy + (ddy / dist) * avgR;
-						changed = true;
-					}
-				}
-			}
-		}
-	}
-
-	return points;
 }
 
 // ---------------------------------------------------------------------------
@@ -1175,8 +1285,12 @@ function rollTrunkBranchCandidate(
 		canopyBottom,
 		40,
 	);
-	const widthStart = randomInRange(rng, 7, 12.25) * branchThicknessScale;
-	const widthEnd = randomInRange(rng, 1.75, 5.25) * branchThicknessScale;
+	const widthStart =
+		randomInRange(rng, TRUNK_BRANCH_WIDTH_START_MIN, TRUNK_BRANCH_WIDTH_START_MAX) *
+		branchThicknessScale;
+	const widthEnd =
+		randomInRange(rng, TRUNK_BRANCH_WIDTH_END_MIN, TRUNK_BRANCH_WIDTH_END_MAX) *
+		branchThicknessScale;
 
 	return {
 		x1: startX,


### PR DESCRIPTION
## Description

- New boundary abstraction (`src/lib/trees/boundaries.ts`) with `circle` + `teardrop` shapes. `Blob` gains `boundary` discriminator + `rotationDeg`.
- New tree shapes: **fir** (teardrop top blob + 3 circle bottom row), **maple** (5 blobs in 180° arc with one branch per blob), **willow** (reuses oak radial with shrunk secondary blobs; character comes from pre-existing crooked trunk + thick branches).
- **Oak fix** (REQ-C-18): secondary blobs now distributed in full 360° around the primary blob with enforced `|cx - W/2| >= 0.15*W` min-distance (5 re-roll attempts, then outward clamp).
- **Birch fix** (REQ-C-19): `rx` range doubled to `W*0.12 – W*0.24`.
- Enabled acute-angle canopy smoothing for maple/willow (REQ-C-12); teardrop blobs gated out per-blob to preserve the point (REQ-C-13).
- Unified boundary sampling dispatch through `BOUNDARIES[blob.boundary].sample(...)`; eliminated duplicate circle sampler.
- Extracted named constants: `TRUNK_BRANCH_WIDTH_*`, `WILLOW_NON_PRIMARY_SCALE_FACTOR`, `SHAPES_WITH_ACUTE_SMOOTHING`.

## Resolves

Closes #8

## Testing

- [x] 20 new unit tests for teardrop point-in-shape + rotation + sampling (`boundaries.test.ts`)
- [x] REQ-C-18 oak radial distribution tests
- [x] REQ-C-19 birch rx range tests
- [x] Fir generator tests (multi-seed: teardrop is always topmost at blob[0])
- [x] Maple generator + per-blob branch tests (`it.each([3, 5, 7])` blobCount)
- [x] Willow generator tests
- [x] Integration smoke + determinism for all new shapes at seed 42
- [x] Full suite: `pnpm run test` — 182 tests passed (up from 118)
- [x] E2E: `pnpm run test:e2e` — 8 tests passed
- [x] `pnpm run check:all` — green