### PR TITLE
#35 feat(scene): tree count slider + depth positioning

### DIFF
--- a/src/lib/scene/scene_config.context.svelte.ts
+++ b/src/lib/scene/scene_config.context.svelte.ts
@@ -1,0 +1,11 @@
+import { SCENE_DEFAULTS } from './scene_config.js';
+
+class SceneConfigState {
+	treeCount = $state(SCENE_DEFAULTS.treeCount);
+	depthSpread = $state(SCENE_DEFAULTS.depthSpread);
+	baseSeed = $state(SCENE_DEFAULTS.baseSeed);
+}
+
+export function createSceneConfigContext() {
+	return new SceneConfigState();
+}

--- a/src/lib/scene/scene_config.ts
+++ b/src/lib/scene/scene_config.ts
@@ -1,0 +1,45 @@
+import type { TreeShape } from '$lib/trees/types.js';
+
+/** Non-custom tree shapes eligible for random scene assignment. */
+export type SceneTreeShape = Exclude<TreeShape, 'custom'>;
+
+/** Shapes eligible for random scene assignment (excludes 'custom'). */
+export const SCENE_SHAPES: readonly SceneTreeShape[] = [
+	'oak',
+	'pine',
+	'birch',
+	'fir',
+	'maple',
+	'willow',
+] as const;
+
+export interface SceneConfig {
+	readonly treeCount: number;
+	readonly depthSpread: number;
+	readonly baseSeed: number;
+}
+
+export const SCENE_DEFAULTS: SceneConfig = {
+	treeCount: 3,
+	depthSpread: 0,
+	baseSeed: 42,
+} as const;
+
+export const SCENE_LIMITS = {
+	treeCountMin: 3,
+	treeCountMax: 100,
+	depthSpreadMin: 0,
+	depthSpreadMax: 100,
+} as const;
+
+/** A positioned tree in the scene, ready for rendering. */
+export interface SceneTreePlacement {
+	readonly shape: SceneTreeShape;
+	readonly seed: number;
+	/** Horizontal position as percentage [0, 100]. */
+	readonly x: number;
+	/** Depth position — higher y = closer to viewer (front). */
+	readonly y: number;
+	/** Scale factor derived from depth: 1.0 at front, ~0.65 at back. */
+	readonly scale: number;
+}

--- a/src/lib/scene/scene_layout.test.ts
+++ b/src/lib/scene/scene_layout.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { generateSceneLayout } from './scene_layout.js';
+import type { SceneConfig } from './scene_config.js';
+
+const BASE_CONFIG: SceneConfig = { treeCount: 10, depthSpread: 50, baseSeed: 42 };
+
+describe('generateSceneLayout', () => {
+	it('returns same output for same config (deterministic)', () => {
+		const a = generateSceneLayout(BASE_CONFIG);
+		const b = generateSceneLayout(BASE_CONFIG);
+		expect(a).toEqual(b);
+	});
+
+	it.each([3, 10, 50, 100])('returns exactly %i trees when treeCount=%i', (count) => {
+		const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: count });
+		expect(result).toHaveLength(count);
+	});
+
+	it('assigns only non-custom shapes', () => {
+		const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 30 });
+		for (const tree of result) {
+			expect(tree.shape).not.toBe('custom');
+		}
+	});
+
+	it('produces unique seeds for each tree', () => {
+		const result = generateSceneLayout(BASE_CONFIG);
+		const seeds = result.map((t) => t.seed);
+		expect(new Set(seeds).size).toBe(seeds.length);
+	});
+
+	it('keeps x positions within [0, 100]', () => {
+		const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 50 });
+		for (const tree of result) {
+			expect(tree.x).toBeGreaterThanOrEqual(0);
+			expect(tree.x).toBeLessThanOrEqual(100);
+		}
+	});
+
+	it('sorts output ascending by y (back-to-front for painter algorithm)', () => {
+		const result = generateSceneLayout(BASE_CONFIG);
+		for (let i = 1; i < result.length; i++) {
+			expect(result[i].y).toBeGreaterThanOrEqual(result[i - 1].y);
+		}
+	});
+
+	describe('depthSpread=0 (flat)', () => {
+		const flat = generateSceneLayout({ ...BASE_CONFIG, depthSpread: 0 });
+
+		it('gives all trees the same y', () => {
+			const ys = new Set(flat.map((t) => t.y));
+			expect(ys.size).toBe(1);
+		});
+
+		it('gives all trees scale 1.0', () => {
+			for (const tree of flat) {
+				expect(tree.scale).toBeCloseTo(1.0, 5);
+			}
+		});
+	});
+
+	describe('depthSpread=100 (full depth)', () => {
+		const deep = generateSceneLayout({
+			...BASE_CONFIG,
+			treeCount: 50,
+			depthSpread: 100,
+		});
+
+		it('has back trees scaled down toward 0.65', () => {
+			const minScale = Math.min(...deep.map((t) => t.scale));
+			expect(minScale).toBeGreaterThanOrEqual(0.64);
+			expect(minScale).toBeLessThanOrEqual(0.75);
+		});
+
+		it('has front trees scaled near 1.0', () => {
+			const maxScale = Math.max(...deep.map((t) => t.scale));
+			expect(maxScale).toBeGreaterThanOrEqual(0.95);
+			expect(maxScale).toBeLessThanOrEqual(1.0);
+		});
+
+		it('scales correlate with y — higher y means larger scale', () => {
+			// Compare first (back) and last (front) after sort
+			const back = deep[0];
+			const front = deep[deep.length - 1];
+			expect(front.scale).toBeGreaterThan(back.scale);
+		});
+	});
+
+	it('produces different layouts for different seeds', () => {
+		const a = generateSceneLayout({ ...BASE_CONFIG, baseSeed: 1 });
+		const b = generateSceneLayout({ ...BASE_CONFIG, baseSeed: 2 });
+		const aXs = a.map((t) => t.x);
+		const bXs = b.map((t) => t.x);
+		expect(aXs).not.toEqual(bXs);
+	});
+});

--- a/src/lib/scene/scene_layout.ts
+++ b/src/lib/scene/scene_layout.ts
@@ -1,0 +1,51 @@
+import { createPrng } from '$lib/trees/prng.js';
+import { SCENE_SHAPES, type SceneConfig, type SceneTreePlacement } from './scene_config.js';
+
+/** Minimum scale for the farthest-back trees. */
+const BACK_SCALE = 0.65;
+
+/**
+ * Generate deterministic scene tree placements from a config.
+ *
+ * Returns an array sorted ascending by y (back-to-front) for painter's
+ * algorithm rendering — DOM/SVG order matches visual depth.
+ */
+export function generateSceneLayout(config: SceneConfig): SceneTreePlacement[] {
+	const { treeCount, depthSpread, baseSeed } = config;
+	const rng = createPrng(baseSeed);
+
+	const placements: SceneTreePlacement[] = [];
+
+	for (let i = 0; i < treeCount; i++) {
+		const shape = SCENE_SHAPES[Math.floor(rng() * SCENE_SHAPES.length)];
+		const seed = baseSeed + i * 1000 + Math.floor(rng() * 999);
+		const x = rng() * 100;
+		const y = depthSpread === 0 ? 0 : rng() * depthSpread;
+
+		placements.push({ shape, seed, x, y, scale: 0 }); // scale computed after
+	}
+
+	// Derive scale from y relative to depth range
+	if (depthSpread === 0) {
+		// Flat — all trees at front, full scale
+		for (let i = 0; i < placements.length; i++) {
+			placements[i] = { ...placements[i], scale: 1 };
+		}
+	} else {
+		const maxY = Math.max(...placements.map((p) => p.y));
+		const minY = Math.min(...placements.map((p) => p.y));
+		const range = maxY - minY;
+
+		for (let i = 0; i < placements.length; i++) {
+			// normalizedDepth 0 = back (min y), 1 = front (max y)
+			const normalizedDepth = range === 0 ? 1 : (placements[i].y - minY) / range;
+			const scale = BACK_SCALE + normalizedDepth * (1 - BACK_SCALE);
+			placements[i] = { ...placements[i], scale };
+		}
+	}
+
+	// Sort ascending by y — back trees first in DOM = painted behind front trees
+	placements.sort((a, b) => a.y - b.y);
+
+	return placements;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,9 +11,13 @@
 	import { SHAPE_DEFAULTS } from '$lib/trees/types.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import { createTreeConfigContext } from '$lib/trees/tree_config.context.svelte.js';
+	import { createSceneConfigContext } from '$lib/scene/scene_config.context.svelte.js';
+	import { generateSceneLayout } from '$lib/scene/scene_layout.js';
+	import { SCENE_LIMITS } from '$lib/scene/scene_config.js';
 	import Shuffle from '@lucide/svelte/icons/shuffle';
 
 	const treeConfig = createTreeConfigContext();
+	const sceneConfig = createSceneConfigContext();
 
 	let usePerShapeDefaults = $state(false);
 	let showAnchors = $state(false);
@@ -27,15 +31,17 @@
 		}),
 	);
 
+	const scenePlacements = $derived(
+		generateSceneLayout({
+			treeCount: sceneConfig.treeCount,
+			depthSpread: sceneConfig.depthSpread,
+			baseSeed: treeConfig.current.seed,
+		}),
+	);
+
 	function randomizeSeed() {
 		treeConfig.current.seed = Math.floor(Math.random() * 100000);
 	}
-
-	const trees = [
-		{ shape: 'oak' as const, ...SHAPE_DEFAULTS.oak, seedOffset: 0 },
-		{ shape: 'pine' as const, ...SHAPE_DEFAULTS.pine, seedOffset: 1000 },
-		{ shape: 'birch' as const, ...SHAPE_DEFAULTS.birch, seedOffset: 2000 },
-	] as const;
 </script>
 
 <svelte:head>
@@ -47,38 +53,49 @@
 		<!-- Scene Preview -->
 		<div
 			data-testid="scene-canvas"
-			class="flex items-center justify-center gap-8 rounded-xl border border-border bg-muted/30 p-8"
+			class="relative overflow-hidden rounded-xl border border-border bg-muted/30"
 		>
-			{#each trees as tree (tree.shape)}
-				<div class="flex w-full max-w-[200px] flex-col items-center gap-2">
+			{#each scenePlacements as placement, index (index)}
+				{@const shapeDefaults = SHAPE_DEFAULTS[placement.shape]}
+				<div
+					data-testid="scene-tree"
+					class="absolute bottom-0"
+					style="
+						left: {placement.x}%;
+						bottom: {placement.y}%;
+						transform: scale({placement.scale}) translateX(-50%);
+						transform-origin: bottom center;
+						width: {160 * placement.scale}px;
+					"
+				>
 					<LowPolyTree
 						config={{
 							...treeConfig.current,
-							shape: tree.shape,
-							seed: treeConfig.current.seed + tree.seedOffset,
-							blobCount: tree.blobCount,
-							branchCount: tree.branchCount,
-							blobSizeVariance: tree.blobSizeVariance,
-							blobCloseness: tree.blobCloseness,
-							branchThickness: tree.branchThickness,
-							trunkSegments: tree.trunkSegments,
-							trunkCrookedness: tree.trunkCrookedness,
-							branchLength: tree.branchLength,
-							branchLengthVariance: tree.branchLengthVariance,
+							shape: placement.shape,
+							seed: placement.seed,
+							blobCount: shapeDefaults.blobCount,
+							branchCount: shapeDefaults.branchCount,
+							blobSizeVariance: shapeDefaults.blobSizeVariance,
+							blobCloseness: shapeDefaults.blobCloseness,
+							branchThickness: shapeDefaults.branchThickness,
+							trunkSegments: shapeDefaults.trunkSegments,
+							trunkCrookedness: shapeDefaults.trunkCrookedness,
+							branchLength: shapeDefaults.branchLength,
+							branchLengthVariance: shapeDefaults.branchLengthVariance,
 							canopyLightColor: usePerShapeDefaults
-								? tree.canopyLightColor
+								? shapeDefaults.canopyLightColor
 								: treeConfig.current.canopyLightColor,
 							canopyDarkColor: usePerShapeDefaults
-								? tree.canopyDarkColor
+								? shapeDefaults.canopyDarkColor
 								: treeConfig.current.canopyDarkColor,
 							trunkHue: usePerShapeDefaults
-								? tree.trunkHue
+								? shapeDefaults.trunkHue
 								: treeConfig.current.trunkHue,
 							trunkSaturation: usePerShapeDefaults
-								? tree.trunkSaturation
+								? shapeDefaults.trunkSaturation
 								: treeConfig.current.trunkSaturation,
 							trunkLightness: usePerShapeDefaults
-								? tree.trunkLightness
+								? shapeDefaults.trunkLightness
 								: treeConfig.current.trunkLightness,
 						}}
 						{showCanopy}
@@ -87,9 +104,6 @@
 						{showAnchors}
 						class="h-auto w-full"
 					/>
-					<span class="text-sm font-medium capitalize text-muted-foreground">
-						{tree.shape}
-					</span>
 				</div>
 			{/each}
 		</div>
@@ -98,6 +112,20 @@
 		<aside data-testid="scene-controls" class="select-none overflow-y-auto p-6">
 			<div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
 				<SectionCard title="Scene Settings" contentClass="space-y-4">
+					<LabeledRangeSlider
+						label="Tree Count"
+						min={SCENE_LIMITS.treeCountMin}
+						max={SCENE_LIMITS.treeCountMax}
+						bind:value={sceneConfig.treeCount}
+						id="tree-count"
+					/>
+					<LabeledRangeSlider
+						label="Depth Spread"
+						min={SCENE_LIMITS.depthSpreadMin}
+						max={SCENE_LIMITS.depthSpreadMax}
+						bind:value={sceneConfig.depthSpread}
+						id="depth-spread"
+					/>
 					<div class="space-y-2">
 						<Label>Base Seed</Label>
 						<div class="flex gap-2">

--- a/tests/e2e/scene_depth.spec.ts
+++ b/tests/e2e/scene_depth.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Scene: tree count slider + depth positioning (#35)', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+	});
+
+	test('tree count slider defaults to 3 and renders 3 trees', async ({ page }) => {
+		const slider = page.locator('#tree-count');
+		await expect(slider).toBeVisible();
+		await expect(slider).toHaveValue('3');
+
+		const trees = page.locator('[data-testid="scene-tree"]');
+		await expect(trees).toHaveCount(3);
+	});
+
+	test('changing tree count slider updates rendered tree count', async ({ page }) => {
+		const slider = page.locator('#tree-count');
+		await slider.fill('10');
+		await slider.dispatchEvent('input');
+
+		const trees = page.locator('[data-testid="scene-tree"]');
+		await expect(trees).toHaveCount(10);
+	});
+
+	test('depth spread slider exists and defaults to 0', async ({ page }) => {
+		const slider = page.locator('#depth-spread');
+		await expect(slider).toBeVisible();
+		await expect(slider).toHaveValue('0');
+	});
+
+	test('deterministic — same seed produces same tree positions on reload', async ({ page }) => {
+		const slider = page.locator('#tree-count');
+		await slider.fill('5');
+		await slider.dispatchEvent('input');
+
+		const getPositions = async () => {
+			const trees = page.locator('[data-testid="scene-tree"]');
+			const count = await trees.count();
+			const positions: string[] = [];
+			for (let i = 0; i < count; i++) {
+				const style = await trees.nth(i).getAttribute('style');
+				positions.push(style ?? '');
+			}
+			return positions;
+		};
+
+		const firstLoad = await getPositions();
+
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+
+		// After reload, set tree count to 5 again
+		const sliderReloaded = page.locator('#tree-count');
+		await sliderReloaded.fill('5');
+		await sliderReloaded.dispatchEvent('input');
+
+		const secondLoad = await getPositions();
+		expect(firstLoad).toEqual(secondLoad);
+	});
+});


### PR DESCRIPTION
## Description
- Add tree count slider (3–100) with random shape and seed per tree
- Add depth spread slider (0–100) with painter's algorithm back-to-front ordering
- Back trees scale to ~65% of front trees via linear interpolation
- Deterministic layout using seeded PRNG — same seed = same scene

## Resolves
Closes #35

## Testing
- [x] 15 unit tests for `generateSceneLayout()` (determinism, count, depth scaling, sort order, shapes, seeds, x bounds)
- [x] 4 E2E tests (slider defaults, count update, depth spread, determinism on reload)
- [x] `check:all` passes (format, lint, typecheck, stylelint, knip)