### PR TITLE
#32 feat(auth): sign-in/sign-up pages redesign & cleanup

### DIFF
--- a/src/lib/components/app-shell/AppSidebar.svelte
+++ b/src/lib/components/app-shell/AppSidebar.svelte
@@ -14,7 +14,7 @@
 	const editorPath = resolve('/editor');
 	const galleryPath = resolve('/gallery');
 	const settingsPath = resolve('/settings');
-	const authPath = resolve('/auth');
+	const authPath = resolve('/auth/sign-in');
 	const signOutPath = resolve('/auth/sign-out');
 
 	const user = $derived(page.data.user);

--- a/src/routes/auth/+layout.svelte
+++ b/src/routes/auth/+layout.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import TreePine from '@lucide/svelte/icons/tree-pine';
+
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	const { children }: Props = $props();
+</script>
+
+<main class="bg-muted flex min-h-screen items-center justify-center px-6 py-12">
+	<div class="w-full max-w-sm space-y-6">
+		<div class="flex items-center justify-center gap-2">
+			<TreePine class="text-primary size-6" />
+			<span class="text-lg font-semibold">Low-Poly Trees</span>
+		</div>
+		{@render children()}
+	</div>
+</main>

--- a/src/routes/auth/sign-in/+page.server.ts
+++ b/src/routes/auth/sign-in/+page.server.ts
@@ -2,7 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = ({ locals }) => {
-	if (!locals.user) {
-		redirect(303, '/auth/sign-in');
+	if (locals.user) {
+		redirect(303, '/');
 	}
 };

--- a/src/routes/auth/sign-in/+page.svelte
+++ b/src/routes/auth/sign-in/+page.svelte
@@ -3,6 +3,13 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardHeader,
+	} from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { authClient } from '$lib/auth/client.js';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -17,14 +24,11 @@
 		email: 'Email',
 	} as const satisfies Record<PendingAction, string>;
 
-	let mode = $state<'sign-in' | 'sign-up'>('sign-in');
 	let errorMessage = $state<string | null>(null);
 	let pendingAction = $state<PendingAction | null>(null);
 
-	let name = $state('');
 	let email = $state('');
 	let password = $state('');
-	let confirmPassword = $state('');
 
 	async function signInWithSocial(provider: SocialProvider) {
 		errorMessage = null;
@@ -50,88 +54,52 @@
 
 	async function handleEmailSubmit() {
 		errorMessage = null;
-
-		if (mode === 'sign-up' && password !== confirmPassword) {
-			errorMessage = 'Passwords do not match.';
+		pendingAction = 'email';
+		const result = await authClient.signIn.email({ email, password });
+		if (result.error) {
+			errorMessage = result.error.message ?? 'Sign-in failed.';
+			pendingAction = null;
 			return;
 		}
-
-		pendingAction = 'email';
-
-		if (mode === 'sign-up') {
-			const result = await authClient.signUp.email({
-				email,
-				password,
-				name,
-			});
-			if (result.error) {
-				errorMessage = result.error.message ?? 'Sign-up failed.';
-				pendingAction = null;
-				return;
-			}
-		} else {
-			const result = await authClient.signIn.email({
-				email,
-				password,
-			});
-			if (result.error) {
-				errorMessage = result.error.message ?? 'Sign-in failed.';
-				pendingAction = null;
-				return;
-			}
-		}
-
 		await goto(resolve('/'));
-	}
-
-	function toggleMode() {
-		mode = mode === 'sign-in' ? 'sign-up' : 'sign-in';
-		errorMessage = null;
 	}
 </script>
 
 <svelte:head>
-	<title>{mode === 'sign-in' ? 'Sign in' : 'Sign up'}</title>
+	<title>Sign In</title>
 </svelte:head>
 
-<main
-	class="bg-background text-foreground flex min-h-screen items-center justify-center px-6 py-12"
->
-	<section class="w-full max-w-sm space-y-6">
-		<header class="space-y-2 text-center">
-			<h1 class="text-3xl font-bold tracking-tight">
-				{mode === 'sign-in' ? 'Sign in' : 'Sign up'}
-			</h1>
-			<p class="text-muted-foreground text-sm">
-				{mode === 'sign-in'
-					? 'Continue with a social account, passkey, or email.'
-					: 'Create your account to get started.'}
-			</p>
-		</header>
-
-		<!-- OAuth buttons -->
-		<div class="flex flex-col gap-3">
+<Card>
+	<CardHeader class="text-center">
+		<h1 class="text-2xl font-medium leading-normal">Sign In</h1>
+		<CardDescription>Continue with a social account, passkey, or email.</CardDescription>
+	</CardHeader>
+	<CardContent class="space-y-4">
+		<div class="flex gap-3">
 			<Button
+				class="flex-1"
 				data-testid="sign-in-google"
 				disabled={pendingAction !== null}
 				onclick={() => signInWithSocial('google')}
 			>
-				Continue with Google
+				Google
 			</Button>
 			<Button
+				class="flex-1"
 				data-testid="sign-in-github"
 				disabled={pendingAction !== null}
 				onclick={() => signInWithSocial('github')}
 			>
-				Continue with GitHub
+				GitHub
 			</Button>
 			<Button
-				data-testid="sign-in-passkey"
+				class="flex-1"
 				variant="outline"
+				data-testid="sign-in-passkey"
 				disabled={pendingAction !== null}
 				onclick={signInWithPasskey}
 			>
-				Continue with Passkey
+				Passkey
 			</Button>
 		</div>
 
@@ -141,7 +109,6 @@
 			<Separator class="flex-1" />
 		</div>
 
-		<!-- Email/password form -->
 		<form
 			class="flex flex-col gap-4"
 			onsubmit={(event) => {
@@ -149,20 +116,6 @@
 				void handleEmailSubmit();
 			}}
 		>
-			{#if mode === 'sign-up'}
-				<div class="space-y-2">
-					<Label for="name">Name</Label>
-					<Input
-						id="name"
-						data-testid="auth-name"
-						type="text"
-						placeholder="Your name"
-						required
-						bind:value={name}
-					/>
-				</div>
-			{/if}
-
 			<div class="space-y-2">
 				<Label for="email">Email</Label>
 				<Input
@@ -188,52 +141,26 @@
 				/>
 			</div>
 
-			{#if mode === 'sign-up'}
-				<div class="space-y-2">
-					<Label for="confirm-password">Confirm Password</Label>
-					<Input
-						id="confirm-password"
-						data-testid="auth-confirm-password"
-						type="password"
-						placeholder="••••••••"
-						required
-						minlength={8}
-						bind:value={confirmPassword}
-					/>
-				</div>
-			{/if}
-
 			<Button type="submit" data-testid="auth-email-submit" disabled={pendingAction !== null}>
-				{mode === 'sign-in' ? 'Sign in' : 'Sign up'}
+				Sign in
 			</Button>
 		</form>
 
 		{#if errorMessage}
-			<p role="alert" class="text-destructive text-center text-sm">{errorMessage}</p>
+			<Alert variant="destructive">
+				<AlertDescription>{errorMessage}</AlertDescription>
+			</Alert>
 		{/if}
 
 		<p class="text-muted-foreground text-center text-sm">
-			{#if mode === 'sign-in'}
-				Don't have an account?
-				<button
-					type="button"
-					class="text-foreground underline underline-offset-4 hover:text-primary"
-					data-testid="auth-toggle-mode"
-					onclick={toggleMode}
-				>
-					Sign up
-				</button>
-			{:else}
-				Already have an account?
-				<button
-					type="button"
-					class="text-foreground underline underline-offset-4 hover:text-primary"
-					data-testid="auth-toggle-mode"
-					onclick={toggleMode}
-				>
-					Sign in
-				</button>
-			{/if}
+			Don't have an account?
+			<a
+				href={resolve('/auth/sign-up')}
+				class="text-foreground underline underline-offset-4 hover:text-primary"
+				data-testid="auth-cross-link"
+			>
+				Sign up
+			</a>
 		</p>
-	</section>
-</main>
+	</CardContent>
+</Card>

--- a/src/routes/auth/sign-up/+page.server.ts
+++ b/src/routes/auth/sign-up/+page.server.ts
@@ -2,7 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = ({ locals }) => {
-	if (!locals.user) {
-		redirect(303, '/auth/sign-in');
+	if (locals.user) {
+		redirect(303, '/');
 	}
 };

--- a/src/routes/auth/sign-up/+page.svelte
+++ b/src/routes/auth/sign-up/+page.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardHeader,
+	} from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { authClient } from '$lib/auth/client.js';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+
+	type SocialProvider = 'google' | 'github';
+	type PendingAction = SocialProvider | 'email';
+
+	const PROVIDER_LABEL = {
+		google: 'Google',
+		github: 'GitHub',
+		email: 'Email',
+	} as const satisfies Record<PendingAction, string>;
+
+	let errorMessage = $state<string | null>(null);
+	let pendingAction = $state<PendingAction | null>(null);
+
+	let name = $state('');
+	let email = $state('');
+	let password = $state('');
+	let confirmPassword = $state('');
+
+	async function signInWithSocial(provider: SocialProvider) {
+		errorMessage = null;
+		pendingAction = provider;
+		const result = await authClient.signIn.social({ provider, callbackURL: resolve('/') });
+		if (result.error) {
+			errorMessage = result.error.message ?? `${PROVIDER_LABEL[provider]} sign-in failed.`;
+			pendingAction = null;
+		}
+	}
+
+	async function handleEmailSubmit() {
+		errorMessage = null;
+
+		if (password !== confirmPassword) {
+			errorMessage = 'Passwords do not match.';
+			return;
+		}
+
+		pendingAction = 'email';
+		const result = await authClient.signUp.email({ email, password, name });
+		if (result.error) {
+			errorMessage = result.error.message ?? 'Sign-up failed.';
+			pendingAction = null;
+			return;
+		}
+		await goto(resolve('/'));
+	}
+</script>
+
+<svelte:head>
+	<title>Sign Up</title>
+</svelte:head>
+
+<Card>
+	<CardHeader class="text-center">
+		<h1 class="text-2xl font-medium leading-normal">Create an account</h1>
+		<CardDescription>Create your account to get started.</CardDescription>
+	</CardHeader>
+	<CardContent class="space-y-4">
+		<div class="flex gap-3">
+			<Button
+				class="flex-1"
+				data-testid="sign-up-google"
+				disabled={pendingAction !== null}
+				onclick={() => signInWithSocial('google')}
+			>
+				Google
+			</Button>
+			<Button
+				class="flex-1"
+				data-testid="sign-up-github"
+				disabled={pendingAction !== null}
+				onclick={() => signInWithSocial('github')}
+			>
+				GitHub
+			</Button>
+		</div>
+
+		<div class="flex items-center gap-4">
+			<Separator class="flex-1" />
+			<span class="text-muted-foreground text-xs uppercase">Or continue with email</span>
+			<Separator class="flex-1" />
+		</div>
+
+		<form
+			class="flex flex-col gap-4"
+			onsubmit={(event) => {
+				event.preventDefault();
+				void handleEmailSubmit();
+			}}
+		>
+			<div class="space-y-2">
+				<Label for="name">Name</Label>
+				<Input
+					id="name"
+					data-testid="auth-name"
+					type="text"
+					placeholder="Your name"
+					required
+					bind:value={name}
+				/>
+			</div>
+
+			<div class="space-y-2">
+				<Label for="email">Email</Label>
+				<Input
+					id="email"
+					data-testid="auth-email"
+					type="email"
+					placeholder="you@example.com"
+					required
+					bind:value={email}
+				/>
+			</div>
+
+			<div class="space-y-2">
+				<Label for="password">Password</Label>
+				<Input
+					id="password"
+					data-testid="auth-password"
+					type="password"
+					placeholder="••••••••"
+					required
+					minlength={8}
+					bind:value={password}
+				/>
+			</div>
+
+			<div class="space-y-2">
+				<Label for="confirm-password">Confirm Password</Label>
+				<Input
+					id="confirm-password"
+					data-testid="auth-confirm-password"
+					type="password"
+					placeholder="••••••••"
+					required
+					minlength={8}
+					bind:value={confirmPassword}
+				/>
+			</div>
+
+			<Button type="submit" data-testid="auth-email-submit" disabled={pendingAction !== null}>
+				Sign up
+			</Button>
+		</form>
+
+		{#if errorMessage}
+			<Alert variant="destructive">
+				<AlertDescription>{errorMessage}</AlertDescription>
+			</Alert>
+		{/if}
+
+		<p class="text-muted-foreground text-center text-sm">
+			Already have an account?
+			<a
+				href={resolve('/auth/sign-in')}
+				class="text-foreground underline underline-offset-4 hover:text-primary"
+				data-testid="auth-cross-link"
+			>
+				Sign in
+			</a>
+		</p>
+	</CardContent>
+</Card>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -54,7 +54,7 @@
 			'status' in error &&
 			(error as { status: unknown }).status === 401
 		) {
-			void goto(resolve('/auth'));
+			void goto(resolve('/auth/sign-in'));
 		}
 	}
 </script>

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,38 +1,76 @@
 import { expect, test } from '@playwright/test';
 
-test.describe('/auth page', () => {
-	test('renders heading and explainer copy', async ({ page }) => {
-		await page.goto('/auth');
-		await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+test.describe('/auth/sign-in page', () => {
+	test('renders heading, description, and 3 social buttons', async ({ page }) => {
+		await page.goto('/auth/sign-in');
+		await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
 		await expect(
 			page.getByText(/Continue with a social account, passkey, or email/i),
 		).toBeVisible();
-	});
-
-	test('renders all three provider buttons', async ({ page }) => {
-		await page.goto('/auth');
 		await expect(page.getByTestId('sign-in-google')).toBeVisible();
 		await expect(page.getByTestId('sign-in-github')).toBeVisible();
 		await expect(page.getByTestId('sign-in-passkey')).toBeVisible();
-		await expect(page.getByTestId('sign-in-google')).toHaveText(/Continue with Google/);
-		await expect(page.getByTestId('sign-in-github')).toHaveText(/Continue with GitHub/);
-		await expect(page.getByTestId('sign-in-passkey')).toHaveText(/Continue with Passkey/);
 	});
 
-	test('renders email/password form with sign-in/sign-up toggle', async ({ page }) => {
-		await page.goto('/auth');
+	test('renders email and password form with submit button', async ({ page }) => {
+		await page.goto('/auth/sign-in');
 		await expect(page.getByTestId('auth-email')).toBeVisible();
 		await expect(page.getByTestId('auth-password')).toBeVisible();
 		await expect(page.getByTestId('auth-email-submit')).toBeVisible();
+	});
 
-		// Toggle to sign-up mode
-		await page.getByTestId('auth-toggle-mode').click();
-		await expect(page.getByRole('heading', { name: 'Sign up' })).toBeVisible();
+	test('has cross-link to sign-up page', async ({ page }) => {
+		await page.goto('/auth/sign-in');
+		const crossLink = page.getByTestId('auth-cross-link');
+		await expect(crossLink).toBeVisible();
+		await expect(crossLink).toHaveText(/Sign up/);
+		await crossLink.click();
+		await expect(page).toHaveURL(/\/auth\/sign-up$/);
+	});
+});
+
+test.describe('/auth/sign-up page', () => {
+	test('renders heading, description, and 2 social buttons (no passkey)', async ({ page }) => {
+		await page.goto('/auth/sign-up');
+		await expect(page.getByRole('heading', { name: 'Create an account' })).toBeVisible();
+		await expect(page.getByText(/Create your account to get started/i)).toBeVisible();
+		await expect(page.getByTestId('sign-up-google')).toBeVisible();
+		await expect(page.getByTestId('sign-up-github')).toBeVisible();
+		await expect(page.getByTestId('sign-in-passkey')).toHaveCount(0);
+	});
+
+	test('renders name, email, password, confirm password form with submit', async ({ page }) => {
+		await page.goto('/auth/sign-up');
 		await expect(page.getByTestId('auth-name')).toBeVisible();
+		await expect(page.getByTestId('auth-email')).toBeVisible();
+		await expect(page.getByTestId('auth-password')).toBeVisible();
 		await expect(page.getByTestId('auth-confirm-password')).toBeVisible();
+		await expect(page.getByTestId('auth-email-submit')).toBeVisible();
+	});
 
-		// Toggle back to sign-in mode
-		await page.getByTestId('auth-toggle-mode').click();
-		await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+	test('has cross-link to sign-in page', async ({ page }) => {
+		await page.goto('/auth/sign-up');
+		const crossLink = page.getByTestId('auth-cross-link');
+		await expect(crossLink).toBeVisible();
+		await expect(crossLink).toHaveText(/Sign in/);
+		await crossLink.click();
+		await expect(page).toHaveURL(/\/auth\/sign-in$/);
+	});
+
+	test('shows password mismatch error', async ({ page }) => {
+		await page.goto('/auth/sign-up');
+		await page.getByTestId('auth-name').fill('Test User');
+		await page.getByTestId('auth-email').fill('test@example.com');
+		await page.getByTestId('auth-password').fill('password123');
+		await page.getByTestId('auth-confirm-password').fill('differentpassword');
+		await page.getByTestId('auth-email-submit').click();
+		await expect(page.getByRole('alert')).toContainText('Passwords do not match');
+	});
+});
+
+test.describe('/auth route', () => {
+	test('old /auth route returns 404', async ({ page }) => {
+		const response = await page.goto('/auth');
+		expect(response?.status()).toBe(404);
 	});
 });


### PR DESCRIPTION
## Description
- Split single `/auth` toggle page into dedicated `/auth/sign-in` and `/auth/sign-up` routes
- Added shared auth layout with `bg-muted` background, TreePine branding, centered card
- Sign-in: Card with Google/GitHub/Passkey buttons + email/password form
- Sign-up: Card with Google/GitHub buttons + name/email/password/confirm form + mismatch validation
- Updated all auth references (AppSidebar, settings redirect, gallery redirect) to `/auth/sign-in`
- Deleted old `/auth/+page.svelte`

## Resolves
Closes #32

## Testing
- [x] 8 E2E tests covering: page rendering, cross-links, social button counts, passkey presence, password mismatch validation, old route 404
- [x] 306 unit tests pass
- [x] `check:all` passes (format + lint + typecheck + stylelint + knip)