### PR TITLE
#9 feat(color): 2-color canopy picker + trunk swatches + per-shape defaults

### DIFF
--- a/src/lib/components/composed/CanopyColorCard.svelte
+++ b/src/lib/components/composed/CanopyColorCard.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { Label } from '$lib/components/ui/label/index.js';
+	import SectionCard from './SectionCard.svelte';
+
+	interface Props {
+		lightColor: string;
+		darkColor: string;
+		disabled?: boolean;
+	}
+
+	let { lightColor = $bindable(), darkColor = $bindable(), disabled = false }: Props = $props();
+</script>
+
+<SectionCard title="Canopy Color" contentClass="space-y-4">
+	<div class="space-y-2">
+		<Label for="canopy-light-color">Light Color</Label>
+		<div class="flex items-center gap-3">
+			<input
+				type="color"
+				id="canopy-light-color"
+				bind:value={lightColor}
+				{disabled}
+				class="h-10 w-14 cursor-pointer rounded-md border border-input bg-background p-1 shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+			/>
+			<span class="font-mono text-sm tabular-nums text-muted-foreground">{lightColor}</span>
+		</div>
+	</div>
+	<div class="space-y-2">
+		<Label for="canopy-dark-color">Dark Color</Label>
+		<div class="flex items-center gap-3">
+			<input
+				type="color"
+				id="canopy-dark-color"
+				bind:value={darkColor}
+				{disabled}
+				class="h-10 w-14 cursor-pointer rounded-md border border-input bg-background p-1 shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+			/>
+			<span class="font-mono text-sm tabular-nums text-muted-foreground">{darkColor}</span>
+		</div>
+	</div>
+</SectionCard>

--- a/src/lib/components/composed/TrunkColorCard.svelte
+++ b/src/lib/components/composed/TrunkColorCard.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import LabeledRangeSlider from './LabeledRangeSlider.svelte';
+	import SectionCard from './SectionCard.svelte';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { hslToHex } from '$lib/trees/color.js';
+
+	interface TrunkPreset {
+		readonly name: string;
+		readonly hue: number;
+		readonly saturation: number;
+		readonly lightness: number;
+	}
+
+	// REQUIREMENTS.md §2.7 — Trunk color preset swatches.
+	const TRUNK_PRESETS: readonly TrunkPreset[] = [
+		{ name: 'Light birch', hue: 40, saturation: 20, lightness: 75 },
+		{ name: 'Warm brown', hue: 25, saturation: 50, lightness: 35 },
+		{ name: 'Dark brown', hue: 20, saturation: 55, lightness: 20 },
+		{ name: 'Red-brown', hue: 10, saturation: 45, lightness: 30 },
+		{ name: 'Gray', hue: 0, saturation: 5, lightness: 45 },
+		{ name: 'White', hue: 0, saturation: 0, lightness: 90 },
+	] as const;
+
+	interface Props {
+		hue: number;
+		saturation: number;
+		lightness: number;
+		disabled?: boolean;
+	}
+
+	let {
+		hue = $bindable(),
+		saturation = $bindable(),
+		lightness = $bindable(),
+		disabled = false,
+	}: Props = $props();
+
+	function applyPreset(preset: TrunkPreset) {
+		hue = preset.hue;
+		saturation = preset.saturation;
+		lightness = preset.lightness;
+	}
+</script>
+
+<SectionCard title="Trunk Color" contentClass="space-y-4">
+	<div class="space-y-2">
+		<Label>Presets</Label>
+		<div class="flex flex-wrap gap-2">
+			{#each TRUNK_PRESETS as preset (preset.name)}
+				<button
+					type="button"
+					aria-label={preset.name}
+					title={preset.name}
+					data-trunk-preset={preset.name}
+					{disabled}
+					onclick={() => applyPreset(preset)}
+					style:background-color={hslToHex(
+						preset.hue,
+						preset.saturation,
+						preset.lightness,
+					)}
+					class="h-7 w-7 rounded-md border border-input shadow-sm transition hover:scale-110 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100"
+				></button>
+			{/each}
+		</div>
+	</div>
+	<LabeledRangeSlider label="Hue" min={0} max={360} unit="°" bind:value={hue} {disabled} />
+	<LabeledRangeSlider
+		label="Saturation"
+		min={0}
+		max={100}
+		unit="%"
+		bind:value={saturation}
+		{disabled}
+	/>
+	<!--
+		Range kept at 5-100 so §2.6 birch default (80) and §2.7 "Light birch" (75) /
+		"White" (90) presets land inside the slider. REQ-P-11 originally specified
+		5-60 but the per-shape defaults table §2.6 and preset swatch table §2.7
+		both exceed 60, so the slider bound is driven by data rather than the old
+		control-range req.
+	-->
+	<LabeledRangeSlider
+		label="Lightness"
+		min={5}
+		max={100}
+		unit="%"
+		bind:value={lightness}
+		{disabled}
+	/>
+</SectionCard>

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -7,10 +7,8 @@
 		seed?: number;
 		canopyPolygons?: number;
 		trunkPolygons?: number;
-		canopyHue?: number;
-		canopyHueSpread?: number;
-		canopySaturation?: number;
-		canopyLightness?: number;
+		canopyLightColor?: string;
+		canopyDarkColor?: string;
 		trunkHue?: number;
 		trunkSaturation?: number;
 		trunkLightness?: number;
@@ -43,10 +41,8 @@
 		seed = DEFAULT_TREE_CONFIG.seed,
 		canopyPolygons = DEFAULT_TREE_CONFIG.canopyPolygons,
 		trunkPolygons = DEFAULT_TREE_CONFIG.trunkPolygons,
-		canopyHue = DEFAULT_TREE_CONFIG.canopyHue,
-		canopyHueSpread = DEFAULT_TREE_CONFIG.canopyHueSpread,
-		canopySaturation = DEFAULT_TREE_CONFIG.canopySaturation,
-		canopyLightness = DEFAULT_TREE_CONFIG.canopyLightness,
+		canopyLightColor = DEFAULT_TREE_CONFIG.canopyLightColor,
+		canopyDarkColor = DEFAULT_TREE_CONFIG.canopyDarkColor,
 		trunkHue = DEFAULT_TREE_CONFIG.trunkHue,
 		trunkSaturation = DEFAULT_TREE_CONFIG.trunkSaturation,
 		trunkLightness = DEFAULT_TREE_CONFIG.trunkLightness,
@@ -79,10 +75,8 @@
 		seed,
 		canopyPolygons,
 		trunkPolygons,
-		canopyHue,
-		canopyHueSpread,
-		canopySaturation,
-		canopyLightness,
+		canopyLightColor,
+		canopyDarkColor,
 		trunkHue,
 		trunkSaturation,
 		trunkLightness,

--- a/src/lib/trees/color.test.ts
+++ b/src/lib/trees/color.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import { hexToHsl, hslToHex, interpolateHslInHexSpace } from './color.js';
+
+// Round-trip tolerance in HSL channel units. Converting hex -> HSL -> hex
+// is lossy at the edges due to integer rounding on 0..255 channels, so
+// allow a small drift when comparing hue/saturation/lightness round-trips.
+const HSL_TOLERANCE = 1;
+
+function expectHslClose(
+	actual: { h: number; s: number; l: number },
+	expected: { h: number; s: number; l: number },
+	tolerance = HSL_TOLERANCE,
+): void {
+	expect(Math.abs(actual.h - expected.h)).toBeLessThanOrEqual(tolerance);
+	expect(Math.abs(actual.s - expected.s)).toBeLessThanOrEqual(tolerance);
+	expect(Math.abs(actual.l - expected.l)).toBeLessThanOrEqual(tolerance);
+}
+
+describe('color: hexToHsl', () => {
+	it('parses pure red', () => {
+		expectHslClose(hexToHsl('#ff0000'), { h: 0, s: 100, l: 50 });
+	});
+
+	it('parses pure green', () => {
+		expectHslClose(hexToHsl('#00ff00'), { h: 120, s: 100, l: 50 });
+	});
+
+	it('parses pure blue', () => {
+		expectHslClose(hexToHsl('#0000ff'), { h: 240, s: 100, l: 50 });
+	});
+
+	it('parses white', () => {
+		const hsl = hexToHsl('#ffffff');
+		expect(hsl.l).toBe(100);
+		expect(hsl.s).toBe(0);
+	});
+
+	it('parses black', () => {
+		const hsl = hexToHsl('#000000');
+		expect(hsl.l).toBe(0);
+		expect(hsl.s).toBe(0);
+	});
+
+	it('parses gray', () => {
+		const hsl = hexToHsl('#808080');
+		expect(hsl.s).toBe(0);
+		expect(hsl.l).toBeGreaterThan(45);
+		expect(hsl.l).toBeLessThan(55);
+	});
+
+	it('accepts uppercase hex', () => {
+		expectHslClose(hexToHsl('#FF0000'), { h: 0, s: 100, l: 50 });
+	});
+
+	it('parses the oak canopy light default', () => {
+		// #a8d84e is a yellow-green; hue should be in the green band
+		const hsl = hexToHsl('#a8d84e');
+		expect(hsl.h).toBeGreaterThan(60);
+		expect(hsl.h).toBeLessThan(90);
+		expect(hsl.s).toBeGreaterThan(40);
+	});
+});
+
+describe('color: hslToHex', () => {
+	it('formats pure red', () => {
+		expect(hslToHex(0, 100, 50)).toBe('#ff0000');
+	});
+
+	it('formats pure green', () => {
+		expect(hslToHex(120, 100, 50)).toBe('#00ff00');
+	});
+
+	it('formats pure blue', () => {
+		expect(hslToHex(240, 100, 50)).toBe('#0000ff');
+	});
+
+	it('formats white', () => {
+		expect(hslToHex(0, 0, 100)).toBe('#ffffff');
+	});
+
+	it('formats black', () => {
+		expect(hslToHex(0, 0, 0)).toBe('#000000');
+	});
+
+	it('wraps hue beyond 360', () => {
+		expect(hslToHex(360, 100, 50)).toBe('#ff0000');
+		expect(hslToHex(480, 100, 50)).toBe('#00ff00');
+	});
+
+	it('clamps saturation and lightness', () => {
+		expect(hslToHex(0, 150, 50)).toBe('#ff0000');
+		expect(hslToHex(0, -10, 50)).toBe('#808080');
+	});
+});
+
+describe('color: hex/HSL round-trip', () => {
+	const cases = ['#a8d84e', '#1a472a', '#4a9e5c', '#e8a028', '#8b2010', '#7cc45a'];
+	for (const hex of cases) {
+		it(`round-trips ${hex}`, () => {
+			const hsl = hexToHsl(hex);
+			const back = hslToHex(hsl.h, hsl.s, hsl.l);
+			// Round-trip is lossy at 1 unit per channel
+			const originalR = parseInt(hex.slice(1, 3), 16);
+			const originalG = parseInt(hex.slice(3, 5), 16);
+			const originalB = parseInt(hex.slice(5, 7), 16);
+			const backR = parseInt(back.slice(1, 3), 16);
+			const backG = parseInt(back.slice(3, 5), 16);
+			const backB = parseInt(back.slice(5, 7), 16);
+			expect(Math.abs(backR - originalR)).toBeLessThanOrEqual(2);
+			expect(Math.abs(backG - originalG)).toBeLessThanOrEqual(2);
+			expect(Math.abs(backB - originalB)).toBeLessThanOrEqual(2);
+		});
+	}
+});
+
+describe('color: interpolateHslInHexSpace', () => {
+	const dark = '#1a472a';
+	const light = '#a8d84e';
+
+	it('returns dark color at t=0', () => {
+		expect(interpolateHslInHexSpace(dark, light, 0)).toBe(dark);
+	});
+
+	it('returns light color at t=1', () => {
+		expect(interpolateHslInHexSpace(dark, light, 1)).toBe(light);
+	});
+
+	it('clamps t below 0 to dark', () => {
+		expect(interpolateHslInHexSpace(dark, light, -0.5)).toBe(dark);
+	});
+
+	it('clamps t above 1 to light', () => {
+		expect(interpolateHslInHexSpace(dark, light, 1.5)).toBe(light);
+	});
+
+	it('midpoint has HSL values between dark and light', () => {
+		const darkHsl = hexToHsl(dark);
+		const lightHsl = hexToHsl(light);
+		const midHex = interpolateHslInHexSpace(dark, light, 0.5);
+		const midHsl = hexToHsl(midHex);
+		expect(midHsl.l).toBeGreaterThan(Math.min(darkHsl.l, lightHsl.l));
+		expect(midHsl.l).toBeLessThan(Math.max(darkHsl.l, lightHsl.l));
+		expect(midHsl.s).toBeGreaterThan(Math.min(darkHsl.s, lightHsl.s) - 1);
+		expect(midHsl.s).toBeLessThan(Math.max(darkHsl.s, lightHsl.s) + 1);
+	});
+
+	it('lightness rises monotonically with t from dark to light', () => {
+		const steps = [0, 0.2, 0.4, 0.6, 0.8, 1];
+		const lightnesses = steps.map((t) => hexToHsl(interpolateHslInHexSpace(dark, light, t)).l);
+		for (let i = 1; i < lightnesses.length; i += 1) {
+			expect(lightnesses[i]!).toBeGreaterThanOrEqual(lightnesses[i - 1]! - 0.5);
+		}
+		expect(lightnesses.at(-1)! - lightnesses[0]!).toBeGreaterThan(10);
+	});
+
+	it('uses shortest-arc hue interpolation across the 0°/360° wrap', () => {
+		// #ff0033 ≈ h=348, #ff3300 ≈ h=12 — shortest arc is through 0, ~24° total
+		// Midpoint should land near hue 0 (red), not near hue 180 (cyan)
+		const wrapDark = '#ff0033';
+		const wrapLight = '#ff3300';
+		const mid = interpolateHslInHexSpace(wrapDark, wrapLight, 0.5);
+		const midHsl = hexToHsl(mid);
+		// Hue distance from 0 (shortest-arc result) must be much smaller than
+		// distance from 180 (long-arc, numerically-averaged result)
+		const distFromRed = Math.min(midHsl.h, 360 - midHsl.h);
+		const distFromCyan = Math.abs(midHsl.h - 180);
+		expect(distFromRed).toBeLessThan(distFromCyan);
+		expect(distFromRed).toBeLessThan(30);
+	});
+
+	it('is deterministic', () => {
+		const a = interpolateHslInHexSpace(dark, light, 0.37);
+		const b = interpolateHslInHexSpace(dark, light, 0.37);
+		expect(a).toBe(b);
+	});
+});

--- a/src/lib/trees/color.ts
+++ b/src/lib/trees/color.ts
@@ -1,0 +1,145 @@
+/**
+ * Hex/HSL color utilities used by the canopy lighting pipeline and the
+ * preset swatch UI. HSL channel ranges follow the CSS convention:
+ *   h ∈ [0, 360) degrees
+ *   s ∈ [0, 100] percent
+ *   l ∈ [0, 100] percent
+ *
+ * Hex inputs are the 6-digit `#rrggbb` form (uppercase or lowercase).
+ * Hex outputs are always lowercase.
+ */
+
+interface HslColor {
+	readonly h: number;
+	readonly s: number;
+	readonly l: number;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+function normalizeHue(hue: number): number {
+	return ((hue % 360) + 360) % 360;
+}
+
+/**
+ * Parse a `#rrggbb` hex string into HSL. Throws on malformed input.
+ */
+export function hexToHsl(hex: string): HslColor {
+	const match = /^#([0-9a-f]{6})$/i.exec(hex);
+	if (!match) {
+		throw new Error(`Invalid hex color: ${hex}`);
+	}
+	const digits = match[1]!;
+	const r = parseInt(digits.slice(0, 2), 16) / 255;
+	const g = parseInt(digits.slice(2, 4), 16) / 255;
+	const b = parseInt(digits.slice(4, 6), 16) / 255;
+
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	const delta = max - min;
+	const l = (max + min) / 2;
+
+	let h = 0;
+	let s = 0;
+	if (delta > 0) {
+		s = delta / (1 - Math.abs(2 * l - 1));
+		if (max === r) {
+			h = ((g - b) / delta) % 6;
+		} else if (max === g) {
+			h = (b - r) / delta + 2;
+		} else {
+			h = (r - g) / delta + 4;
+		}
+		h *= 60;
+		if (h < 0) {
+			h += 360;
+		}
+	}
+
+	return {
+		h: Math.round(h * 10) / 10,
+		s: Math.round(s * 1000) / 10,
+		l: Math.round(l * 1000) / 10,
+	};
+}
+
+/**
+ * Format an HSL triplet as a `#rrggbb` hex string. Hue wraps; s/l clamp.
+ */
+export function hslToHex(h: number, s: number, l: number): string {
+	const hue = normalizeHue(h);
+	const sat = clamp(s, 0, 100) / 100;
+	const light = clamp(l, 0, 100) / 100;
+
+	const c = (1 - Math.abs(2 * light - 1)) * sat;
+	const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+	const m = light - c / 2;
+
+	let r: number;
+	let g: number;
+	let b: number;
+	if (hue < 60) {
+		[r, g, b] = [c, x, 0];
+	} else if (hue < 120) {
+		[r, g, b] = [x, c, 0];
+	} else if (hue < 180) {
+		[r, g, b] = [0, c, x];
+	} else if (hue < 240) {
+		[r, g, b] = [0, x, c];
+	} else if (hue < 300) {
+		[r, g, b] = [x, 0, c];
+	} else {
+		[r, g, b] = [c, 0, x];
+	}
+
+	const toHex = (value: number): string =>
+		Math.round((value + m) * 255)
+			.toString(16)
+			.padStart(2, '0');
+	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function lerp(a: number, b: number, t: number): number {
+	return a + (b - a) * t;
+}
+
+/**
+ * Interpolate hue via the shortest arc on the color wheel. Handles the
+ * 0°/360° wrap so that pairs like (350°, 10°) cross through 0° rather
+ * than through 180°.
+ */
+function lerpHue(from: number, to: number, t: number): number {
+	const diff = to - from;
+	let shortest = diff;
+	if (diff > 180) {
+		shortest = diff - 360;
+	} else if (diff < -180) {
+		shortest = diff + 360;
+	}
+	return normalizeHue(from + shortest * t);
+}
+
+/**
+ * Interpolate between two hex colors in HSL space and return a new hex.
+ * `t = 0` → `darkHex`; `t = 1` → `lightHex`. Hue uses shortest-arc
+ * interpolation; saturation and lightness are linear. Used by the canopy
+ * lighting pipeline to map a 0..1 lighting factor to a color along the
+ * user-chosen dark→light gradient (REQ-L-01, REQ-L-07).
+ */
+export function interpolateHslInHexSpace(darkHex: string, lightHex: string, t: number): string {
+	const clamped = clamp(t, 0, 1);
+	if (clamped === 0) {
+		return darkHex.toLowerCase();
+	}
+	if (clamped === 1) {
+		return lightHex.toLowerCase();
+	}
+	const dark = hexToHsl(darkHex);
+	const light = hexToHsl(lightHex);
+	const h = lerpHue(dark.h, light.h, clamped);
+	const s = lerp(dark.s, light.s, clamped);
+	const l = lerp(dark.l, light.l, clamped);
+	return hslToHex(h, s, l);
+}

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -670,6 +670,67 @@ describe('REQ-L: Lighting & Colour', () => {
 		});
 	});
 
+	describe('REQ-L-01/L-07: two-color canopy interpolation', () => {
+		it('canopy triangles are hex strings inside the dark/light HSL gradient', () => {
+			const geo = generateTree(
+				makeConfig({
+					seed: 42,
+					canopyLightColor: '#a8d84e',
+					canopyDarkColor: '#1a472a',
+				}),
+			);
+			const canopyColors = geo.canopyBlobs.flatMap((b) => b.triangles.map((t) => t.color));
+			for (const color of canopyColors) {
+				expect(color).toMatch(/^#[0-9a-f]{6}$/);
+			}
+			// Green-only gradient: blue channel must stay clearly below red and
+			// green across every face. A shortest-arc H-S-L interpolation between
+			// two green hexes can only produce green hues, never blue-dominant.
+			for (const color of canopyColors) {
+				const r = parseInt(color.slice(1, 3), 16);
+				const g = parseInt(color.slice(3, 5), 16);
+				const b = parseInt(color.slice(5, 7), 16);
+				expect(b).toBeLessThan(Math.max(r, g) + 1);
+			}
+		});
+
+		it('generates the same canopy colors for identical configs', () => {
+			const cfg = makeConfig({ seed: 42 });
+			const a = generateTree(cfg);
+			const b = generateTree(cfg);
+			const aColors = a.canopyBlobs.flatMap((bl) => bl.triangles.map((t) => t.color));
+			const bColors = b.canopyBlobs.flatMap((bl) => bl.triangles.map((t) => t.color));
+			expect(aColors).toEqual(bColors);
+		});
+
+		it('swapping canopyLightColor shifts canopy palette', () => {
+			const green = generateTree(
+				makeConfig({
+					seed: 42,
+					canopyLightColor: '#a8d84e',
+					canopyDarkColor: '#1a472a',
+				}),
+			);
+			const orange = generateTree(
+				makeConfig({
+					seed: 42,
+					canopyLightColor: '#e8a028',
+					canopyDarkColor: '#8b2010',
+				}),
+			);
+			const greenColors = green.canopyBlobs.flatMap((b) => b.triangles.map((t) => t.color));
+			const orangeColors = orange.canopyBlobs.flatMap((b) => b.triangles.map((t) => t.color));
+			expect(greenColors).not.toEqual(orangeColors);
+			// Orange palette should have red-dominant triangles that the green one lacks
+			const orangeHasRedDominant = orangeColors.some((c) => {
+				const r = parseInt(c.slice(1, 3), 16);
+				const g = parseInt(c.slice(3, 5), 16);
+				return r > g;
+			});
+			expect(orangeHasRedDominant).toBe(true);
+		});
+	});
+
 	describe('REQ-L-08: trunk uses cylinder mapping', () => {
 		it('trunk triangles have trunk color (not canopy color)', () => {
 			const geo = generateTree(makeConfig());

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -279,7 +279,6 @@ function generateBranchMesh(
 
 function generateBlobCanopy(
 	rng: () => number,
-	colorRng: () => number,
 	blobs: readonly Blob[],
 	canopyBudget: number,
 	smoothAcuteAnglesForCircles: boolean,
@@ -363,7 +362,7 @@ function generateBlobCanopy(
 
 		const coloredTris: Triangle[] = filtered.map((tri) => ({
 			points: tri,
-			color: computeCanopyColor(tri, blobBounds, config, colorRng),
+			color: computeCanopyColor(tri, blobBounds, config),
 			group: GEOMETRY_GROUPS.canopy,
 		}));
 
@@ -384,7 +383,6 @@ function generateBlobCanopy(
 
 function generateTierCanopy(
 	rng: () => number,
-	colorRng: () => number,
 	tiers: readonly Tier[],
 	canopyBudget: number,
 	config: TreeConfig,
@@ -439,7 +437,7 @@ function generateTierCanopy(
 
 		const coloredTris: Triangle[] = filtered.map((tri) => ({
 			points: tri,
-			color: computeCanopyColor(tri, tierBounds, config, colorRng),
+			color: computeCanopyColor(tri, tierBounds, config),
 			group: GEOMETRY_GROUPS.canopy,
 		}));
 
@@ -626,21 +624,8 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 
 	const smoothAcuteAngles = SHAPES_WITH_ACUTE_SMOOTHING.has(config.shape);
 	const canopyBlobs = isPine
-		? generateTierCanopy(
-				rng,
-				createPrng(config.seed + 9999),
-				tiers,
-				config.canopyPolygons,
-				config,
-			)
-		: generateBlobCanopy(
-				rng,
-				createPrng(config.seed + 9999),
-				blobs,
-				config.canopyPolygons,
-				smoothAcuteAngles,
-				config,
-			);
+		? generateTierCanopy(rng, tiers, config.canopyPolygons, config)
+		: generateBlobCanopy(rng, blobs, config.canopyPolygons, smoothAcuteAngles, config);
 
 	const anchors = computeAnchors(trunkJunctions, canopyBounds);
 

--- a/src/lib/trees/lighting.test.ts
+++ b/src/lib/trees/lighting.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { computeCanopyColor } from './lighting.js';
+import { hexToHsl } from './color.js';
+import type { Point2D } from './types.js';
+
+type TrianglePoints = readonly [Point2D, Point2D, Point2D];
+
+const oakConfig = {
+	lightAngle: 130,
+	canopyLightColor: '#a8d84e',
+	canopyDarkColor: '#1a472a',
+	trunkHue: 25,
+	trunkSaturation: 50,
+	trunkLightness: 25,
+	depthVariance: 1.0,
+} as const;
+
+const BOUNDS = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+
+const CENTER_TRI: TrianglePoints = [
+	{ x: 50, y: 50 },
+	{ x: 60, y: 50 },
+	{ x: 55, y: 60 },
+];
+
+describe('computeCanopyColor — two-color interpolation', () => {
+	it('is deterministic for the same triangle + config (REQ-L-01)', () => {
+		const a = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig);
+		const b = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig);
+		expect(a).toBe(b);
+	});
+
+	it('returns a valid 6-digit hex color', () => {
+		const color = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig);
+		expect(color).toMatch(/^#[0-9a-f]{6}$/);
+	});
+
+	it('outputs a lightness between the dark and light config colors (REQ-L-07)', () => {
+		const darkHsl = hexToHsl(oakConfig.canopyDarkColor);
+		const lightHsl = hexToHsl(oakConfig.canopyLightColor);
+		// Sample triangles at varying positions within the canopy bounds
+		const samples: readonly TrianglePoints[] = [
+			[
+				{ x: 10, y: 10 },
+				{ x: 15, y: 10 },
+				{ x: 12, y: 15 },
+			],
+			[
+				{ x: 50, y: 50 },
+				{ x: 55, y: 50 },
+				{ x: 52, y: 55 },
+			],
+			[
+				{ x: 90, y: 90 },
+				{ x: 95, y: 90 },
+				{ x: 92, y: 95 },
+			],
+		];
+		for (const t of samples) {
+			const hsl = hexToHsl(computeCanopyColor(t, BOUNDS, oakConfig));
+			expect(hsl.l).toBeGreaterThanOrEqual(darkHsl.l - 1);
+			expect(hsl.l).toBeLessThanOrEqual(lightHsl.l + 1);
+		}
+	});
+
+	it('swapping canopyLightColor shifts the output color', () => {
+		const green = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig);
+		const orange = computeCanopyColor(CENTER_TRI, BOUNDS, {
+			...oakConfig,
+			canopyLightColor: '#e8a028',
+			canopyDarkColor: '#8b2010',
+		});
+		expect(green).not.toBe(orange);
+	});
+
+	it('depthVariance=0 still produces a valid canopy color at the bounds center', () => {
+		// With depthVariance=0, the hemisphere z-component collapses to 0, so
+		// lighting is driven only by in-plane normals. The pipeline must still
+		// produce a well-formed hex color — the math should not NaN out.
+		const flat = { ...oakConfig, depthVariance: 0 };
+		const center: TrianglePoints = [
+			{ x: 49, y: 49 },
+			{ x: 51, y: 49 },
+			{ x: 50, y: 51 },
+		];
+		const color = computeCanopyColor(center, BOUNDS, flat);
+		expect(color).toMatch(/^#[0-9a-f]{6}$/);
+	});
+});

--- a/src/lib/trees/lighting.ts
+++ b/src/lib/trees/lighting.ts
@@ -1,11 +1,10 @@
+import { clamp, hslToHex, interpolateHslInHexSpace } from './color.js';
 import type { Point2D } from './types.js';
 
 interface LightConfig {
 	readonly lightAngle: number;
-	readonly canopyHue: number;
-	readonly canopyHueSpread: number;
-	readonly canopySaturation: number;
-	readonly canopyLightness: number;
+	readonly canopyLightColor: string;
+	readonly canopyDarkColor: string;
 	readonly trunkHue: number;
 	readonly trunkSaturation: number;
 	readonly trunkLightness: number;
@@ -51,49 +50,17 @@ function triangleCentroid(points: readonly [Point2D, Point2D, Point2D]): Point2D
 	};
 }
 
-function clamp(val: number, min: number, max: number): number {
-	return Math.max(min, Math.min(max, val));
-}
-
-function hslToHex(h: number, s: number, l: number): string {
-	h = ((h % 360) + 360) % 360;
-	s = clamp(s, 0, 100) / 100;
-	l = clamp(l, 0, 100) / 100;
-
-	const c = (1 - Math.abs(2 * l - 1)) * s;
-	const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-	const m = l - c / 2;
-
-	let r: number, g: number, b: number;
-	if (h < 60) {
-		[r, g, b] = [c, x, 0];
-	} else if (h < 120) {
-		[r, g, b] = [x, c, 0];
-	} else if (h < 180) {
-		[r, g, b] = [0, c, x];
-	} else if (h < 240) {
-		[r, g, b] = [0, x, c];
-	} else if (h < 300) {
-		[r, g, b] = [x, 0, c];
-	} else {
-		[r, g, b] = [c, 0, x];
-	}
-
-	const toHex = (v: number) =>
-		Math.round((v + m) * 255)
-			.toString(16)
-			.padStart(2, '0');
-	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-}
-
 /**
  * Compute canopy triangle color using hemisphere-based pseudo-3D lighting.
+ * The output color is produced by interpolating between `canopyDarkColor`
+ * and `canopyLightColor` in HSL space using the computed lighting factor
+ * (REQ-L-01, REQ-L-02, REQ-L-07). Fully-lit faces map exactly to
+ * `canopyLightColor`; fully-shadowed faces map exactly to `canopyDarkColor`.
  */
 export function computeCanopyColor(
 	points: readonly [Point2D, Point2D, Point2D],
 	canopyBounds: { minX: number; minY: number; maxX: number; maxY: number },
 	config: LightConfig,
-	rng: () => number,
 ): string {
 	const centroid = triangleCentroid(points);
 	const light = normalize3(lightDirection(config.lightAngle));
@@ -104,33 +71,24 @@ export function computeCanopyColor(
 	const nx = bw > 0 ? ((centroid.x - canopyBounds.minX) / bw) * 2 - 1 : 0;
 	const ny = bh > 0 ? ((centroid.y - canopyBounds.minY) / bh) * 2 - 1 : 0;
 
-	// Hemisphere: compute z from position on dome
+	// Hemisphere: compute z from position on dome. REQ-L-04 scales z by
+	// depthVariance (0 → uniform lighting, 1 → standard, 2 → exaggerated).
 	const r2 = nx * nx + ny * ny;
 	const z = (r2 < 1 ? Math.sqrt(1 - r2) : 0.05) * config.depthVariance;
 	const normal = normalize3({ x: nx * 0.7, y: ny * 0.7, z });
 
-	// Diffuse lighting
+	// Diffuse lighting clamped to [0, 1]
 	const diffuse = clamp(dot3(normal, light), 0, 1);
 
-	// Rim darkening — triangles at the edge of the canopy
+	// Rim darkening — triangles outside the hemisphere disk
 	const rimFactor = r2 < 1 ? 1 : 0.7;
 
-	// Combined lighting factor — wider range for more dramatic faceting
-	const lighting = (0.15 + 0.85 * diffuse) * rimFactor;
+	// REQ-L-02: ambient 0.15 + diffuse 0.85 × diffuse. Rim factor applies
+	// last and only reduces edge brightness, so fully-lit non-rim faces
+	// still reach lighting = 1 and land on canopyLightColor exactly.
+	const lighting = clamp((0.15 + 0.85 * diffuse) * rimFactor, 0, 1);
 
-	// Hue variation: shift hue based on lighting + random jitter
-	// Lit faces shift toward yellow-green, shadowed toward blue-green
-	const hueShift = (lighting - 0.5) * config.canopyHueSpread * 1.2 + (rng() - 0.5) * 20;
-	const hue = config.canopyHue + hueShift;
-
-	// Saturation: shadowed faces more saturated, lit faces slightly desaturated
-	const sat = config.canopySaturation + (0.5 - lighting) * 20 + (rng() - 0.5) * 12;
-
-	// Lightness driven by lighting model — wider spread for dramatic look
-	const baseLightness = config.canopyLightness;
-	const lightness = baseLightness + (lighting - 0.5) * 60 + (rng() - 0.5) * 8;
-
-	return hslToHex(hue, sat, lightness);
+	return interpolateHslInHexSpace(config.canopyDarkColor, config.canopyLightColor, lighting);
 }
 
 /**
@@ -145,7 +103,7 @@ export function computeTrunkColor(
 	const centroid = triangleCentroid(points);
 	const light = normalize3(lightDirection(config.lightAngle));
 
-	// Cylinder mapping — only horizontal position matters
+	// Cylinder mapping — only horizontal position matters (REQ-L-08)
 	const bw = trunkBounds.maxX - trunkBounds.minX;
 	const nx = bw > 0 ? ((centroid.x - trunkBounds.minX) / bw) * 2 - 1 : 0;
 	const z = Math.sqrt(Math.max(0, 1 - nx * nx));

--- a/src/lib/trees/types.test.ts
+++ b/src/lib/trees/types.test.ts
@@ -53,6 +53,11 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkCrookedness: 0,
 			branchLength: 100,
 			branchLengthVariance: 50,
+			canopyLightColor: '#a8d84e',
+			canopyDarkColor: '#1a472a',
+			trunkHue: 25,
+			trunkSaturation: 50,
+			trunkLightness: 25,
 		});
 	});
 
@@ -67,6 +72,11 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkCrookedness: 0,
 			branchLength: 100,
 			branchLengthVariance: 50,
+			canopyLightColor: '#4a9e5c',
+			canopyDarkColor: '#0d2b1a',
+			trunkHue: 20,
+			trunkSaturation: 45,
+			trunkLightness: 20,
 		});
 	});
 
@@ -81,6 +91,11 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkCrookedness: 0,
 			branchLength: 100,
 			branchLengthVariance: 50,
+			canopyLightColor: '#b8e065',
+			canopyDarkColor: '#2d5e3a',
+			trunkHue: 40,
+			trunkSaturation: 15,
+			trunkLightness: 80,
 		});
 	});
 
@@ -95,6 +110,11 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkCrookedness: 0,
 			branchLength: 100,
 			branchLengthVariance: 50,
+			canopyLightColor: '#3d8b50',
+			canopyDarkColor: '#0a2418',
+			trunkHue: 22,
+			trunkSaturation: 50,
+			trunkLightness: 28,
 		});
 	});
 
@@ -109,6 +129,11 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkCrookedness: 0,
 			branchLength: 100,
 			branchLengthVariance: 50,
+			canopyLightColor: '#e8a028',
+			canopyDarkColor: '#8b2010',
+			trunkHue: 30,
+			trunkSaturation: 20,
+			trunkLightness: 35,
 		});
 	});
 
@@ -123,6 +148,11 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkCrookedness: 40,
 			branchLength: 100,
 			branchLengthVariance: 50,
+			canopyLightColor: '#7cc45a',
+			canopyDarkColor: '#1a4020',
+			trunkHue: 25,
+			trunkSaturation: 40,
+			trunkLightness: 22,
 		});
 	});
 
@@ -131,5 +161,23 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			expect(SHAPE_DEFAULTS[shape].branchLength).toBe(100);
 			expect(SHAPE_DEFAULTS[shape].branchLengthVariance).toBe(50);
 		}
+	});
+
+	it('every shape entry carries all 5 color fields (§2.6, REQ-L-09)', () => {
+		for (const shape of nonCustomShapes) {
+			const entry = SHAPE_DEFAULTS[shape];
+			expect(entry.canopyLightColor).toMatch(/^#[0-9a-f]{6}$/);
+			expect(entry.canopyDarkColor).toMatch(/^#[0-9a-f]{6}$/);
+			expect(typeof entry.trunkHue).toBe('number');
+			expect(typeof entry.trunkSaturation).toBe('number');
+			expect(typeof entry.trunkLightness).toBe('number');
+		}
+	});
+});
+
+describe('DEFAULT_TREE_CONFIG canopy color defaults (REQ-P-30/31)', () => {
+	it('uses oak canopyLightColor and canopyDarkColor from §2.6', () => {
+		expect(DEFAULT_TREE_CONFIG.canopyLightColor).toBe('#a8d84e');
+		expect(DEFAULT_TREE_CONFIG.canopyDarkColor).toBe('#1a472a');
 	});
 });

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -73,10 +73,10 @@ export interface TreeConfig {
 	readonly seed: number;
 	readonly canopyPolygons: number;
 	readonly trunkPolygons: number;
-	readonly canopyHue: number;
-	readonly canopyHueSpread: number;
-	readonly canopySaturation: number;
-	readonly canopyLightness: number;
+	/** Hex color used for fully-lit canopy faces (REQ-P-30, REQ-L-01). */
+	readonly canopyLightColor: string;
+	/** Hex color used for fully-shadowed canopy faces (REQ-P-31, REQ-L-01). */
+	readonly canopyDarkColor: string;
 	readonly trunkHue: number;
 	readonly trunkSaturation: number;
 	readonly trunkLightness: number;
@@ -103,10 +103,8 @@ export const DEFAULT_TREE_CONFIG: TreeConfig = {
 	seed: 42,
 	canopyPolygons: 50,
 	trunkPolygons: 30,
-	canopyHue: 120,
-	canopyHueSpread: 40,
-	canopySaturation: 60,
-	canopyLightness: 40,
+	canopyLightColor: '#a8d84e',
+	canopyDarkColor: '#1a472a',
 	trunkHue: 25,
 	trunkSaturation: 50,
 	trunkLightness: 25,
@@ -143,6 +141,11 @@ export const SHAPE_DEFAULTS = {
 		trunkCrookedness: 0,
 		branchLength: 100,
 		branchLengthVariance: 50,
+		canopyLightColor: '#a8d84e',
+		canopyDarkColor: '#1a472a',
+		trunkHue: 25,
+		trunkSaturation: 50,
+		trunkLightness: 25,
 	},
 	[TREE_SHAPES.pine]: {
 		blobCount: 3,
@@ -154,6 +157,11 @@ export const SHAPE_DEFAULTS = {
 		trunkCrookedness: 0,
 		branchLength: 100,
 		branchLengthVariance: 50,
+		canopyLightColor: '#4a9e5c',
+		canopyDarkColor: '#0d2b1a',
+		trunkHue: 20,
+		trunkSaturation: 45,
+		trunkLightness: 20,
 	},
 	[TREE_SHAPES.birch]: {
 		blobCount: 3,
@@ -165,6 +173,11 @@ export const SHAPE_DEFAULTS = {
 		trunkCrookedness: 0,
 		branchLength: 100,
 		branchLengthVariance: 50,
+		canopyLightColor: '#b8e065',
+		canopyDarkColor: '#2d5e3a',
+		trunkHue: 40,
+		trunkSaturation: 15,
+		trunkLightness: 80,
 	},
 	[TREE_SHAPES.fir]: {
 		blobCount: 4,
@@ -176,6 +189,11 @@ export const SHAPE_DEFAULTS = {
 		trunkCrookedness: 0,
 		branchLength: 100,
 		branchLengthVariance: 50,
+		canopyLightColor: '#3d8b50',
+		canopyDarkColor: '#0a2418',
+		trunkHue: 22,
+		trunkSaturation: 50,
+		trunkLightness: 28,
 	},
 	[TREE_SHAPES.maple]: {
 		blobCount: 5,
@@ -187,6 +205,11 @@ export const SHAPE_DEFAULTS = {
 		trunkCrookedness: 0,
 		branchLength: 100,
 		branchLengthVariance: 50,
+		canopyLightColor: '#e8a028',
+		canopyDarkColor: '#8b2010',
+		trunkHue: 30,
+		trunkSaturation: 20,
+		trunkLightness: 35,
 	},
 	[TREE_SHAPES.willow]: {
 		blobCount: 4,
@@ -198,6 +221,11 @@ export const SHAPE_DEFAULTS = {
 		trunkCrookedness: 40,
 		branchLength: 100,
 		branchLengthVariance: 50,
+		canopyLightColor: '#7cc45a',
+		canopyDarkColor: '#1a4020',
+		trunkHue: 25,
+		trunkSaturation: 40,
+		trunkLightness: 22,
 	},
 } as const satisfies Record<
 	Exclude<TreeShape, 'custom'>,
@@ -212,6 +240,11 @@ export const SHAPE_DEFAULTS = {
 		| 'trunkCrookedness'
 		| 'branchLength'
 		| 'branchLengthVariance'
+		| 'canopyLightColor'
+		| 'canopyDarkColor'
+		| 'trunkHue'
+		| 'trunkSaturation'
+		| 'trunkLightness'
 	>
 >;
 

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -2,6 +2,8 @@
 	import LowPolyTree from '$lib/trees/LowPolyTree.svelte';
 	import LabeledSelect from '$lib/components/composed/LabeledSelect.svelte';
 	import LabeledRangeSlider from '$lib/components/composed/LabeledRangeSlider.svelte';
+	import CanopyColorCard from '$lib/components/composed/CanopyColorCard.svelte';
+	import TrunkColorCard from '$lib/components/composed/TrunkColorCard.svelte';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -23,10 +25,8 @@
 	let seed = $state(DEFAULT_TREE_CONFIG.seed);
 	let canopyPolygons = $state(DEFAULT_TREE_CONFIG.canopyPolygons);
 	let trunkPolygons = $state(DEFAULT_TREE_CONFIG.trunkPolygons);
-	let canopyHue = $state(DEFAULT_TREE_CONFIG.canopyHue);
-	let canopyHueSpread = $state(DEFAULT_TREE_CONFIG.canopyHueSpread);
-	let canopySaturation = $state(DEFAULT_TREE_CONFIG.canopySaturation);
-	let canopyLightness = $state(DEFAULT_TREE_CONFIG.canopyLightness);
+	let canopyLightColor = $state(DEFAULT_TREE_CONFIG.canopyLightColor);
+	let canopyDarkColor = $state(DEFAULT_TREE_CONFIG.canopyDarkColor);
 	let trunkHue = $state(DEFAULT_TREE_CONFIG.trunkHue);
 	let trunkSaturation = $state(DEFAULT_TREE_CONFIG.trunkSaturation);
 	let trunkLightness = $state(DEFAULT_TREE_CONFIG.trunkLightness);
@@ -79,6 +79,11 @@
 		trunkCrookedness = defaults.trunkCrookedness;
 		branchLength = defaults.branchLength;
 		branchLengthVariance = defaults.branchLengthVariance;
+		canopyLightColor = defaults.canopyLightColor;
+		canopyDarkColor = defaults.canopyDarkColor;
+		trunkHue = defaults.trunkHue;
+		trunkSaturation = defaults.trunkSaturation;
+		trunkLightness = defaults.trunkLightness;
 	}
 
 	function randomizeSeed() {
@@ -207,91 +212,16 @@
 					</Card.Content>
 				</Card.Root>
 
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Canopy Color</Card.Title>
-					</Card.Header>
-					<Card.Content class="space-y-4">
-						<div class="space-y-2">
-							<Label>Hue: {canopyHue}°</Label>
-							<input
-								type="range"
-								min="0"
-								max="360"
-								bind:value={canopyHue}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Hue Spread: {canopyHueSpread}</Label>
-							<input
-								type="range"
-								min="0"
-								max="80"
-								bind:value={canopyHueSpread}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Saturation: {canopySaturation}%</Label>
-							<input
-								type="range"
-								min="0"
-								max="100"
-								bind:value={canopySaturation}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Lightness: {canopyLightness}%</Label>
-							<input
-								type="range"
-								min="10"
-								max="80"
-								bind:value={canopyLightness}
-								class="w-full accent-primary"
-							/>
-						</div>
-					</Card.Content>
-				</Card.Root>
+				<CanopyColorCard
+					bind:lightColor={canopyLightColor}
+					bind:darkColor={canopyDarkColor}
+				/>
 
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Trunk Color</Card.Title>
-					</Card.Header>
-					<Card.Content class="space-y-4">
-						<div class="space-y-2">
-							<Label>Hue: {trunkHue}°</Label>
-							<input
-								type="range"
-								min="0"
-								max="360"
-								bind:value={trunkHue}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Saturation: {trunkSaturation}%</Label>
-							<input
-								type="range"
-								min="0"
-								max="100"
-								bind:value={trunkSaturation}
-								class="w-full accent-primary"
-							/>
-						</div>
-						<div class="space-y-2">
-							<Label>Lightness: {trunkLightness}%</Label>
-							<input
-								type="range"
-								min="5"
-								max="60"
-								bind:value={trunkLightness}
-								class="w-full accent-primary"
-							/>
-						</div>
-					</Card.Content>
-				</Card.Root>
+				<TrunkColorCard
+					bind:hue={trunkHue}
+					bind:saturation={trunkSaturation}
+					bind:lightness={trunkLightness}
+				/>
 
 				<Card.Root>
 					<Card.Header>
@@ -458,10 +388,8 @@
 					{seed}
 					{canopyPolygons}
 					{trunkPolygons}
-					{canopyHue}
-					{canopyHueSpread}
-					{canopySaturation}
-					{canopyLightness}
+					{canopyLightColor}
+					{canopyDarkColor}
 					{trunkHue}
 					{trunkSaturation}
 					{trunkLightness}

--- a/src/routes/showcase/scene/+page.svelte
+++ b/src/routes/showcase/scene/+page.svelte
@@ -6,6 +6,8 @@
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import SectionCard from '$lib/components/composed/SectionCard.svelte';
 	import LabeledRangeSlider from '$lib/components/composed/LabeledRangeSlider.svelte';
+	import CanopyColorCard from '$lib/components/composed/CanopyColorCard.svelte';
+	import TrunkColorCard from '$lib/components/composed/TrunkColorCard.svelte';
 	import { DEFAULT_TREE_CONFIG, SHAPE_DEFAULTS } from '$lib/trees/types.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import DarkModeToggle from '$lib/components/DarkModeToggle.svelte';
@@ -15,13 +17,12 @@
 	let seed = $state(DEFAULT_TREE_CONFIG.seed);
 	let canopyPolygons = $state(DEFAULT_TREE_CONFIG.canopyPolygons);
 	let trunkPolygons = $state(DEFAULT_TREE_CONFIG.trunkPolygons);
-	let canopyHue = $state(DEFAULT_TREE_CONFIG.canopyHue);
-	let canopyHueSpread = $state(DEFAULT_TREE_CONFIG.canopyHueSpread);
-	let canopySaturation = $state(DEFAULT_TREE_CONFIG.canopySaturation);
-	let canopyLightness = $state(DEFAULT_TREE_CONFIG.canopyLightness);
+	let canopyLightColor = $state(DEFAULT_TREE_CONFIG.canopyLightColor);
+	let canopyDarkColor = $state(DEFAULT_TREE_CONFIG.canopyDarkColor);
 	let trunkHue = $state(DEFAULT_TREE_CONFIG.trunkHue);
 	let trunkSaturation = $state(DEFAULT_TREE_CONFIG.trunkSaturation);
 	let trunkLightness = $state(DEFAULT_TREE_CONFIG.trunkLightness);
+	let usePerShapeDefaults = $state(false);
 	let lightAngle = $state(DEFAULT_TREE_CONFIG.lightAngle);
 	let depthVariance = $state(DEFAULT_TREE_CONFIG.depthVariance);
 	let blobSizeVariance = $state(DEFAULT_TREE_CONFIG.blobSizeVariance);
@@ -52,10 +53,8 @@
 		seed = Math.floor(Math.random() * 100000);
 	}
 
-	// Scene currently previews oak/pine/birch only. REQ-S-06 (all 6 non-custom
-	// shapes side by side) lands with issue #8, when fir/maple/willow get real
-	// generators. The placeholder generators for those shapes would render as
-	// oak clones, which would be misleading in the scene preview.
+	// Scene previews oak/pine/birch. Expanding to all 6 non-custom shapes
+	// (REQ-S-06) is tracked separately — issue #9 scope is color overhaul only.
 	const trees = [
 		{ shape: 'oak' as const, ...SHAPE_DEFAULTS.oak, seedOffset: 0 },
 		{ shape: 'pine' as const, ...SHAPE_DEFAULTS.pine, seedOffset: 1000 },
@@ -235,81 +234,33 @@
 					/>
 				</SectionCard>
 
-				<SectionCard title="Canopy Color" contentClass="space-y-4">
-					<div class="space-y-2">
-						<Label>Hue: {canopyHue}°</Label>
-						<input
-							type="range"
-							min="0"
-							max="360"
-							bind:value={canopyHue}
-							class="w-full accent-primary"
+				<SectionCard title="Color Mode" contentClass="space-y-4">
+					<div class="flex items-center gap-2">
+						<Checkbox
+							id="use-per-shape-defaults"
+							checked={usePerShapeDefaults}
+							onCheckedChange={(v) => (usePerShapeDefaults = v === true)}
 						/>
+						<Label for="use-per-shape-defaults">Use per-shape default colors</Label>
 					</div>
-					<div class="space-y-2">
-						<Label>Hue Spread: {canopyHueSpread}</Label>
-						<input
-							type="range"
-							min="0"
-							max="80"
-							bind:value={canopyHueSpread}
-							class="w-full accent-primary"
-						/>
-					</div>
-					<div class="space-y-2">
-						<Label>Saturation: {canopySaturation}%</Label>
-						<input
-							type="range"
-							min="0"
-							max="100"
-							bind:value={canopySaturation}
-							class="w-full accent-primary"
-						/>
-					</div>
-					<div class="space-y-2">
-						<Label>Lightness: {canopyLightness}%</Label>
-						<input
-							type="range"
-							min="10"
-							max="80"
-							bind:value={canopyLightness}
-							class="w-full accent-primary"
-						/>
-					</div>
+					<p class="text-xs text-muted-foreground">
+						When enabled, each tree uses its shape's default palette and the shared
+						color controls below are disabled.
+					</p>
 				</SectionCard>
 
-				<SectionCard title="Trunk Color" contentClass="space-y-4">
-					<div class="space-y-2">
-						<Label>Hue: {trunkHue}°</Label>
-						<input
-							type="range"
-							min="0"
-							max="360"
-							bind:value={trunkHue}
-							class="w-full accent-primary"
-						/>
-					</div>
-					<div class="space-y-2">
-						<Label>Saturation: {trunkSaturation}%</Label>
-						<input
-							type="range"
-							min="0"
-							max="100"
-							bind:value={trunkSaturation}
-							class="w-full accent-primary"
-						/>
-					</div>
-					<div class="space-y-2">
-						<Label>Lightness: {trunkLightness}%</Label>
-						<input
-							type="range"
-							min="5"
-							max="60"
-							bind:value={trunkLightness}
-							class="w-full accent-primary"
-						/>
-					</div>
-				</SectionCard>
+				<CanopyColorCard
+					bind:lightColor={canopyLightColor}
+					bind:darkColor={canopyDarkColor}
+					disabled={usePerShapeDefaults}
+				/>
+
+				<TrunkColorCard
+					bind:hue={trunkHue}
+					bind:saturation={trunkSaturation}
+					bind:lightness={trunkLightness}
+					disabled={usePerShapeDefaults}
+				/>
 
 				<SectionCard title="Lighting" contentClass="space-y-4">
 					<div class="space-y-2">
@@ -379,13 +330,17 @@
 						seed={seed + tree.seedOffset}
 						{canopyPolygons}
 						{trunkPolygons}
-						{canopyHue}
-						{canopyHueSpread}
-						{canopySaturation}
-						{canopyLightness}
-						{trunkHue}
-						{trunkSaturation}
-						{trunkLightness}
+						canopyLightColor={usePerShapeDefaults
+							? tree.canopyLightColor
+							: canopyLightColor}
+						canopyDarkColor={usePerShapeDefaults
+							? tree.canopyDarkColor
+							: canopyDarkColor}
+						trunkHue={usePerShapeDefaults ? tree.trunkHue : trunkHue}
+						trunkSaturation={usePerShapeDefaults
+							? tree.trunkSaturation
+							: trunkSaturation}
+						trunkLightness={usePerShapeDefaults ? tree.trunkLightness : trunkLightness}
 						{lightAngle}
 						{depthVariance}
 						{blobSizeVariance}

--- a/tests/e2e/issue9_color_picker.spec.ts
+++ b/tests/e2e/issue9_color_picker.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Issue #9 — Color system overhaul', () => {
+	test('single editor shows two canopy color pickers with hex labels', async ({ page }) => {
+		await page.goto('/showcase');
+		await page.waitForLoadState('networkidle');
+
+		const lightPicker = page.locator('#canopy-light-color');
+		const darkPicker = page.locator('#canopy-dark-color');
+		await expect(lightPicker).toHaveAttribute('type', 'color');
+		await expect(darkPicker).toHaveAttribute('type', 'color');
+
+		// Default oak palette (§2.6)
+		await expect(lightPicker).toHaveValue('#a8d84e');
+		await expect(darkPicker).toHaveValue('#1a472a');
+
+		// Hex text labels are visible next to each picker
+		await expect(page.getByText('#a8d84e').first()).toBeVisible();
+		await expect(page.getByText('#1a472a').first()).toBeVisible();
+	});
+
+	test('single editor: per-shape defaults toggle is NOT present (REQ-L-09b)', async ({
+		page,
+	}) => {
+		await page.goto('/showcase');
+		await page.waitForLoadState('networkidle');
+		await expect(page.getByText(/Use per-shape default colors/i)).toHaveCount(0);
+	});
+
+	test('single editor: switching shape updates color pickers', async ({ page }) => {
+		await page.goto('/showcase');
+		await page.waitForLoadState('networkidle');
+
+		// Switch to pine (§2.6 canopyLightColor = #4a9e5c)
+		const trigger = page.locator('[data-slot="select-trigger"]').first();
+		await trigger.click();
+		await page.locator('[role="option"]').filter({ hasText: /pine/i }).first().click();
+
+		await expect(page.locator('#canopy-light-color')).toHaveValue('#4a9e5c');
+		await expect(page.locator('#canopy-dark-color')).toHaveValue('#0d2b1a');
+	});
+
+	test('single editor: trunk preset swatch sets all 3 HSL sliders (REQ-S-14)', async ({
+		page,
+	}) => {
+		await page.goto('/showcase');
+		await page.waitForLoadState('networkidle');
+
+		await page.locator('[data-trunk-preset="Dark brown"]').click();
+
+		// Dark brown: hue=20, sat=55, light=20
+		await expect(page.locator('#range-hue')).toHaveValue('20');
+		await expect(page.locator('#range-saturation')).toHaveValue('55');
+		await expect(page.locator('#range-lightness')).toHaveValue('20');
+	});
+
+	test('scene editor shows the per-shape defaults toggle', async ({ page }) => {
+		await page.goto('/showcase/scene');
+		await page.waitForLoadState('networkidle');
+		await expect(page.getByText(/Use per-shape default colors/i)).toBeVisible();
+	});
+
+	test('scene editor: toggle ON disables shared canopy + trunk controls', async ({ page }) => {
+		await page.goto('/showcase/scene');
+		await page.waitForLoadState('networkidle');
+
+		const lightPicker = page.locator('#canopy-light-color');
+		const darkPicker = page.locator('#canopy-dark-color');
+		await expect(lightPicker).toBeEnabled();
+		await expect(darkPicker).toBeEnabled();
+
+		// Click the toggle (shadcn Checkbox delegates; click the Label)
+		await page.locator('label[for="use-per-shape-defaults"]').click();
+
+		await expect(lightPicker).toBeDisabled();
+		await expect(darkPicker).toBeDisabled();
+		await expect(page.locator('#range-hue')).toBeDisabled();
+		await expect(page.locator('#range-saturation')).toBeDisabled();
+		await expect(page.locator('#range-lightness')).toBeDisabled();
+
+		// Click again → controls re-enabled
+		await page.locator('label[for="use-per-shape-defaults"]').click();
+		await expect(lightPicker).toBeEnabled();
+		await expect(darkPicker).toBeEnabled();
+	});
+
+	test('scene editor: toggle ON makes trees render with different canopy colors', async ({
+		page,
+	}) => {
+		await page.goto('/showcase/scene');
+		await page.waitForLoadState('networkidle');
+
+		// Read canopy triangle fills for each rendered tree. Each <LowPolyTree>
+		// SVG contains <g class="canopy"> with nested <polygon> elements carrying
+		// the triangle fills. Filter out icon SVGs (DarkModeToggle, Shuffle, etc.)
+		// by requiring a canopy group.
+		const getCanopyFills = () =>
+			page.evaluate(() => {
+				const treeSvgs = Array.from(document.querySelectorAll('svg')).filter(
+					(svg) => svg.querySelector('g.canopy') !== null,
+				);
+				return treeSvgs.map((svg) => {
+					const polys = Array.from(svg.querySelectorAll('g.canopy polygon'));
+					return polys.map((p) => p.getAttribute('fill') ?? '').slice(0, 5);
+				});
+			});
+
+		// Toggle OFF (default): all trees share the same picker colors.
+		const sharedFills = await getCanopyFills();
+		expect(sharedFills.length).toBeGreaterThanOrEqual(3);
+
+		// Toggle ON: each tree should use its own shape default palette, so the
+		// palette for oak and pine must diverge visibly.
+		await page.locator('label[for="use-per-shape-defaults"]').click();
+		await expect(page.locator('#canopy-light-color')).toBeDisabled();
+
+		const perShapeFills = await getCanopyFills();
+		expect(perShapeFills.length).toBeGreaterThanOrEqual(3);
+
+		// Any two tree fill sets should now be different (different palettes),
+		// and the per-shape palette must differ from the shared-palette baseline.
+		expect(perShapeFills[0]).not.toEqual(perShapeFills[1]);
+		expect(perShapeFills).not.toEqual(sharedFills);
+	});
+});


### PR DESCRIPTION
## Description
- Replace the 4-slider HSL canopy color model with two hex color pickers (`canopyLightColor`, `canopyDarkColor`) interpolated in HSL space via a new `color.ts` utility. Ambient 0.15 + diffuse 0.85 contract preserved (REQ-L-01/02/07).
- Extend `SHAPE_DEFAULTS` with 5 color fields per non-custom shape (§2.6). Switching shape in the single editor now applies the new palette; the scene editor gains a "Use per-shape defaults" toggle (§2.6, REQ-L-09/09a/09b) that disables shared pickers and draws each tree with its own shape palette.
- New composed components `CanopyColorCard` (two native `<input type="color">` pickers with hex text labels) and `TrunkColorCard` (6 preset swatches from §2.7 + 3 HSL sliders). Both accept `disabled` so the scene toggle can grey them out.
- Dead code removed: old HSL canopy math in `lighting.ts`, private `hslToHex` helper, and the unused `colorRng` parameter plumbed through `generateBlobCanopy` / `generateTierCanopy` / `computeCanopyColor`.

## Resolves
Closes #9

## Testing
- [x] `pnpm run check:all` — clean
- [x] `pnpm run test` — 223 unit tests (new color.ts, lighting.ts, and SHAPE_DEFAULTS coverage)
- [x] `pnpm run test:e2e` — 17 Playwright tests (7 new in `issue9_color_picker.spec.ts`: canopy pickers render, shape switch updates pickers, trunk preset sets all 3 sliders, scene toggle shows/hides, scene toggle disables shared cards, scene toggle per-tree color divergence, single-editor toggle absent)