### PR TITLE
#12 feat(app-shell): sidebar nav + tree persistence + gallery

### DIFF
--- a/drizzle/0001_saved_trees.sql
+++ b/drizzle/0001_saved_trees.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "saved_trees" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"config" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "saved_trees" ADD CONSTRAINT "saved_trees_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -95,7 +95,7 @@ export default [
 	},
 	{
 		files: ['src/**/*.ts'],
-		ignores: ['src/routes/**/+*'],
+		ignores: ['src/routes/**/+*', 'src/lib/components/ui/**', 'src/lib/hooks/**'],
 		plugins: { 'check-file': checkFile },
 		rules: {
 			'check-file/filename-naming-convention': [
@@ -111,6 +111,15 @@ export default [
 		plugins: { 'check-file': checkFile },
 		rules: {
 			'check-file/filename-naming-convention': ['error', { '**/*.svelte': 'PASCAL_CASE' }],
+		},
+	},
+	{
+		// Gallery thumbnails link to /showcase with a dynamic ?saved=<id> query string.
+		// `svelte/no-navigation-without-resolve` does not accept query strings appended to
+		// a resolve() call, so we turn it off for this file.
+		files: ['src/routes/gallery/**/*.svelte'],
+		rules: {
+			'svelte/no-navigation-without-resolve': 'off',
 		},
 	},
 ];

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -7,6 +7,7 @@ const config: KnipConfig = {
 		'src/lib/reactivity/*.svelte.ts',
 		'src/lib/context/*.context.svelte.ts',
 		'src/lib/components/ui/*/index.ts',
+		'src/lib/components/ui/*/*.svelte.ts',
 	],
 	project: ['src/**/*.{ts,svelte}'],
 	ignoreDependencies: [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"delaunator": "^5.1.0",
 		"drizzle-orm": "^0.45.1",
 		"mode-watcher": "^1.1.0",
-		"postgres": "^3.4.8"
+		"postgres": "^3.4.8",
+		"valibot": "^1.3.1"
 	},
 	"devDependencies": {
 		"@better-auth/cli": "~1.4.22",
@@ -43,7 +44,7 @@
 		"@fontsource-variable/noto-sans": "^5.2.10",
 		"@inlang/paraglide-js": "^2.15.1",
 		"@internationalized/date": "^3.12.0",
-		"@lucide/svelte": "^1.7.0",
+		"@lucide/svelte": "^1.8.0",
 		"@playwright/test": "^1.58.2",
 		"@storybook/addon-a11y": "^10.3.3",
 		"@storybook/addon-docs": "^10.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       postgres:
         specifier: ^3.4.8
         version: 3.4.9
+      valibot:
+        specifier: ^1.3.1
+        version: 1.3.1(typescript@5.9.3)
     devDependencies:
       '@better-auth/cli':
         specifier: ~1.4.22
@@ -49,7 +52,7 @@ importers:
         specifier: ^3.12.0
         version: 3.12.0
       '@lucide/svelte':
-        specifier: ^1.7.0
+        specifier: ^1.8.0
         version: 1.8.0(svelte@5.55.2)
       '@playwright/test':
         specifier: ^1.58.2
@@ -4692,6 +4695,14 @@ packages:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-plugin-devtools-json@1.0.0:
     resolution: {integrity: sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw==}
     peerDependencies:
@@ -9058,6 +9069,10 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@13.0.0: {}
+
+  valibot@1.3.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   vite-plugin-devtools-json@1.0.0(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:

--- a/src/lib/components/app-shell/AppSidebar.svelte
+++ b/src/lib/components/app-shell/AppSidebar.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import TreePine from '@lucide/svelte/icons/tree-pine';
+	import Trees from '@lucide/svelte/icons/trees';
+	import Images from '@lucide/svelte/icons/images';
+	import LogIn from '@lucide/svelte/icons/log-in';
+	import LogOut from '@lucide/svelte/icons/log-out';
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
+	import DarkModeToggle from '$lib/components/DarkModeToggle.svelte';
+
+	const showcasePath = resolve('/showcase');
+	const scenePath = resolve('/showcase/scene');
+	const galleryPath = resolve('/gallery');
+	const authPath = resolve('/auth');
+	const signOutPath = resolve('/auth/sign-out');
+
+	const user = $derived(page.data.user);
+</script>
+
+<Sidebar.Root collapsible="icon">
+	<Sidebar.Header>
+		<div class="flex items-center gap-2 px-2 py-1.5">
+			<TreePine class="size-5 text-primary" />
+			<span class="font-semibold group-data-[collapsible=icon]:hidden">Low-Poly Trees</span>
+		</div>
+	</Sidebar.Header>
+	<Sidebar.Content>
+		<Sidebar.Group>
+			<Sidebar.GroupLabel>Navigation</Sidebar.GroupLabel>
+			<Sidebar.GroupContent>
+				<Sidebar.Menu>
+					<Sidebar.MenuItem>
+						<Sidebar.MenuButton
+							isActive={page.url.pathname === showcasePath}
+							tooltipContent="Single Editor"
+						>
+							{#snippet child({ props })}
+								<a href={resolve('/showcase')} {...props}>
+									<TreePine />
+									<span>Single Editor</span>
+								</a>
+							{/snippet}
+						</Sidebar.MenuButton>
+					</Sidebar.MenuItem>
+					<Sidebar.MenuItem>
+						<Sidebar.MenuButton
+							isActive={page.url.pathname === scenePath}
+							tooltipContent="Scene Editor"
+						>
+							{#snippet child({ props })}
+								<a href={resolve('/showcase/scene')} {...props}>
+									<Trees />
+									<span>Scene Editor</span>
+								</a>
+							{/snippet}
+						</Sidebar.MenuButton>
+					</Sidebar.MenuItem>
+					<Sidebar.MenuItem>
+						<Sidebar.MenuButton
+							isActive={page.url.pathname === galleryPath}
+							tooltipContent="Gallery"
+						>
+							{#snippet child({ props })}
+								<a href={resolve('/gallery')} {...props}>
+									<Images />
+									<span>Gallery</span>
+								</a>
+							{/snippet}
+						</Sidebar.MenuButton>
+					</Sidebar.MenuItem>
+				</Sidebar.Menu>
+			</Sidebar.GroupContent>
+		</Sidebar.Group>
+	</Sidebar.Content>
+	<Sidebar.Footer>
+		<div class="flex items-center gap-2 px-2 py-1.5 group-data-[collapsible=icon]:hidden">
+			<DarkModeToggle />
+		</div>
+		{#if user}
+			<Sidebar.Menu>
+				<Sidebar.MenuItem>
+					<div
+						class="flex items-center gap-2 px-2 py-1.5 group-data-[collapsible=icon]:hidden"
+					>
+						{#if user.image}
+							<img
+								src={user.image}
+								alt={user.name}
+								class="size-8 rounded-full object-cover"
+							/>
+						{:else}
+							<div
+								class="flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+							>
+								{user.name.slice(0, 2).toUpperCase()}
+							</div>
+						{/if}
+						<div class="min-w-0 flex-1">
+							<p class="truncate text-sm font-medium">{user.name}</p>
+							<p class="truncate text-xs text-muted-foreground">{user.email}</p>
+						</div>
+					</div>
+					<form method="POST" action={signOutPath}>
+						<Sidebar.MenuButton
+							data-testid="sidebar-sign-out"
+							tooltipContent="Sign out"
+						>
+							{#snippet child({ props })}
+								<button type="submit" {...props}>
+									<LogOut />
+									<span>Sign out</span>
+								</button>
+							{/snippet}
+						</Sidebar.MenuButton>
+					</form>
+				</Sidebar.MenuItem>
+			</Sidebar.Menu>
+		{:else}
+			<Sidebar.Menu>
+				<Sidebar.MenuItem>
+					<Sidebar.MenuButton data-testid="sidebar-sign-in" tooltipContent="Sign in">
+						{#snippet child({ props })}
+							<a href={authPath} {...props}>
+								<LogIn />
+								<span>Sign in</span>
+							</a>
+						{/snippet}
+					</Sidebar.MenuButton>
+				</Sidebar.MenuItem>
+			</Sidebar.Menu>
+		{/if}
+	</Sidebar.Footer>
+	<Sidebar.Rail />
+</Sidebar.Root>

--- a/src/lib/components/ui/sheet/index.ts
+++ b/src/lib/components/ui/sheet/index.ts
@@ -1,0 +1,34 @@
+import Root from './sheet.svelte';
+import Portal from './sheet-portal.svelte';
+import Trigger from './sheet-trigger.svelte';
+import Close from './sheet-close.svelte';
+import Overlay from './sheet-overlay.svelte';
+import Content from './sheet-content.svelte';
+import Header from './sheet-header.svelte';
+import Footer from './sheet-footer.svelte';
+import Title from './sheet-title.svelte';
+import Description from './sheet-description.svelte';
+
+export {
+	Root,
+	Close,
+	Trigger,
+	Portal,
+	Overlay,
+	Content,
+	Header,
+	Footer,
+	Title,
+	Description,
+	//
+	Root as Sheet,
+	Close as SheetClose,
+	Trigger as SheetTrigger,
+	Portal as SheetPortal,
+	Overlay as SheetOverlay,
+	Content as SheetContent,
+	Header as SheetHeader,
+	Footer as SheetFooter,
+	Title as SheetTitle,
+	Description as SheetDescription,
+};

--- a/src/lib/components/ui/sheet/sheet-close.svelte
+++ b/src/lib/components/ui/sheet/sheet-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.CloseProps = $props();
+</script>
+
+<SheetPrimitive.Close bind:ref data-slot="sheet-close" {...restProps} />

--- a/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,0 +1,60 @@
+<script lang="ts" module>
+	export type Side = 'top' | 'right' | 'bottom' | 'left';
+</script>
+
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+	import type { Snippet } from 'svelte';
+	import SheetPortal from './sheet-portal.svelte';
+	import SheetOverlay from './sheet-overlay.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import XIcon from '@lucide/svelte/icons/x';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import type { ComponentProps } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		side = 'right',
+		showCloseButton = true,
+		portalProps,
+		children,
+		...restProps
+	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetPortal>>;
+		side?: Side;
+		showCloseButton?: boolean;
+		children: Snippet;
+	} = $props();
+</script>
+
+<SheetPortal {...portalProps}>
+	<SheetOverlay />
+	<SheetPrimitive.Content
+		bind:ref
+		data-slot="sheet-content"
+		data-side={side}
+		class={cn(
+			'bg-popover text-popover-foreground fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10',
+			className,
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		{#if showCloseButton}
+			<SheetPrimitive.Close data-slot="sheet-close">
+				{#snippet child({ props })}
+					<Button
+						variant="ghost"
+						class="absolute top-4 right-4"
+						size="icon-sm"
+						{...props}
+					>
+						<XIcon />
+						<span class="sr-only">Close</span>
+					</Button>
+				{/snippet}
+			</SheetPrimitive.Close>
+		{/if}
+	</SheetPrimitive.Content>
+</SheetPortal>

--- a/src/lib/components/ui/sheet/sheet-description.svelte
+++ b/src/lib/components/ui/sheet/sheet-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.DescriptionProps = $props();
+</script>
+
+<SheetPrimitive.Description
+	bind:ref
+	data-slot="sheet-description"
+	class={cn('text-muted-foreground text-sm', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-footer.svelte
+++ b/src/lib/components/ui/sheet/sheet-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-footer"
+	class={cn('gap-2 p-4 mt-auto flex flex-col', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sheet/sheet-header.svelte
+++ b/src/lib/components/ui/sheet/sheet-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-header"
+	class={cn('gap-1.5 p-4 flex flex-col', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sheet/sheet-overlay.svelte
+++ b/src/lib/components/ui/sheet/sheet-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.OverlayProps = $props();
+</script>
+
+<SheetPrimitive.Overlay
+	bind:ref
+	data-slot="sheet-overlay"
+	class={cn(
+		'bg-black/10 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50',
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-portal.svelte
+++ b/src/lib/components/ui/sheet/sheet-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+
+	let { ...restProps }: SheetPrimitive.PortalProps = $props();
+</script>
+
+<SheetPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/sheet/sheet-title.svelte
+++ b/src/lib/components/ui/sheet/sheet-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.TitleProps = $props();
+</script>
+
+<SheetPrimitive.Title
+	bind:ref
+	data-slot="sheet-title"
+	class={cn('font-heading text-foreground font-medium', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-trigger.svelte
+++ b/src/lib/components/ui/sheet/sheet-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.TriggerProps = $props();
+</script>
+
+<SheetPrimitive.Trigger bind:ref data-slot="sheet-trigger" {...restProps} />

--- a/src/lib/components/ui/sheet/sheet.svelte
+++ b/src/lib/components/ui/sheet/sheet.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: SheetPrimitive.RootProps = $props();
+</script>
+
+<SheetPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/sidebar/constants.ts
+++ b/src/lib/components/ui/sidebar/constants.ts
@@ -1,0 +1,6 @@
+export const SIDEBAR_COOKIE_NAME = 'sidebar:state';
+export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+export const SIDEBAR_WIDTH = '16rem';
+export const SIDEBAR_WIDTH_MOBILE = '18rem';
+export const SIDEBAR_WIDTH_ICON = '3rem';
+export const SIDEBAR_KEYBOARD_SHORTCUT = 'b';

--- a/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/src/lib/components/ui/sidebar/context.svelte.ts
@@ -1,0 +1,81 @@
+import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
+import { getContext, setContext } from 'svelte';
+import { SIDEBAR_KEYBOARD_SHORTCUT } from './constants.js';
+
+type Getter<T> = () => T;
+
+export interface SidebarStateProps {
+	/**
+	 * A getter function that returns the current open state of the sidebar.
+	 * We use a getter function here to support `bind:open` on the `Sidebar.Provider`
+	 * component.
+	 */
+	open: Getter<boolean>;
+
+	/**
+	 * A function that sets the open state of the sidebar. To support `bind:open`, we need
+	 * a source of truth for changing the open state to ensure it will be synced throughout
+	 * the sub-components and any `bind:` references.
+	 */
+	setOpen: (open: boolean) => void;
+}
+
+class SidebarState {
+	readonly props: SidebarStateProps;
+	open = $derived.by(() => this.props.open());
+	openMobile = $state(false);
+	setOpen: SidebarStateProps['setOpen'];
+	#isMobile: IsMobile;
+	state = $derived.by(() => (this.open ? 'expanded' : 'collapsed'));
+
+	constructor(props: SidebarStateProps) {
+		this.setOpen = props.setOpen;
+		this.#isMobile = new IsMobile();
+		this.props = props;
+	}
+
+	// Convenience getter for checking if the sidebar is mobile
+	// without this, we would need to use `sidebar.isMobile.current` everywhere
+	get isMobile() {
+		return this.#isMobile.current;
+	}
+
+	// Event handler to apply to the `<svelte:window>`
+	handleShortcutKeydown = (e: KeyboardEvent) => {
+		if (e.key === SIDEBAR_KEYBOARD_SHORTCUT && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			this.toggle();
+		}
+	};
+
+	setOpenMobile = (value: boolean) => {
+		this.openMobile = value;
+	};
+
+	toggle = () => {
+		return this.#isMobile.current
+			? (this.openMobile = !this.openMobile)
+			: this.setOpen(!this.open);
+	};
+}
+
+const SYMBOL_KEY = 'scn-sidebar';
+
+/**
+ * Instantiates a new `SidebarState` instance and sets it in the context.
+ *
+ * @param props The constructor props for the `SidebarState` class.
+ * @returns  The `SidebarState` instance.
+ */
+export function setSidebar(props: SidebarStateProps): SidebarState {
+	return setContext(Symbol.for(SYMBOL_KEY), new SidebarState(props));
+}
+
+/**
+ * Retrieves the `SidebarState` instance from the context. This is a class instance,
+ * so you cannot destructure it.
+ * @returns The `SidebarState` instance.
+ */
+export function useSidebar(): SidebarState {
+	return getContext(Symbol.for(SYMBOL_KEY));
+}

--- a/src/lib/components/ui/sidebar/index.ts
+++ b/src/lib/components/ui/sidebar/index.ts
@@ -1,0 +1,75 @@
+import { useSidebar } from './context.svelte.js';
+import Content from './sidebar-content.svelte';
+import Footer from './sidebar-footer.svelte';
+import GroupAction from './sidebar-group-action.svelte';
+import GroupContent from './sidebar-group-content.svelte';
+import GroupLabel from './sidebar-group-label.svelte';
+import Group from './sidebar-group.svelte';
+import Header from './sidebar-header.svelte';
+import Input from './sidebar-input.svelte';
+import Inset from './sidebar-inset.svelte';
+import MenuAction from './sidebar-menu-action.svelte';
+import MenuBadge from './sidebar-menu-badge.svelte';
+import MenuButton from './sidebar-menu-button.svelte';
+import MenuItem from './sidebar-menu-item.svelte';
+import MenuSkeleton from './sidebar-menu-skeleton.svelte';
+import MenuSubButton from './sidebar-menu-sub-button.svelte';
+import MenuSubItem from './sidebar-menu-sub-item.svelte';
+import MenuSub from './sidebar-menu-sub.svelte';
+import Menu from './sidebar-menu.svelte';
+import Provider from './sidebar-provider.svelte';
+import Rail from './sidebar-rail.svelte';
+import Separator from './sidebar-separator.svelte';
+import Trigger from './sidebar-trigger.svelte';
+import Root from './sidebar.svelte';
+
+export {
+	Content,
+	Footer,
+	Group,
+	GroupAction,
+	GroupContent,
+	GroupLabel,
+	Header,
+	Input,
+	Inset,
+	Menu,
+	MenuAction,
+	MenuBadge,
+	MenuButton,
+	MenuItem,
+	MenuSkeleton,
+	MenuSub,
+	MenuSubButton,
+	MenuSubItem,
+	Provider,
+	Rail,
+	Root,
+	Separator,
+	//
+	Root as Sidebar,
+	Content as SidebarContent,
+	Footer as SidebarFooter,
+	Group as SidebarGroup,
+	GroupAction as SidebarGroupAction,
+	GroupContent as SidebarGroupContent,
+	GroupLabel as SidebarGroupLabel,
+	Header as SidebarHeader,
+	Input as SidebarInput,
+	Inset as SidebarInset,
+	Menu as SidebarMenu,
+	MenuAction as SidebarMenuAction,
+	MenuBadge as SidebarMenuBadge,
+	MenuButton as SidebarMenuButton,
+	MenuItem as SidebarMenuItem,
+	MenuSkeleton as SidebarMenuSkeleton,
+	MenuSub as SidebarMenuSub,
+	MenuSubButton as SidebarMenuSubButton,
+	MenuSubItem as SidebarMenuSubItem,
+	Provider as SidebarProvider,
+	Rail as SidebarRail,
+	Separator as SidebarSeparator,
+	Trigger as SidebarTrigger,
+	Trigger,
+	useSidebar,
+};

--- a/src/lib/components/ui/sidebar/sidebar-content.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-content.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-content"
+	data-sidebar="content"
+	class={cn(
+		'no-scrollbar gap-2 flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sidebar/sidebar-footer.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-footer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-footer"
+	data-sidebar="footer"
+	class={cn('gap-2 p-2 flex flex-col', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sidebar/sidebar-group-action.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-group-action.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		child,
+		...restProps
+	}: WithElementRef<HTMLButtonAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-md p-0 focus-visible:ring-2 [&>svg]:size-4 flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
+			className,
+		),
+		'data-slot': 'sidebar-group-action',
+		'data-sidebar': 'group-action',
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<button bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/src/lib/components/ui/sidebar/sidebar-group-content.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-group-content.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-group-content"
+	data-sidebar="group-content"
+	class={cn('text-sm w-full', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sidebar/sidebar-group-label.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-group-label.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		children,
+		child,
+		class: className,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			'text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0',
+			className,
+		),
+		'data-slot': 'sidebar-group-label',
+		'data-sidebar': 'group-label',
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/src/lib/components/ui/sidebar/sidebar-group.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-group.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-group"
+	data-sidebar="group"
+	class={cn('p-2 relative flex w-full min-w-0 flex-col', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sidebar/sidebar-header.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-header.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-header"
+	data-sidebar="header"
+	class={cn('gap-2 p-2 flex flex-col', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sidebar/sidebar-input.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-input.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(''),
+		class: className,
+		...restProps
+	}: ComponentProps<typeof Input> = $props();
+</script>
+
+<Input
+	bind:ref
+	bind:value
+	data-slot="sidebar-input"
+	data-sidebar="input"
+	class={cn('bg-background h-8 w-full shadow-none', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<main
+	bind:this={ref}
+	data-slot="sidebar-inset"
+	class={cn(
+		'bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</main>

--- a/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		showOnHover = false,
+		children,
+		child,
+		...restProps
+	}: WithElementRef<HTMLButtonAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		showOnHover?: boolean;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
+			showOnHover &&
+				'peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0',
+			className,
+		),
+		'data-slot': 'sidebar-menu-action',
+		'data-sidebar': 'menu-action',
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<button bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/src/lib/components/ui/sidebar/sidebar-menu-badge.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-badge.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-menu-badge"
+	data-sidebar="menu-badge"
+	class={cn(
+		'text-sidebar-foreground peer-hover/menu-button:text-sidebar-accent-foreground peer-data-active/menu-button:text-sidebar-accent-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 rounded-md px-1 text-xs font-medium peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
@@ -1,0 +1,103 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	export const sidebarMenuButtonVariants = tv({
+		base: 'ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-md p-2 text-left text-sm transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium peer/menu-button group/menu-button flex w-full items-center overflow-hidden outline-hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate',
+		variants: {
+			variant: {
+				default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+				outline:
+					'bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+			},
+			size: {
+				default: 'h-8 text-sm',
+				sm: 'h-7 text-xs',
+				lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default',
+		},
+	});
+
+	export type SidebarMenuButtonVariant = VariantProps<
+		typeof sidebarMenuButtonVariants
+	>['variant'];
+	export type SidebarMenuButtonSize = VariantProps<typeof sidebarMenuButtonVariants>['size'];
+</script>
+
+<script lang="ts">
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { cn, type WithElementRef, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import { mergeProps } from 'bits-ui';
+	import type { ComponentProps, Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { useSidebar } from './context.svelte.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		child,
+		variant = 'default',
+		size = 'default',
+		isActive = false,
+		tooltipContent,
+		tooltipContentProps,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+		isActive?: boolean;
+		variant?: SidebarMenuButtonVariant;
+		size?: SidebarMenuButtonSize;
+		tooltipContent?: Snippet | string;
+		tooltipContentProps?: WithoutChildrenOrChild<ComponentProps<typeof Tooltip.Content>>;
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const sidebar = useSidebar();
+
+	const buttonProps = $derived({
+		class: cn(sidebarMenuButtonVariants({ variant, size }), className),
+		'data-slot': 'sidebar-menu-button',
+		'data-sidebar': 'menu-button',
+		'data-size': size,
+		'data-active': isActive,
+		...restProps,
+	});
+</script>
+
+{#snippet Button({ props }: { props?: Record<string, unknown> })}
+	{@const mergedProps = mergeProps(buttonProps, props)}
+	{#if child}
+		{@render child({ props: mergedProps })}
+	{:else}
+		<button bind:this={ref} {...mergedProps}>
+			{@render children?.()}
+		</button>
+	{/if}
+{/snippet}
+
+{#if tooltipContent === undefined}
+	{@render Button({})}
+{:else}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				{@render Button({ props })}
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content
+			side="right"
+			align="center"
+			hidden={sidebar.state !== 'collapsed' || sidebar.isMobile}
+			{...tooltipContentProps}
+		>
+			{#if typeof tooltipContent === 'string'}
+				{tooltipContent}
+			{:else if tooltipContent}
+				{@render tooltipContent()}
+			{/if}
+		</Tooltip.Content>
+	</Tooltip.Root>
+{/if}

--- a/src/lib/components/ui/sidebar/sidebar-menu-item.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-item.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLLIElement>, HTMLLIElement> = $props();
+</script>
+
+<li
+	bind:this={ref}
+	data-slot="sidebar-menu-item"
+	data-sidebar="menu-item"
+	class={cn('group/menu-item relative', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</li>

--- a/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		showIcon = false,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		showIcon?: boolean;
+	} = $props();
+
+	// Random width between 50% and 90%
+	const width = `${Math.floor(Math.random() * 40) + 50}%`;
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-menu-skeleton"
+	data-sidebar="menu-skeleton"
+	class={cn('h-8 gap-2 rounded-md px-2 flex items-center', className)}
+	{...restProps}
+>
+	{#if showIcon}
+		<Skeleton class="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />
+	{/if}
+	<Skeleton
+		class="h-4 max-w-(--skeleton-width) flex-1"
+		data-sidebar="menu-skeleton-text"
+		style="
+
+--skeleton-width: {width};"
+	/>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLAnchorAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		children,
+		child,
+		class: className,
+		size = 'md',
+		isActive = false,
+		...restProps
+	}: WithElementRef<HTMLAnchorAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		size?: 'sm' | 'md';
+		isActive?: boolean;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground h-7 gap-2 rounded-md px-2 focus-visible:ring-2 data-[size=md]:text-sm data-[size=sm]:text-xs [&>svg]:size-4 flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0',
+			className,
+		),
+		'data-slot': 'sidebar-menu-sub-button',
+		'data-sidebar': 'menu-sub-button',
+		'data-size': size,
+		'data-active': isActive,
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<a bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</a>
+{/if}

--- a/src/lib/components/ui/sidebar/sidebar-menu-sub-item.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-sub-item.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		children,
+		class: className,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLLIElement>> = $props();
+</script>
+
+<li
+	bind:this={ref}
+	data-slot="sidebar-menu-sub-item"
+	data-sidebar="menu-sub-item"
+	class={cn('group/menu-sub-item relative', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</li>

--- a/src/lib/components/ui/sidebar/sidebar-menu-sub.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-sub.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();
+</script>
+
+<ul
+	bind:this={ref}
+	data-slot="sidebar-menu-sub"
+	data-sidebar="menu-sub"
+	class={cn(
+		'border-sidebar-border mx-3.5 translate-x-px gap-1 border-l px-2.5 py-0.5 group-data-[collapsible=icon]:hidden flex min-w-0 flex-col',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</ul>

--- a/src/lib/components/ui/sidebar/sidebar-menu.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLUListElement>, HTMLUListElement> = $props();
+</script>
+
+<ul
+	bind:this={ref}
+	data-slot="sidebar-menu"
+	data-sidebar="menu"
+	class={cn('gap-1 flex w-full min-w-0 flex-col', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</ul>

--- a/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import {
+		SIDEBAR_COOKIE_MAX_AGE,
+		SIDEBAR_COOKIE_NAME,
+		SIDEBAR_WIDTH,
+		SIDEBAR_WIDTH_ICON,
+	} from './constants.js';
+	import { setSidebar } from './context.svelte.js';
+
+	let {
+		ref = $bindable(null),
+		open = $bindable(true),
+		onOpenChange = () => {},
+		class: className,
+		style,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		open?: boolean;
+		onOpenChange?: (open: boolean) => void;
+	} = $props();
+
+	const sidebar = setSidebar({
+		open: () => open,
+		setOpen: (value: boolean) => {
+			open = value;
+			onOpenChange(value);
+
+			// This sets the cookie to keep the sidebar state.
+			document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+		},
+	});
+</script>
+
+<svelte:window onkeydown={sidebar.handleShortcutKeydown} />
+
+<Tooltip.Provider delayDuration={0}>
+	<div
+		data-slot="sidebar-wrapper"
+		style="
+
+--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
+		class={cn(
+			'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full',
+			className,
+		)}
+		bind:this={ref}
+		{...restProps}
+	>
+		{@render children?.()}
+	</div>
+</Tooltip.Provider>

--- a/src/lib/components/ui/sidebar/sidebar-rail.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-rail.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { useSidebar } from './context.svelte.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<button
+	bind:this={ref}
+	data-sidebar="rail"
+	data-slot="sidebar-rail"
+	aria-label="Toggle Sidebar"
+	tabindex={-1}
+	onclick={sidebar.toggle}
+	title="Toggle Sidebar"
+	class={cn(
+		'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
+		'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
+		'[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+		'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full',
+		'[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+		'[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</button>

--- a/src/lib/components/ui/sidebar/sidebar-separator.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-separator.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { cn } from '$lib/utils.js';
+	import type { ComponentProps } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ComponentProps<typeof Separator> = $props();
+</script>
+
+<Separator
+	bind:ref
+	data-slot="sidebar-separator"
+	data-sidebar="separator"
+	class={cn('bg-sidebar-border mx-2 w-auto', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
+	import { cn } from '$lib/utils.js';
+	import type { ComponentProps } from 'svelte';
+	import { useSidebar } from './context.svelte.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		onclick,
+		...restProps
+	}: ComponentProps<typeof Button> & {
+		onclick?: (e: MouseEvent) => void;
+	} = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<Button
+	bind:ref
+	data-sidebar="trigger"
+	data-slot="sidebar-trigger"
+	variant="ghost"
+	size="icon-sm"
+	class={cn('cn-sidebar-trigger', className)}
+	type="button"
+	onclick={(e) => {
+		onclick?.(e);
+		sidebar.toggle();
+	}}
+	{...restProps}
+>
+	<PanelLeftIcon />
+	<span class="sr-only">Toggle Sidebar</span>
+</Button>

--- a/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/src/lib/components/ui/sidebar/sidebar.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+	import * as Sheet from '$lib/components/ui/sheet/index.js';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { SIDEBAR_WIDTH_MOBILE } from './constants.js';
+	import { useSidebar } from './context.svelte.js';
+
+	let {
+		ref = $bindable(null),
+		side = 'left',
+		variant = 'sidebar',
+		collapsible = 'offcanvas',
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		side?: 'left' | 'right';
+		variant?: 'sidebar' | 'floating' | 'inset';
+		collapsible?: 'offcanvas' | 'icon' | 'none';
+	} = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+{#if collapsible === 'none'}
+	<div
+		class={cn(
+			'bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col',
+			className,
+		)}
+		bind:this={ref}
+		{...restProps}
+	>
+		{@render children?.()}
+	</div>
+{:else if sidebar.isMobile}
+	<Sheet.Root
+		bind:open={() => sidebar.openMobile, (v) => sidebar.setOpenMobile(v)}
+		{...restProps}
+	>
+		<Sheet.Content
+			bind:ref
+			data-sidebar="sidebar"
+			data-slot="sidebar"
+			data-mobile="true"
+			class={cn(
+				'bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden',
+				className,
+			)}
+			style="
+
+--sidebar-width: {SIDEBAR_WIDTH_MOBILE};"
+			{side}
+		>
+			<Sheet.Header class="sr-only">
+				<Sheet.Title>Sidebar</Sheet.Title>
+				<Sheet.Description>Displays the mobile sidebar.</Sheet.Description>
+			</Sheet.Header>
+			<div class="flex h-full w-full flex-col">
+				{@render children?.()}
+			</div>
+		</Sheet.Content>
+	</Sheet.Root>
+{:else}
+	<div
+		bind:this={ref}
+		class="text-sidebar-foreground group peer hidden md:block"
+		data-state={sidebar.state}
+		data-collapsible={sidebar.state === 'collapsed' ? collapsible : ''}
+		data-variant={variant}
+		data-side={side}
+		data-slot="sidebar"
+	>
+		<!-- This is what handles the sidebar gap on desktop -->
+		<div
+			data-slot="sidebar-gap"
+			class={cn(
+				'transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent',
+				'group-data-[collapsible=offcanvas]:w-0',
+				'group-data-[side=right]:rotate-180',
+				variant === 'floating' || variant === 'inset'
+					? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
+					: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
+			)}
+		></div>
+		<div
+			data-slot="sidebar-container"
+			class={cn(
+				'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
+				side === 'left'
+					? 'start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]'
+					: 'end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]',
+				// Adjust the padding for floating and inset variants.
+				variant === 'floating' || variant === 'inset'
+					? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
+					: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s',
+				className,
+			)}
+			{...restProps}
+		>
+			<div
+				data-sidebar="sidebar"
+				data-slot="sidebar-inner"
+				class="bg-sidebar group-data-[variant=floating]:ring-sidebar-border group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 flex size-full flex-col"
+			>
+				{@render children?.()}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/ui/tooltip/index.ts
+++ b/src/lib/components/ui/tooltip/index.ts
@@ -1,0 +1,19 @@
+import Root from './tooltip.svelte';
+import Trigger from './tooltip-trigger.svelte';
+import Content from './tooltip-content.svelte';
+import Provider from './tooltip-provider.svelte';
+import Portal from './tooltip-portal.svelte';
+
+export {
+	Root,
+	Trigger,
+	Content,
+	Provider,
+	Portal,
+	//
+	Root as Tooltip,
+	Content as TooltipContent,
+	Trigger as TooltipTrigger,
+	Provider as TooltipProvider,
+	Portal as TooltipPortal,
+};

--- a/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import TooltipPortal from './tooltip-portal.svelte';
+	import type { ComponentProps } from 'svelte';
+	import type { WithoutChildrenOrChild } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 0,
+		side = 'top',
+		children,
+		arrowClasses,
+		portalProps,
+		...restProps
+	}: TooltipPrimitive.ContentProps & {
+		arrowClasses?: string;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof TooltipPortal>>;
+	} = $props();
+</script>
+
+<TooltipPortal {...portalProps}>
+	<TooltipPrimitive.Content
+		bind:ref
+		data-slot="tooltip-content"
+		{sideOffset}
+		{side}
+		class={cn(
+			'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm bg-foreground text-background z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)',
+			className,
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<TooltipPrimitive.Arrow>
+			{#snippet child({ props })}
+				<div
+					class={cn(
+						'size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground z-50',
+						'data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%+2px)]',
+						'data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%+1px)]',
+						'data-[side=right]:translate-x-[calc(50%+2px)] data-[side=right]:translate-y-1/2',
+						'data-[side=left]:-translate-y-[calc(50%-3px)]',
+						arrowClasses,
+					)}
+					{...props}
+				></div>
+			{/snippet}
+		</TooltipPrimitive.Arrow>
+	</TooltipPrimitive.Content>
+</TooltipPortal>

--- a/src/lib/components/ui/tooltip/tooltip-portal.svelte
+++ b/src/lib/components/ui/tooltip/tooltip-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+	let { ...restProps }: TooltipPrimitive.PortalProps = $props();
+</script>
+
+<TooltipPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/tooltip/tooltip-provider.svelte
+++ b/src/lib/components/ui/tooltip/tooltip-provider.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+	let { delayDuration = 0, ...restProps }: TooltipPrimitive.ProviderProps = $props();
+</script>
+
+<TooltipPrimitive.Provider {delayDuration} {...restProps} />

--- a/src/lib/components/ui/tooltip/tooltip-trigger.svelte
+++ b/src/lib/components/ui/tooltip/tooltip-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps = $props();
+</script>
+
+<TooltipPrimitive.Trigger bind:ref data-slot="tooltip-trigger" {...restProps} />

--- a/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/src/lib/components/ui/tooltip/tooltip.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+	import TooltipProvider from './tooltip-provider.svelte';
+
+	let { open = $bindable(false), ...restProps }: TooltipPrimitive.RootProps = $props();
+</script>
+
+<TooltipProvider>
+	<TooltipPrimitive.Root bind:open {...restProps} />
+</TooltipProvider>

--- a/src/lib/hooks/is-mobile.svelte.ts
+++ b/src/lib/hooks/is-mobile.svelte.ts
@@ -1,0 +1,9 @@
+import { MediaQuery } from 'svelte/reactivity';
+
+const DEFAULT_MOBILE_BREAKPOINT = 768;
+
+export class IsMobile extends MediaQuery {
+	constructor(breakpoint: number = DEFAULT_MOBILE_BREAKPOINT) {
+		super(`max-width: ${breakpoint - 1}px`);
+	}
+}

--- a/src/lib/server/db/saved_trees.schema.ts
+++ b/src/lib/server/db/saved_trees.schema.ts
@@ -1,0 +1,14 @@
+import { jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import type { TreeConfig } from '$lib/trees/types.js';
+import { user } from './auth.schema.js';
+
+export const savedTrees = pgTable('saved_trees', {
+	id: text('id').primaryKey(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => user.id, { onDelete: 'cascade' }),
+	name: text('name').notNull(),
+	config: jsonb('config').$type<TreeConfig>().notNull(),
+	createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+	updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,1 +1,2 @@
 export * from './auth.schema.js';
+export * from './saved_trees.schema.js';

--- a/src/lib/server/saved_trees.test.ts
+++ b/src/lib/server/saved_trees.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DEFAULT_TREE_CONFIG, TREE_SHAPES, type TreeShape } from '$lib/trees/types.js';
+
+interface SavedRow {
+	id: string;
+	userId: string;
+	name: string;
+	config: typeof DEFAULT_TREE_CONFIG;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+// In-memory fake DB. The mock translates drizzle chain calls into in-memory operations.
+const rows: SavedRow[] = [];
+
+function resetDb() {
+	rows.length = 0;
+}
+
+// Filter predicates captured by the mocked chain.
+interface Filter {
+	userId?: string;
+	id?: string;
+	nameLike?: string;
+}
+
+function matches(row: SavedRow, f: Filter): boolean {
+	if (f.userId !== undefined && row.userId !== f.userId) {
+		return false;
+	}
+	if (f.id !== undefined && row.id !== f.id) {
+		return false;
+	}
+	if (f.nameLike !== undefined) {
+		const prefix = f.nameLike.replace('%', '');
+		if (!row.name.startsWith(prefix)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// The mocked drizzle operators return tagged filter descriptors.
+vi.mock('drizzle-orm', () => ({
+	and: (...parts: Filter[]): Filter => Object.assign({}, ...parts),
+	eq: (col: { name: string }, value: string): Filter => {
+		if (col.name === 'user_id') {
+			return { userId: value };
+		}
+		if (col.name === 'id') {
+			return { id: value };
+		}
+		if (col.name === 'name') {
+			return { nameLike: value };
+		}
+		return {};
+	},
+	like: (_col: unknown, value: string): Filter => ({ nameLike: value }),
+	desc: (col: unknown) => col,
+}));
+
+vi.mock('./db/saved_trees.schema.js', () => ({
+	savedTrees: {
+		id: { name: 'id' },
+		userId: { name: 'user_id' },
+		name: { name: 'name' },
+		config: { name: 'config' },
+		createdAt: { name: 'created_at' },
+		updatedAt: { name: 'updated_at' },
+		$inferSelect: {} as SavedRow,
+	},
+}));
+
+vi.mock('./db/index.js', () => {
+	function selectBuilder() {
+		let filter: Filter = {};
+		const api = {
+			from: () => api,
+			where: (f: Filter) => {
+				filter = f;
+				return api;
+			},
+			orderBy: async () =>
+				rows
+					.slice()
+					.filter((r) => matches(r, filter))
+					.reverse(),
+			limit: async () => rows.filter((r) => matches(r, filter)).slice(0, 1),
+		};
+		return api;
+	}
+
+	function insertBuilder() {
+		let pending: Omit<SavedRow, 'createdAt' | 'updatedAt'> | null = null;
+		const api = {
+			values: (v: Omit<SavedRow, 'createdAt' | 'updatedAt'>) => {
+				pending = v;
+				return api;
+			},
+			returning: async () => {
+				if (!pending) {
+					throw new Error('no values');
+				}
+				const now = new Date();
+				const row: SavedRow = { ...pending, createdAt: now, updatedAt: now };
+				rows.push(row);
+				return [row];
+			},
+		};
+		return api;
+	}
+
+	function deleteBuilder() {
+		const api = {
+			where: async (f: Filter) => {
+				for (let i = rows.length - 1; i >= 0; i--) {
+					if (matches(rows[i], f)) {
+						rows.splice(i, 1);
+					}
+				}
+			},
+		};
+		return api;
+	}
+
+	function updateBuilder() {
+		let pending: Partial<SavedRow> = {};
+		const api = {
+			set: (v: Partial<SavedRow>) => {
+				pending = v;
+				return api;
+			},
+			where: async (f: Filter) => {
+				for (const row of rows) {
+					if (matches(row, f)) {
+						Object.assign(row, pending);
+					}
+				}
+			},
+		};
+		return api;
+	}
+
+	return {
+		db: {
+			select: () => selectBuilder(),
+			insert: () => insertBuilder(),
+			delete: () => deleteBuilder(),
+			update: () => updateBuilder(),
+		},
+	};
+});
+
+import {
+	createSavedTree,
+	deleteSavedTree,
+	getSavedTree,
+	listSavedTrees,
+	renameSavedTree,
+} from './saved_trees.js';
+
+function makeConfig(shape: TreeShape = TREE_SHAPES.oak) {
+	return { ...DEFAULT_TREE_CONFIG, shape };
+}
+
+beforeEach(() => {
+	resetDb();
+});
+
+describe('createSavedTree', () => {
+	it('assigns auto-name "{Shape} #1" for the first save of a shape', async () => {
+		const row = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(TREE_SHAPES.oak),
+		});
+		expect(row.name).toBe('Oak #1');
+	});
+
+	it('increments auto-name per user + per shape', async () => {
+		await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(TREE_SHAPES.oak),
+		});
+		const second = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(TREE_SHAPES.oak),
+		});
+		const pineFirst = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.pine,
+			config: makeConfig(TREE_SHAPES.pine),
+		});
+		expect(second.name).toBe('Oak #2');
+		expect(pineFirst.name).toBe('Pine #1');
+	});
+
+	it('isolates auto-name counter between users', async () => {
+		await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		const forUserB = await createSavedTree({
+			userId: 'user-b',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		expect(forUserB.name).toBe('Oak #1');
+	});
+
+	it('capitalizes custom shape as "Custom #N"', async () => {
+		const row = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.custom,
+			config: makeConfig(TREE_SHAPES.custom),
+		});
+		expect(row.name).toBe('Custom #1');
+	});
+
+	it('persists the config snapshot as-is', async () => {
+		const config = { ...makeConfig(), seed: 1234 };
+		const row = await createSavedTree({
+			userId: 'user-a',
+			shape: config.shape,
+			config,
+		});
+		expect(row.config.seed).toBe(1234);
+	});
+});
+
+describe('listSavedTrees', () => {
+	it('returns only the requested user rows', async () => {
+		await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		await createSavedTree({
+			userId: 'user-b',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		const forUserA = await listSavedTrees('user-a');
+		expect(forUserA).toHaveLength(1);
+		expect(forUserA[0].userId).toBe('user-a');
+	});
+
+	it('returns rows in reverse-insertion order (newest first)', async () => {
+		const first = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		const second = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.pine,
+			config: makeConfig(TREE_SHAPES.pine),
+		});
+		const list = await listSavedTrees('user-a');
+		expect(list[0].id).toBe(second.id);
+		expect(list[1].id).toBe(first.id);
+	});
+});
+
+describe('getSavedTree', () => {
+	it('returns a row the user owns', async () => {
+		const created = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		const fetched = await getSavedTree(created.id, 'user-a');
+		expect(fetched?.id).toBe(created.id);
+	});
+
+	it('returns null when the row is owned by another user', async () => {
+		const created = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		const fetched = await getSavedTree(created.id, 'user-b');
+		expect(fetched).toBeNull();
+	});
+});
+
+describe('deleteSavedTree', () => {
+	it('deletes a row the user owns', async () => {
+		const created = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		await deleteSavedTree(created.id, 'user-a');
+		const afterList = await listSavedTrees('user-a');
+		expect(afterList).toHaveLength(0);
+	});
+
+	it('does not delete rows owned by another user', async () => {
+		const created = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		await deleteSavedTree(created.id, 'user-b');
+		const afterList = await listSavedTrees('user-a');
+		expect(afterList).toHaveLength(1);
+	});
+});
+
+describe('renameSavedTree', () => {
+	it('updates name for a row the user owns', async () => {
+		const created = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		await renameSavedTree(created.id, 'user-a', 'My Favorite Oak');
+		const fetched = await getSavedTree(created.id, 'user-a');
+		expect(fetched?.name).toBe('My Favorite Oak');
+	});
+
+	it('does not update name for a row owned by another user', async () => {
+		const created = await createSavedTree({
+			userId: 'user-a',
+			shape: TREE_SHAPES.oak,
+			config: makeConfig(),
+		});
+		await renameSavedTree(created.id, 'user-b', 'Hacked Name');
+		const fetched = await getSavedTree(created.id, 'user-a');
+		expect(fetched?.name).toBe('Oak #1');
+	});
+});

--- a/src/lib/server/saved_trees.ts
+++ b/src/lib/server/saved_trees.ts
@@ -1,0 +1,75 @@
+import { and, desc, eq, like } from 'drizzle-orm';
+import { db } from './db/index.js';
+import { savedTrees } from './db/saved_trees.schema.js';
+import { TREE_SHAPES, type TreeConfig, type TreeShape } from '$lib/trees/types.js';
+
+const SHAPE_LABELS: Record<TreeShape, string> = {
+	[TREE_SHAPES.oak]: 'Oak',
+	[TREE_SHAPES.pine]: 'Pine',
+	[TREE_SHAPES.birch]: 'Birch',
+	[TREE_SHAPES.fir]: 'Fir',
+	[TREE_SHAPES.maple]: 'Maple',
+	[TREE_SHAPES.willow]: 'Willow',
+	[TREE_SHAPES.custom]: 'Custom',
+} as const;
+
+type SavedTreeRow = typeof savedTrees.$inferSelect;
+
+async function nextAutoName(userId: string, shape: TreeShape): Promise<string> {
+	const label = SHAPE_LABELS[shape];
+	const rows = await db
+		.select({ id: savedTrees.id })
+		.from(savedTrees)
+		.where(and(eq(savedTrees.userId, userId), like(savedTrees.name, `${label} #%`)))
+		.orderBy(savedTrees.id);
+	return `${label} #${rows.length + 1}`;
+}
+
+interface CreateSavedTreeInput {
+	readonly userId: string;
+	readonly shape: TreeShape;
+	readonly config: TreeConfig;
+}
+
+export async function createSavedTree(input: CreateSavedTreeInput): Promise<SavedTreeRow> {
+	const name = await nextAutoName(input.userId, input.shape);
+	const id = crypto.randomUUID();
+	const [row] = await db
+		.insert(savedTrees)
+		.values({
+			id,
+			userId: input.userId,
+			name,
+			config: input.config,
+		})
+		.returning();
+	return row;
+}
+
+export async function listSavedTrees(userId: string): Promise<SavedTreeRow[]> {
+	return db
+		.select()
+		.from(savedTrees)
+		.where(eq(savedTrees.userId, userId))
+		.orderBy(desc(savedTrees.createdAt));
+}
+
+export async function getSavedTree(id: string, userId: string): Promise<SavedTreeRow | null> {
+	const [row] = await db
+		.select()
+		.from(savedTrees)
+		.where(and(eq(savedTrees.id, id), eq(savedTrees.userId, userId)))
+		.limit(1);
+	return row ?? null;
+}
+
+export async function deleteSavedTree(id: string, userId: string): Promise<void> {
+	await db.delete(savedTrees).where(and(eq(savedTrees.id, id), eq(savedTrees.userId, userId)));
+}
+
+export async function renameSavedTree(id: string, userId: string, name: string): Promise<void> {
+	await db
+		.update(savedTrees)
+		.set({ name, updatedAt: new Date() })
+		.where(and(eq(savedTrees.id, id), eq(savedTrees.userId, userId)));
+}

--- a/src/lib/trees/saved_trees.remote.ts
+++ b/src/lib/trees/saved_trees.remote.ts
@@ -1,0 +1,70 @@
+import * as v from 'valibot';
+import { error } from '@sveltejs/kit';
+import { command, form, getRequestEvent, query } from '$app/server';
+import * as savedTreesDb from '$lib/server/saved_trees.js';
+import { DEFAULT_TREE_CONFIG, TREE_SHAPES, type TreeConfig } from '$lib/trees/types.js';
+
+function requireUser() {
+	const { locals } = getRequestEvent();
+	if (!locals.user) {
+		error(401, 'Unauthorized');
+	}
+	return locals.user;
+}
+
+const treeShapeSchema = v.picklist(Object.values(TREE_SHAPES));
+
+export const listSavedTrees = query(async () => {
+	const user = requireUser();
+	return savedTreesDb.listSavedTrees(user.id);
+});
+
+export const getSavedTree = query(v.string(), async (id) => {
+	const user = requireUser();
+	const row = await savedTreesDb.getSavedTree(id, user.id);
+	if (!row) {
+		error(404, 'Not found');
+	}
+	return {
+		...row,
+		config: { ...DEFAULT_TREE_CONFIG, ...(row.config as TreeConfig) },
+	};
+});
+
+export const saveTree = form(
+	v.object({
+		config: v.pipe(
+			v.string(),
+			v.transform((s) => JSON.parse(s) as TreeConfig),
+		),
+	}),
+	async ({ config }) => {
+		const user = requireUser();
+		const shape = v.parse(treeShapeSchema, config.shape);
+		const saved = await savedTreesDb.createSavedTree({
+			userId: user.id,
+			shape,
+			config,
+		});
+		void listSavedTrees().refresh();
+		return { success: true, id: saved.id, name: saved.name };
+	},
+);
+
+export const deleteSavedTree = command(v.string(), async (id) => {
+	const user = requireUser();
+	await savedTreesDb.deleteSavedTree(id, user.id);
+	void listSavedTrees().refresh();
+});
+
+export const renameSavedTree = command(
+	v.object({
+		id: v.string(),
+		name: v.pipe(v.string(), v.nonEmpty(), v.maxLength(80)),
+	}),
+	async ({ id, name }) => {
+		const user = requireUser();
+		await savedTreesDb.renameSavedTree(id, user.id, name);
+		void listSavedTrees().refresh();
+	},
+);

--- a/src/lib/utils/format_relative.ts
+++ b/src/lib/utils/format_relative.ts
@@ -1,0 +1,27 @@
+const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+interface Division {
+	readonly amount: number;
+	readonly unit: Intl.RelativeTimeFormatUnit;
+}
+
+const DIVISIONS: readonly Division[] = [
+	{ amount: 60, unit: 'seconds' },
+	{ amount: 60, unit: 'minutes' },
+	{ amount: 24, unit: 'hours' },
+	{ amount: 7, unit: 'days' },
+	{ amount: 4.34524, unit: 'weeks' },
+	{ amount: 12, unit: 'months' },
+	{ amount: Number.POSITIVE_INFINITY, unit: 'years' },
+];
+
+export function formatRelative(date: Date, now: Date = new Date()): string {
+	let duration = (date.getTime() - now.getTime()) / 1000;
+	for (const division of DIVISIONS) {
+		if (Math.abs(duration) < division.amount) {
+			return RELATIVE_FORMATTER.format(Math.round(duration), division.unit);
+		}
+		duration /= division.amount;
+	}
+	return RELATIVE_FORMATTER.format(Math.round(duration), 'years');
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,14 @@
+import type { LayoutServerLoad } from './$types.js';
+
+export const load: LayoutServerLoad = ({ locals }) => {
+	return {
+		user: locals.user
+			? {
+					id: locals.user.id,
+					name: locals.user.name,
+					email: locals.user.email,
+					image: locals.user.image ?? null,
+				}
+			: null,
+	};
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,8 @@
 	import '../app.css';
 	import { ModeWatcher } from 'mode-watcher';
 	import { setShowcaseFormContext } from '$lib/context/showcase_form.context.svelte';
+	import AppSidebar from '$lib/components/app-shell/AppSidebar.svelte';
+	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import favicon from '$lib/assets/favicon.svg';
 	import figtreeLatinUrl from '@fontsource-variable/figtree/files/figtree-latin-wght-normal.woff2?url';
 	import notoSansLatinUrl from '@fontsource-variable/noto-sans/files/noto-sans-latin-wght-normal.woff2?url';
@@ -31,4 +33,9 @@
 	/>
 </svelte:head>
 
-{@render children()}
+<Sidebar.Provider>
+	<AppSidebar />
+	<Sidebar.Inset>
+		{@render children()}
+	</Sidebar.Inset>
+</Sidebar.Provider>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+	import LowPolyTree from '$lib/trees/LowPolyTree.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import {
+		deleteSavedTree,
+		listSavedTrees,
+		renameSavedTree,
+	} from '$lib/trees/saved_trees.remote.js';
+	import { formatRelative } from '$lib/utils/format_relative.js';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import Trash2 from '@lucide/svelte/icons/trash-2';
+
+	let renamingId = $state<string | null>(null);
+	let renameValue = $state('');
+
+	function startRename(id: string, current: string) {
+		renamingId = id;
+		renameValue = current;
+	}
+
+	async function commitRename(id: string) {
+		const trimmed = renameValue.trim();
+		if (trimmed && trimmed.length <= 80) {
+			await renameSavedTree({ id, name: trimmed });
+		}
+		renamingId = null;
+	}
+
+	async function confirmDelete(id: string, name: string) {
+		const confirmed = globalThis.confirm(`Delete ${name}? This cannot be undone.`);
+		if (!confirmed) {
+			return;
+		}
+		await deleteSavedTree(id);
+	}
+
+	function handleAuthError(error: unknown) {
+		if (
+			typeof error === 'object' &&
+			error !== null &&
+			'status' in error &&
+			(error as { status: unknown }).status === 401
+		) {
+			void goto(resolve('/auth'));
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Gallery</title>
+</svelte:head>
+
+<main class="container mx-auto p-6">
+	<header class="mb-6">
+		<h1 class="text-2xl font-bold tracking-tight">Your Saved Trees</h1>
+		<p class="text-sm text-muted-foreground">
+			Click a thumbnail to open it in the single editor.
+		</p>
+	</header>
+
+	<svelte:boundary onerror={handleAuthError}>
+		{#snippet pending()}
+			<p class="text-muted-foreground">Loading gallery…</p>
+		{/snippet}
+
+		{#snippet failed(error, reset)}
+			{@const message = error instanceof Error ? error.message : 'Something went wrong'}
+			<div class="rounded-md border border-destructive/40 bg-destructive/10 p-4">
+				<p class="text-sm text-destructive">Error: {message}</p>
+				<Button variant="outline" class="mt-2" onclick={reset}>Retry</Button>
+			</div>
+		{/snippet}
+
+		{@const trees = await listSavedTrees()}
+		{#if trees.length === 0}
+			<p class="text-muted-foreground" data-testid="gallery-empty">
+				No saved trees yet. Head to the
+				<a href={resolve('/showcase')} class="underline">Single Editor</a>
+				to create one.
+			</p>
+		{:else}
+			<div
+				class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4"
+				data-testid="gallery-grid"
+			>
+				{#each trees as tree (tree.id)}
+					<article
+						class="group relative flex flex-col rounded-lg border border-border bg-card p-3 shadow-sm transition-shadow hover:shadow-md"
+						data-testid="gallery-card"
+						data-tree-id={tree.id}
+					>
+						<a
+							href={`${resolve('/showcase')}?saved=${encodeURIComponent(tree.id)}`}
+							class="block aspect-square overflow-hidden rounded-md bg-muted/30"
+							aria-label={`Open ${tree.name} in editor`}
+						>
+							<LowPolyTree {...tree.config} class="h-full w-full" />
+						</a>
+						<div class="mt-2 min-w-0 flex-1">
+							{#if renamingId === tree.id}
+								<Input
+									bind:value={renameValue}
+									onblur={() => commitRename(tree.id)}
+									onkeydown={(event) => {
+										if (event.key === 'Enter') {
+											event.preventDefault();
+											void commitRename(tree.id);
+										} else if (event.key === 'Escape') {
+											renamingId = null;
+										}
+									}}
+									maxlength={80}
+									autofocus
+									class="h-7 text-sm"
+									data-testid="gallery-rename-input"
+								/>
+							{:else}
+								<button
+									type="button"
+									class="w-full truncate text-left text-sm font-medium hover:underline"
+									onclick={() => startRename(tree.id, tree.name)}
+									data-testid="gallery-card-name"
+								>
+									{tree.name}
+								</button>
+							{/if}
+							<p class="text-xs text-muted-foreground">
+								{formatRelative(new Date(tree.createdAt))}
+							</p>
+						</div>
+						<Button
+							variant="ghost"
+							size="icon"
+							class="absolute right-2 top-2 size-7 opacity-0 transition-opacity group-hover:opacity-100"
+							data-testid="gallery-delete-button"
+							onclick={(event) => {
+								event.preventDefault();
+								event.stopPropagation();
+								void confirmDelete(tree.id, tree.name);
+							}}
+							aria-label={`Delete ${tree.name}`}
+						>
+							<Trash2 class="size-4" />
+						</Button>
+					</article>
+				{/each}
+			</div>
+		{/if}
+	</svelte:boundary>
+</main>

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -14,12 +14,17 @@
 		TREE_SHAPE_OPTIONS,
 		SHAPE_DEFAULTS,
 		DEFAULT_TREE_CONFIG,
+		type TreeConfig,
 		type TreeShape,
 	} from '$lib/trees/types.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
-	import DarkModeToggle from '$lib/components/DarkModeToggle.svelte';
-	import { resolve } from '$app/paths';
+	import { getSavedTree, saveTree } from '$lib/trees/saved_trees.remote.js';
+	import { page } from '$app/state';
 	import Shuffle from '@lucide/svelte/icons/shuffle';
+	import Save from '@lucide/svelte/icons/save';
+
+	const user = $derived(page.data.user);
+	const signedIn = $derived(user !== null);
 
 	let shape = $state<TreeShape>(DEFAULT_TREE_CONFIG.shape);
 	let seed = $state(DEFAULT_TREE_CONFIG.seed);
@@ -51,11 +56,71 @@
 	let showBranches = $state(true);
 	let showTrunk = $state(true);
 
+	const currentConfig = $derived<TreeConfig>({
+		shape,
+		seed,
+		canopyPolygons,
+		trunkPolygons,
+		canopyLightColor,
+		canopyDarkColor,
+		trunkHue,
+		trunkSaturation,
+		trunkLightness,
+		lightAngle,
+		blobCount,
+		branchCount,
+		depthVariance,
+		blobSizeVariance,
+		blobCloseness,
+		trunkThickness,
+		branchThickness,
+		canopySize,
+		trunkHeight,
+		trunkBranchRatio,
+		trunkLean,
+		trunkSegments,
+		trunkCrookedness,
+		branchLength,
+		branchLengthVariance,
+	});
+
 	const branchCountDisabled = $derived(isParamDisabled(shape, 'branchCount', {}));
 	const trunkBranchRatioDisabled = $derived(isParamDisabled(shape, 'trunkBranchRatio', {}));
 	const trunkCrookednessDisabled = $derived(
 		isParamDisabled(shape, 'trunkCrookedness', { trunkSegments }),
 	);
+
+	const savedId = $derived(page.url.searchParams.get('saved'));
+	const savedTreeQuery = $derived(savedId === null ? null : getSavedTree(savedId));
+	let hydratedId = $state<string | null>(null);
+
+	function applyConfig(config: TreeConfig) {
+		shape = config.shape;
+		seed = config.seed;
+		canopyPolygons = config.canopyPolygons;
+		trunkPolygons = config.trunkPolygons;
+		canopyLightColor = config.canopyLightColor;
+		canopyDarkColor = config.canopyDarkColor;
+		trunkHue = config.trunkHue;
+		trunkSaturation = config.trunkSaturation;
+		trunkLightness = config.trunkLightness;
+		lightAngle = config.lightAngle;
+		blobCount = config.blobCount;
+		branchCount = config.branchCount;
+		depthVariance = config.depthVariance;
+		blobSizeVariance = config.blobSizeVariance;
+		blobCloseness = config.blobCloseness;
+		trunkThickness = config.trunkThickness;
+		branchThickness = config.branchThickness;
+		canopySize = config.canopySize;
+		trunkHeight = config.trunkHeight;
+		trunkBranchRatio = config.trunkBranchRatio;
+		trunkLean = config.trunkLean;
+		trunkSegments = config.trunkSegments;
+		trunkCrookedness = config.trunkCrookedness;
+		branchLength = config.branchLength;
+		branchLengthVariance = config.branchLengthVariance;
+	}
 
 	function isTreeShape(value: string): value is TreeShape {
 		return (Object.values(TREE_SHAPES) as readonly string[]).includes(value);
@@ -89,24 +154,29 @@
 	function randomizeSeed() {
 		seed = Math.floor(Math.random() * 100000);
 	}
+
+	// Hydrate state from saved tree when ?saved=id is present. Guarded by hydratedId
+	// to seed state exactly once per id — local edits are not overwritten by re-renders.
+	$effect(() => {
+		if (!savedTreeQuery) {
+			return;
+		}
+		const currentSavedId = savedId;
+		if (currentSavedId === null || hydratedId === currentSavedId) {
+			return;
+		}
+		void (async () => {
+			const data = await savedTreeQuery;
+			if (currentSavedId !== savedId) {
+				return;
+			}
+			applyConfig(data.config);
+			hydratedId = currentSavedId;
+		})();
+	});
 </script>
 
-<main class="grid h-dvh grid-rows-[auto_1fr] bg-background text-foreground">
-	<header class="border-b border-border">
-		<div class="flex items-center justify-between px-6 py-4">
-			<div class="flex items-center gap-4">
-				<h1 class="text-xl font-bold tracking-tight">Low-Poly Tree Generator</h1>
-				<a
-					href={resolve('/showcase/scene')}
-					class="text-sm text-muted-foreground underline-offset-4 hover:underline"
-				>
-					Scene View
-				</a>
-			</div>
-			<DarkModeToggle />
-		</div>
-	</header>
-
+<main class="grid h-dvh grid-rows-[1fr] bg-background text-foreground">
 	<div class="grid grid-cols-[320px_1fr] overflow-hidden xl:grid-cols-[640px_1fr]">
 		<!-- Controls -->
 		<aside class="select-none overflow-y-auto p-6">
@@ -116,6 +186,28 @@
 						<Card.Title>Shape</Card.Title>
 					</Card.Header>
 					<Card.Content class="space-y-4">
+						<form {...saveTree} class="flex flex-col gap-2">
+							<input
+								type="hidden"
+								name="config"
+								value={JSON.stringify(currentConfig)}
+							/>
+							<Button
+								type="submit"
+								disabled={!signedIn}
+								data-testid="save-tree-button"
+								class="w-full"
+							>
+								<Save class="mr-2 size-4" />
+								{signedIn ? 'Save' : 'Sign in to save'}
+							</Button>
+							{#if saveTree.result?.success}
+								<p class="text-xs text-muted-foreground" role="status">
+									Saved as {saveTree.result.name}
+								</p>
+							{/if}
+						</form>
+
 						<LabeledSelect
 							label="Tree Type"
 							options={TREE_SHAPE_OPTIONS}

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('app shell sidebar (anonymous)', () => {
+	test('renders the sidebar with navigation links and a sign-in button on /showcase', async ({
+		page,
+	}) => {
+		await page.goto('/showcase');
+
+		await expect(page.getByRole('link', { name: 'Single Editor' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Scene Editor' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Gallery' })).toBeVisible();
+		await expect(page.getByTestId('sidebar-sign-in')).toBeVisible();
+	});
+
+	test('renders the sidebar on the landing page', async ({ page }) => {
+		await page.goto('/');
+		await expect(page.getByTestId('sidebar-sign-in')).toBeVisible();
+	});
+
+	test('nav link to Gallery redirects anonymous users to /auth', async ({ page }) => {
+		await page.goto('/showcase');
+		await page.getByRole('link', { name: 'Gallery' }).click();
+		await page.waitForURL(/\/auth/);
+		await expect(page).toHaveURL(/\/auth/);
+	});
+
+	test('save button in single editor is disabled for anonymous users', async ({ page }) => {
+		await page.goto('/showcase');
+		const saveButton = page.getByTestId('save-tree-button');
+		await expect(saveButton).toBeVisible();
+		await expect(saveButton).toBeDisabled();
+		await expect(saveButton).toHaveText(/Sign in to save/i);
+	});
+});


### PR DESCRIPTION
## Description

Bundled app shell + tree persistence + gallery using **SvelteKit remote functions** (experimental) as the entire data layer.

- **Sidebar (M5)** — shadcn-svelte `sidebar-07` wraps every route. Nav: Single Editor, Scene Editor, Gallery. Footer: user avatar + name + sign-out form when authenticated, Sign in button when anon. DarkModeToggle moved into the sidebar footer.
- **Persistence (M6)** — new `saved_trees` Drizzle table (migration `0001_saved_trees.sql`) keyed on BetterAuth `user.id`. Server CRUD in `src/lib/server/saved_trees.ts`, remote functions in `src/lib/trees/saved_trees.remote.ts` (`query`/`form`/`command` with valibot). Save button in the single tree editor spreads the `saveTree` remote form; disabled + labelled "Sign in to save" for anonymous users. Auto-name format `"{Shape} #{N}"` scoped per user + per shape.
- **Gallery (M7)** — `/gallery` calls `listSavedTrees()` inside a `<svelte:boundary>` with pending/failed snippets. Thumbnails render via the existing `<LowPolyTree>`, clicking navigates to `/showcase?saved=<id>` which hydrates local `$state` via `getSavedTree`. Delete is confirmed via `window.confirm`; rename is inline-edit. Anonymous access is rejected by the remote query (401) and the boundary's `onerror` redirects to `/auth`.

## Notable implementation decisions

- **Remote functions first** — no `+page.server.ts` for gallery/save/restore; everything flows through `src/lib/trees/saved_trees.remote.ts` with single-flight `listSavedTrees().refresh()` on every mutation.
- **File naming** — added `src/lib/components/ui/**` and `src/lib/hooks/**` to the snake_case ESLint override so shadcn-generated files (e.g. `is-mobile.svelte.ts`) don't block the build.
- **`svelte/no-navigation-without-resolve`** — disabled for `src/routes/gallery/**/*.svelte` only, because the rule does not accept a dynamic `?saved=<id>` query string appended to `resolve('/showcase')`.
- **Drizzle meta** — `drizzle/meta/` is gitignored in this repo, so I hand-wrote `0001_saved_trees.sql` rather than relying on `drizzle-kit generate`. Noting as tech debt: the gitignore entry should eventually be removed so incremental migrations work out of the box.
- **ID generation** — `crypto.randomUUID()` (no new dependency); `valibot` added.
- **Experimental flags** — unchanged. `svelte.config.js` already had `kit.experimental.remoteFunctions: true` and `compilerOptions.experimental.async: true`.

## Resolves

Closes #12

## Test plan

- [x] 13 Vitest unit tests for `saved_trees` CRUD + ownership isolation + auto-name logic (mocked DB)
- [x] Full `pnpm run check:all` (prettier + oxlint + stylelint + knip + svelte-check + eslint) clean
- [x] `pnpm run test` — 236 tests passing
- [x] `pnpm run build` — Cloudflare adapter build succeeds
- [x] New Playwright sidebar spec (`tests/e2e/sidebar.spec.ts`) covering: sidebar renders on `/showcase` and `/`, nav links, anon sign-in button, anon gallery → `/auth` redirect, save button disabled for anon
- [ ] CI green (watching now)