### PR TITLE
#36 feat(anchors): dynamic anchor computation

### DIFF
--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -83,8 +83,8 @@
 	{#if showAnchors}
 		<g class="anchors-group">
 			<circle
-				cx={geometry.anchors.trunkBottom.x}
-				cy={geometry.anchors.trunkBottom.y}
+				cx={geometry.anchors.trunkBase.x}
+				cy={geometry.anchors.trunkBase.y}
 				r="4"
 				fill="#ef4444"
 				stroke="white"
@@ -107,13 +107,49 @@
 				stroke-width="1"
 			/>
 			<circle
-				cx={geometry.anchors.canopyCenter.x}
-				cy={geometry.anchors.canopyCenter.y}
+				cx={geometry.anchors.crownCenter.x}
+				cy={geometry.anchors.crownCenter.y}
 				r="4"
 				fill="#22c55e"
 				stroke="white"
 				stroke-width="1"
 			/>
+			<circle
+				cx={geometry.anchors.crownTop.x}
+				cy={geometry.anchors.crownTop.y}
+				r="4"
+				fill="#06b6d4"
+				stroke="white"
+				stroke-width="1"
+			/>
+			<circle
+				cx={geometry.anchors.roots.x}
+				cy={geometry.anchors.roots.y}
+				r="4"
+				fill="#a855f7"
+				stroke="white"
+				stroke-width="1"
+			/>
+			{#each geometry.anchors.branchTips as tip (tip)}
+				<circle
+					cx={tip.x}
+					cy={tip.y}
+					r="3"
+					fill="#f43f5e"
+					stroke="white"
+					stroke-width="0.5"
+				/>
+			{/each}
+			{#each geometry.anchors.fruitSlots as slot (slot)}
+				<circle
+					cx={slot.x}
+					cy={slot.y}
+					r="3"
+					fill="#10b981"
+					stroke="white"
+					stroke-width="0.5"
+				/>
+			{/each}
 		</g>
 	{/if}
 </svg>

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -161,7 +161,7 @@ describe('REQ-C: Canopy Generation', () => {
 	describe('REQ-C-01: blob centering on trunk axis', () => {
 		it('canopy centroid stays within 5px of trunk axis for single-blob oak', () => {
 			const geo = generateTree(makeConfig({ blobCount: 1, shape: 'oak' }));
-			const center = geo.anchors.canopyCenter;
+			const center = geo.anchors.crownCenter;
 			expect(Math.abs(center.x - VIEWBOX_WIDTH / 2)).toBeLessThan(5);
 		});
 	});
@@ -299,7 +299,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 	describe('REQ-T-02: trunk tapers linearly', () => {
 		it('bottom half of trunk vertices spans wider x-range than top half', () => {
 			const geo = generateTree(makeConfig({ seed: 1 }));
-			const midY = (geo.anchors.trunkTop.y + geo.anchors.trunkBottom.y) / 2;
+			const midY = (geo.anchors.trunkTop.y + geo.anchors.trunkBase.y) / 2;
 			const topXs = geo.trunkTriangles.flatMap((t) =>
 				t.points.filter((p) => p.y < midY).map((p) => p.x),
 			);
@@ -331,8 +331,8 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 		it('trunkHeight 30 produces shorter trunk than 150', () => {
 			const geoShort = generateTree(makeConfig({ trunkHeight: 30, seed: 42 }));
 			const geoTall = generateTree(makeConfig({ trunkHeight: 150, seed: 42 }));
-			const shortHeight = geoShort.anchors.trunkBottom.y - geoShort.anchors.trunkTop.y;
-			const tallHeight = geoTall.anchors.trunkBottom.y - geoTall.anchors.trunkTop.y;
+			const shortHeight = geoShort.anchors.trunkBase.y - geoShort.anchors.trunkTop.y;
+			const tallHeight = geoTall.anchors.trunkBase.y - geoTall.anchors.trunkTop.y;
 			expect(tallHeight).toBeGreaterThan(shortHeight);
 		});
 	});
@@ -343,7 +343,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 		it('oak canopy centroid shifts down by 75 when trunkHeight drops 100 → 50', () => {
 			const base = generateTree(makeConfig({ trunkHeight: 100, seed: 42 }));
 			const shortTrunk = generateTree(makeConfig({ trunkHeight: 50, seed: 42 }));
-			const shift = shortTrunk.anchors.canopyCenter.y - base.anchors.canopyCenter.y;
+			const shift = shortTrunk.anchors.crownCenter.y - base.anchors.crownCenter.y;
 			expect(shift).toBeCloseTo(75, 5);
 		});
 
@@ -354,7 +354,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 			const shortTrunk = generateTree(
 				makeConfig({ trunkHeight: 50, seed: 42, shape: 'pine' }),
 			);
-			const shift = shortTrunk.anchors.canopyCenter.y - base.anchors.canopyCenter.y;
+			const shift = shortTrunk.anchors.crownCenter.y - base.anchors.crownCenter.y;
 			expect(shift).toBeCloseTo(60, 5);
 		});
 
@@ -362,7 +362,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 		it('oak canopy shift equals trunkTop shift between trunkHeight 100 and 50', () => {
 			const base = generateTree(makeConfig({ trunkHeight: 100, seed: 42 }));
 			const shortTrunk = generateTree(makeConfig({ trunkHeight: 50, seed: 42 }));
-			const canopyShift = shortTrunk.anchors.canopyCenter.y - base.anchors.canopyCenter.y;
+			const canopyShift = shortTrunk.anchors.crownCenter.y - base.anchors.crownCenter.y;
 			const trunkShift = shortTrunk.anchors.trunkTop.y - base.anchors.trunkTop.y;
 			expect(canopyShift).toBeCloseTo(trunkShift, 5);
 		});
@@ -409,8 +409,8 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 			const { min, max } = extremeYVertices(geo.branchTriangles);
 			const branchAxis = { dx: min.x - max.x, dy: min.y - max.y };
 			const trunkAxis = {
-				dx: geo.anchors.trunkTop.x - geo.anchors.trunkBottom.x,
-				dy: geo.anchors.trunkTop.y - geo.anchors.trunkBottom.y,
+				dx: geo.anchors.trunkTop.x - geo.anchors.trunkBase.x,
+				dy: geo.anchors.trunkTop.y - geo.anchors.trunkBase.y,
 			};
 			const dot = branchAxis.dx * trunkAxis.dx + branchAxis.dy * trunkAxis.dy;
 			const magB = Math.hypot(branchAxis.dx, branchAxis.dy);
@@ -504,7 +504,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 		it('trunkLean=0 produces perfectly vertical trunk axis (no jitter)', () => {
 			const geo = generateTree(makeConfig({ trunkLean: 0, trunkSegments: 1 }));
 			expect(geo.anchors.trunkTop.x).toBeCloseTo(VIEWBOX_WIDTH / 2, 10);
-			expect(geo.anchors.trunkBottom.x).toBeCloseTo(VIEWBOX_WIDTH / 2, 10);
+			expect(geo.anchors.trunkBase.x).toBeCloseTo(VIEWBOX_WIDTH / 2, 10);
 		});
 
 		it('trunkLean=0 is deterministic across different seeds (no hidden random)', () => {
@@ -519,20 +519,20 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 			const geo = generateTree(
 				makeConfig({ trunkLean: leanDeg, trunkSegments: 1, seed: 42 }),
 			);
-			const trunkHeight = geo.anchors.trunkBottom.y - geo.anchors.trunkTop.y;
+			const trunkHeight = geo.anchors.trunkBase.y - geo.anchors.trunkTop.y;
 			const expectedLeanPx = Math.tan((leanDeg * Math.PI) / 180) * trunkHeight;
-			const actualLeanPx = geo.anchors.trunkTop.x - geo.anchors.trunkBottom.x;
+			const actualLeanPx = geo.anchors.trunkTop.x - geo.anchors.trunkBase.x;
 			expect(actualLeanPx).toBeCloseTo(expectedLeanPx, 5);
 		});
 
 		it('positive lean shifts trunkTop to the right of the base', () => {
 			const geo = generateTree(makeConfig({ trunkLean: 45, trunkSegments: 1 }));
-			expect(geo.anchors.trunkTop.x).toBeGreaterThan(geo.anchors.trunkBottom.x);
+			expect(geo.anchors.trunkTop.x).toBeGreaterThan(geo.anchors.trunkBase.x);
 		});
 
 		it('negative lean shifts trunkTop to the left of the base', () => {
 			const geo = generateTree(makeConfig({ trunkLean: -45, trunkSegments: 1 }));
-			expect(geo.anchors.trunkTop.x).toBeLessThan(geo.anchors.trunkBottom.x);
+			expect(geo.anchors.trunkTop.x).toBeLessThan(geo.anchors.trunkBase.x);
 		});
 	});
 
@@ -600,7 +600,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 					seed: 42,
 				}),
 			);
-			const canopyShiftX = leaned.anchors.canopyCenter.x - base.anchors.canopyCenter.x;
+			const canopyShiftX = leaned.anchors.crownCenter.x - base.anchors.crownCenter.x;
 			const trunkTopShiftX = leaned.anchors.trunkTop.x - base.anchors.trunkTop.x;
 			expect(canopyShiftX).toBeCloseTo(trunkTopShiftX, 5);
 		});
@@ -619,7 +619,7 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 			for (const tri of geo.trunkTriangles) {
 				for (const p of tri.points) {
 					expect(p.y).toBeGreaterThanOrEqual(geo.anchors.trunkTop.y - 3);
-					expect(p.y).toBeLessThanOrEqual(geo.anchors.trunkBottom.y + 3);
+					expect(p.y).toBeLessThanOrEqual(geo.anchors.trunkBase.y + 3);
 				}
 			}
 		});
@@ -764,23 +764,123 @@ describe('REQ-O: Output', () => {
 	});
 
 	describe('REQ-O-02: TreeAnchors', () => {
-		it('exposes four anchor points', () => {
+		it('B1: exposes all anchor fields with correct types', () => {
 			const geo = generateTree(makeConfig());
-			expect(geo.anchors).toHaveProperty('trunkTop');
-			expect(geo.anchors).toHaveProperty('trunkMiddle');
-			expect(geo.anchors).toHaveProperty('trunkBottom');
-			expect(geo.anchors).toHaveProperty('canopyCenter');
-			for (const key of ['trunkTop', 'trunkMiddle', 'trunkBottom', 'canopyCenter'] as const) {
+			for (const key of [
+				'trunkTop',
+				'trunkMiddle',
+				'trunkBase',
+				'crownCenter',
+				'crownTop',
+				'roots',
+			] as const) {
 				expect(typeof geo.anchors[key].x).toBe('number');
 				expect(typeof geo.anchors[key].y).toBe('number');
 			}
+			expect(Array.isArray(geo.anchors.branchTips)).toBe(true);
+			expect(Array.isArray(geo.anchors.fruitSlots)).toBe(true);
 		});
 
-		it('trunkMiddle is between trunkTop and trunkBottom', () => {
+		it('B2: crownCenter is center of canopy bounding box', () => {
+			const geo = generateTree(makeConfig({ shape: 'oak' }));
+			expect(typeof geo.anchors.crownCenter.x).toBe('number');
+			expect(typeof geo.anchors.crownCenter.y).toBe('number');
+		});
+
+		it('B3: crownTop is above crownCenter', () => {
+			const geo = generateTree(makeConfig({ shape: 'oak' }));
+			expect(geo.anchors.crownTop.y).toBeLessThan(geo.anchors.crownCenter.y);
+		});
+
+		it('B4: trunkBase is at ground level (below trunkTop and trunkMiddle)', () => {
 			const geo = generateTree(makeConfig());
-			const midY = geo.anchors.trunkMiddle.y;
-			expect(midY).toBeGreaterThan(geo.anchors.trunkTop.y);
-			expect(midY).toBeLessThan(geo.anchors.trunkBottom.y);
+			expect(geo.anchors.trunkBase.y).toBeGreaterThan(geo.anchors.trunkTop.y);
+			expect(geo.anchors.trunkBase.y).toBeGreaterThan(geo.anchors.trunkMiddle.y);
+		});
+
+		it('B5: roots is below trunkBase with same x', () => {
+			const geo = generateTree(makeConfig());
+			expect(geo.anchors.roots.y).toBeGreaterThan(geo.anchors.trunkBase.y);
+			expect(geo.anchors.roots.x).toBe(geo.anchors.trunkBase.x);
+		});
+
+		it('B6: branchTips has one tip per generated branch', () => {
+			const geo = generateTree(makeConfig({ shape: 'oak', branchCount: 3, seed: 42 }));
+			// Branch count is a target — generation may reject some due to overlap.
+			// branchTips must still be > 0 and each must be a valid Point2D.
+			expect(geo.anchors.branchTips.length).toBeGreaterThan(0);
+			// Verify branchTriangles exist iff branchTips exist
+			expect(geo.branchTriangles.length).toBeGreaterThan(0);
+			for (const tip of geo.anchors.branchTips) {
+				expect(typeof tip.x).toBe('number');
+				expect(typeof tip.y).toBe('number');
+			}
+		});
+
+		it('B6b: branchTips is empty when branchCount is 0', () => {
+			const geo = generateTree(makeConfig({ shape: 'birch', branchCount: 0, seed: 42 }));
+			expect(Array.isArray(geo.anchors.branchTips)).toBe(true);
+		});
+
+		it('B7: branchTips is empty for pine shape', () => {
+			const geo = generateTree(makeConfig({ shape: 'pine', seed: 42 }));
+			expect(geo.anchors.branchTips).toHaveLength(0);
+		});
+
+		it('B8: fruitSlots has 5-7 positions', () => {
+			const geo = generateTree(makeConfig({ shape: 'oak', seed: 42 }));
+			expect(geo.anchors.fruitSlots.length).toBeGreaterThanOrEqual(5);
+			expect(geo.anchors.fruitSlots.length).toBeLessThanOrEqual(7);
+		});
+
+		it('B9: fruitSlots are within canopy bounding area', () => {
+			// Fruit slots are Poisson-sampled inside the pre-triangulation blob
+			// ellipses, which extend slightly beyond triangulated mesh vertices.
+			// Use a generous margin (10 px) to account for the ellipse-to-mesh gap.
+			const geo = generateTree(makeConfig({ shape: 'oak', seed: 42 }));
+			const allCanopyVertices = geo.canopyBlobs.flatMap((b) =>
+				b.triangles.flatMap((t) => t.points),
+			);
+			const margin = 10;
+			const minX = Math.min(...allCanopyVertices.map((p) => p.x));
+			const maxX = Math.max(...allCanopyVertices.map((p) => p.x));
+			const minY = Math.min(...allCanopyVertices.map((p) => p.y));
+			const maxY = Math.max(...allCanopyVertices.map((p) => p.y));
+			for (const slot of geo.anchors.fruitSlots) {
+				expect(slot.x).toBeGreaterThanOrEqual(minX - margin);
+				expect(slot.x).toBeLessThanOrEqual(maxX + margin);
+				expect(slot.y).toBeGreaterThanOrEqual(minY - margin);
+				expect(slot.y).toBeLessThanOrEqual(maxY + margin);
+			}
+		});
+
+		it('B10: fruitSlots are deterministic — same seed same positions', () => {
+			const geo1 = generateTree(makeConfig({ shape: 'oak', seed: 42 }));
+			const geo2 = generateTree(makeConfig({ shape: 'oak', seed: 42 }));
+			expect(geo1.anchors.fruitSlots).toEqual(geo2.anchors.fruitSlots);
+		});
+
+		it('B11: fruitSlots differ between different seeds', () => {
+			const geo1 = generateTree(makeConfig({ shape: 'oak', seed: 42 }));
+			const geo2 = generateTree(makeConfig({ shape: 'oak', seed: 99 }));
+			const same = geo1.anchors.fruitSlots.every(
+				(s, i) =>
+					s.x === geo2.anchors.fruitSlots[i]?.x && s.y === geo2.anchors.fruitSlots[i]?.y,
+			);
+			expect(same).toBe(false);
+		});
+
+		it('B12: trunkMiddle is between trunkTop and trunkBase', () => {
+			const geo = generateTree(makeConfig());
+			expect(geo.anchors.trunkMiddle.y).toBeGreaterThan(geo.anchors.trunkTop.y);
+			expect(geo.anchors.trunkMiddle.y).toBeLessThan(geo.anchors.trunkBase.y);
+		});
+
+		it('B13: pine trees have valid crownTop and fruitSlots', () => {
+			const geo = generateTree(makeConfig({ shape: 'pine', seed: 42 }));
+			expect(geo.anchors.crownTop.y).toBeLessThan(geo.anchors.crownCenter.y);
+			expect(geo.anchors.fruitSlots.length).toBeGreaterThanOrEqual(5);
+			expect(geo.anchors.fruitSlots.length).toBeLessThanOrEqual(7);
 		});
 	});
 });

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -16,6 +16,7 @@ import {
 	computeEffectiveTrunkTop,
 	isPointInTrunkPath,
 	isPointInBranch,
+	isPointInBlobs,
 	generateBranches,
 	getBlobsBounds,
 	sampleTierBoundary,
@@ -119,9 +120,17 @@ function computeTrunkXBounds(
 	};
 }
 
+const ROOTS_DEPTH_PX = 15;
+const FRUIT_SLOTS_SEED_OFFSET = 54321;
+
 function computeAnchors(
 	trunkJunctions: readonly Point2D[],
 	canopyBounds: { minX: number; minY: number; maxX: number; maxY: number },
+	allBranches: readonly BranchSegment[],
+	canopyBlobs: readonly BlobGeometry[],
+	blobs: readonly Blob[],
+	tiers: readonly Tier[],
+	seed: number,
 ): TreeAnchors {
 	const baseJunction = trunkJunctions[0]!;
 	const topJunction = trunkJunctions[trunkJunctions.length - 1]!;
@@ -129,17 +138,69 @@ function computeAnchors(
 	// so it remains visually meaningful for multi-segment crooked trunks.
 	const midY = (baseJunction.y + topJunction.y) / 2;
 
+	const crownCenter: Point2D = {
+		x: (canopyBounds.minX + canopyBounds.maxX) / 2,
+		y: (canopyBounds.minY + canopyBounds.maxY) / 2,
+	};
+
+	// crownTop: vertex with minimum y across all canopy triangles
+	let crownTopY = Infinity;
+	let crownTopX = crownCenter.x;
+	for (const blob of canopyBlobs) {
+		for (const tri of blob.triangles) {
+			for (const p of tri.points) {
+				if (p.y < crownTopY) {
+					crownTopY = p.y;
+					crownTopX = p.x;
+				}
+			}
+		}
+	}
+	const crownTop: Point2D =
+		crownTopY < Infinity
+			? { x: crownTopX, y: crownTopY }
+			: { x: crownCenter.x, y: canopyBounds.minY };
+
+	// branchTips: endpoint of each branch
+	const branchTips: Point2D[] = allBranches.map((b) => ({ x: b.x2, y: b.y2 }));
+
+	// fruitSlots: 5-7 Poisson-sampled points within canopy
+	const fruitRng = createPrng(seed + FRUIT_SLOTS_SEED_OFFSET);
+	const fruitCount = 5 + Math.floor(fruitRng() * 3);
+	const boundsArea =
+		(canopyBounds.maxX - canopyBounds.minX) * (canopyBounds.maxY - canopyBounds.minY);
+	const minDistance = Math.max(3, Math.sqrt(boundsArea / fruitCount) * 0.6);
+
+	let containmentTest: (x: number, y: number) => boolean;
+	if (blobs.length > 0) {
+		containmentTest = (x, y) => isPointInBlobs(x, y, blobs);
+	} else if (tiers.length > 0) {
+		containmentTest = (x, y) => tiers.some((t) => isPointInTier(x, y, t));
+	} else {
+		// Zero-blob custom trees degenerate bounds → poissonSample produces ≤1 point
+		containmentTest = () => true;
+	}
+
+	const fruitSlots = poissonSample(
+		fruitRng,
+		fruitCount,
+		canopyBounds,
+		containmentTest,
+		minDistance,
+	);
+
 	return {
 		trunkTop: topJunction,
 		trunkMiddle: {
 			x: sampleTrunkCenterX(trunkJunctions, midY),
 			y: midY,
 		},
-		trunkBottom: baseJunction,
-		canopyCenter: {
-			x: (canopyBounds.minX + canopyBounds.maxX) / 2,
-			y: (canopyBounds.minY + canopyBounds.maxY) / 2,
-		},
+		trunkBase: baseJunction,
+		crownCenter,
+		crownTop,
+		roots: { x: baseJunction.x, y: baseJunction.y + ROOTS_DEPTH_PX },
+		branchTips,
+		fruitSlots,
 	};
 }
 
@@ -660,7 +721,15 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 		? generateTierCanopy(rng, tiers, config.canopyPolygons, config)
 		: generateBlobCanopy(rng, blobs, config.canopyPolygons, smoothAcuteAngles, config);
 
-	const anchors = computeAnchors(trunkJunctions, canopyBounds);
+	const anchors = computeAnchors(
+		trunkJunctions,
+		canopyBounds,
+		allBranches,
+		canopyBlobs,
+		blobs,
+		tiers,
+		config.seed,
+	);
 
 	return {
 		trunkTriangles,

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -19,6 +19,7 @@ export {
 
 export {
 	getBlobsBounds,
+	isPointInBlobs,
 	isPointInBranch,
 	sampleTierBoundary,
 	validateNoFloatingBlobs,

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -20,8 +20,12 @@ export interface Triangle {
 export interface TreeAnchors {
 	readonly trunkTop: Point2D;
 	readonly trunkMiddle: Point2D;
-	readonly trunkBottom: Point2D;
-	readonly canopyCenter: Point2D;
+	readonly trunkBase: Point2D;
+	readonly crownCenter: Point2D;
+	readonly crownTop: Point2D;
+	readonly roots: Point2D;
+	readonly branchTips: readonly Point2D[];
+	readonly fruitSlots: readonly Point2D[];
 }
 
 export interface Tier {


### PR DESCRIPTION
## Description
- Replace hardcoded anchors with dynamically computed anchors derived from actual generated geometry
- Add scalar anchors: `crownCenter`, `crownTop`, `trunkBase`, `roots` (rename `trunkBottom`→`trunkBase`, `canopyCenter`→`crownCenter`)
- Add array anchors: `branchTips[]` (branch endpoints), `fruitSlots[]` (5-7 Poisson-sampled canopy positions)
- Update `showAnchors` visualization with all new anchor types
- `fruitSlots` are deterministic per seed and use blob/tier containment for accurate placement

## Resolves
Closes #36

## Testing
- [x] 14 new unit tests for all V1 anchor behaviors (B1-B13 + B6b)
- [x] 333 total unit tests passing
- [x] Migrated ~40 existing test references to new anchor names
- [x] Static checks clean (format, lint, typecheck, stylelint, knip)
- [x] E2E: 48/49 pass (1 pre-existing auth flake unrelated to anchors)