### PR TITLE
#40 feat(tools): decorative tool accessories + idle animations

### DIFF
--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -11,6 +11,12 @@
 		computeBranchDuration,
 		computeBranchDelay,
 	} from '$lib/trees/animation.js';
+	import TreeTool from '$lib/trees/TreeTool.svelte';
+	import {
+		TOOL_TYPES,
+		TOOL_ANCHOR_MAP,
+		type ToolVisibility,
+	} from '$lib/trees/tools/tool_types.js';
 
 	interface Props {
 		config?: TreeConfig;
@@ -22,6 +28,8 @@
 		animateCanopySway?: boolean;
 		animateBranches?: boolean;
 		animateGrowth?: boolean;
+		toolVisibility?: ToolVisibility;
+		animateTools?: boolean;
 		class?: string;
 		onanchors?: (anchors: TreeAnchors) => void;
 	}
@@ -36,6 +44,8 @@
 		animateCanopySway = false,
 		animateBranches = false,
 		animateGrowth = false,
+		toolVisibility,
+		animateTools = false,
 		class: className = '',
 		onanchors,
 	}: Props = $props();
@@ -157,6 +167,21 @@
 						stroke={tri.color}
 						stroke-width="0.5"
 					/>
+				{/each}
+			</g>
+		{/if}
+
+		{#if toolVisibility}
+			<g class="tools-group">
+				{#each Object.values(TOOL_TYPES) as toolType (toolType)}
+					{#if toolVisibility[toolType].visible}
+						<TreeTool
+							tool={toolType}
+							anchor={geometry.anchors[TOOL_ANCHOR_MAP[toolType]]}
+							size={toolVisibility[toolType].size}
+							animate={animateTools}
+						/>
+					{/if}
 				{/each}
 			</g>
 		{/if}

--- a/src/lib/trees/TreeTool.svelte
+++ b/src/lib/trees/TreeTool.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	import type { Point2D } from '$lib/trees/types/core.js';
+	import { TOOL_SVG_DATA } from '$lib/trees/tools/tool_svg_data.js';
+	import { TOOL_ANIMATIONS } from '$lib/trees/tools/tool_animations.js';
+	import type { ToolType } from '$lib/trees/tools/tool_types.js';
+
+	interface Props {
+		tool: ToolType;
+		anchor: Point2D;
+		size: number;
+		animate: boolean;
+	}
+
+	let { tool, anchor, size, animate }: Props = $props();
+
+	const svgData = $derived(TOOL_SVG_DATA[tool]);
+	const animationConfig = $derived(TOOL_ANIMATIONS[tool]);
+
+	const cssClass = $derived(
+		tool === 'wateringCan'
+			? 'tool-watering-can'
+			: tool === 'birdNest'
+				? 'tool-bird-nest'
+				: `tool-${tool}`,
+	);
+</script>
+
+<!-- Outer <g> for positioning (translate + scale) — not animated -->
+<g data-tool={tool} transform="translate({anchor.x}, {anchor.y}) scale({size})">
+	<!-- Inner <g> for CSS animation — does not affect positioning -->
+	<g
+		class="tool-anim {cssClass}"
+		class:animate-tool={animate}
+		style="--tool-duration: {animationConfig.duration}s;"
+	>
+		{#each svgData.polygons as polygon (polygon)}
+			<polygon
+				points={polygon.points}
+				fill={polygon.fill}
+				stroke={polygon.fill}
+				stroke-width="0.3"
+			/>
+		{/each}
+	</g>
+</g>
+
+<style>
+	@keyframes tool-shovel-idle {
+		0%,
+		100% {
+			transform: translateY(0);
+		}
+
+		50% {
+			transform: translateY(-3px);
+		}
+	}
+
+	@keyframes tool-ladder-idle {
+		0%,
+		100% {
+			transform: rotate(0deg);
+		}
+
+		25% {
+			transform: rotate(2deg);
+		}
+
+		75% {
+			transform: rotate(-2deg);
+		}
+	}
+
+	@keyframes tool-watering-can-idle {
+		0%,
+		100% {
+			transform: rotate(0deg);
+		}
+
+		20% {
+			transform: rotate(5deg);
+		}
+
+		50% {
+			transform: rotate(12deg);
+		}
+
+		70% {
+			transform: rotate(15deg);
+		}
+
+		85% {
+			transform: rotate(8deg);
+		}
+	}
+
+	@keyframes tool-bird-nest-idle {
+		0%,
+		100% {
+			transform: translateY(0);
+		}
+
+		50% {
+			transform: translateY(-2px);
+		}
+	}
+
+	.tool-anim.animate-tool {
+		animation: var(--tool-animation-name) var(--tool-duration) ease-in-out infinite;
+		will-change: transform;
+	}
+
+	.tool-shovel.animate-tool {
+		--tool-animation-name: tool-shovel-idle;
+	}
+
+	.tool-ladder.animate-tool {
+		--tool-animation-name: tool-ladder-idle;
+	}
+
+	.tool-watering-can.animate-tool {
+		--tool-animation-name: tool-watering-can-idle;
+	}
+
+	.tool-bird-nest.animate-tool {
+		--tool-animation-name: tool-bird-nest-idle;
+	}
+</style>

--- a/src/lib/trees/tools/tool_animations.test.ts
+++ b/src/lib/trees/tools/tool_animations.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { TOOL_ANIMATIONS } from './tool_animations.js';
+import { TOOL_TYPES } from './tool_types.js';
+
+describe('TOOL_ANIMATIONS', () => {
+	it('has animation config for all 4 tool types', () => {
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(TOOL_ANIMATIONS).toHaveProperty(toolType);
+		}
+	});
+
+	it('each tool has a unique keyframe name', () => {
+		const names = Object.values(TOOL_ANIMATIONS).map((a) => a.keyframeName);
+		expect(new Set(names).size).toBe(names.length);
+	});
+
+	it('shovel duration is 2s', () => {
+		expect(TOOL_ANIMATIONS.shovel.duration).toBe(2);
+	});
+
+	it('ladder duration is 3s', () => {
+		expect(TOOL_ANIMATIONS.ladder.duration).toBe(3);
+	});
+
+	it('watering can duration is 2.5s', () => {
+		expect(TOOL_ANIMATIONS.wateringCan.duration).toBe(2.5);
+	});
+
+	it('bird nest duration is 2s', () => {
+		expect(TOOL_ANIMATIONS.birdNest.duration).toBe(2);
+	});
+
+	it('each tool has a non-empty keyframe name', () => {
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(TOOL_ANIMATIONS[toolType].keyframeName.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('each tool has a CSS property string', () => {
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(typeof TOOL_ANIMATIONS[toolType].cssProperty).toBe('string');
+			expect(TOOL_ANIMATIONS[toolType].cssProperty.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/lib/trees/tools/tool_animations.ts
+++ b/src/lib/trees/tools/tool_animations.ts
@@ -1,0 +1,30 @@
+import type { ToolType } from './tool_types.js';
+
+interface ToolAnimationConfig {
+	readonly keyframeName: string;
+	readonly duration: number;
+	readonly cssProperty: string;
+}
+
+export const TOOL_ANIMATIONS = {
+	shovel: {
+		keyframeName: 'tool-shovel-idle',
+		duration: 2,
+		cssProperty: 'translateY',
+	},
+	ladder: {
+		keyframeName: 'tool-ladder-idle',
+		duration: 3,
+		cssProperty: 'rotate',
+	},
+	wateringCan: {
+		keyframeName: 'tool-watering-can-idle',
+		duration: 2.5,
+		cssProperty: 'rotate',
+	},
+	birdNest: {
+		keyframeName: 'tool-bird-nest-idle',
+		duration: 2,
+		cssProperty: 'translateY',
+	},
+} as const satisfies Record<ToolType, ToolAnimationConfig>;

--- a/src/lib/trees/tools/tool_svg_data.test.ts
+++ b/src/lib/trees/tools/tool_svg_data.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { TOOL_SVG_DATA } from './tool_svg_data.js';
+import { TOOL_TYPES } from './tool_types.js';
+
+describe('TOOL_SVG_DATA', () => {
+	it('has SVG data for all 4 tool types', () => {
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(TOOL_SVG_DATA).toHaveProperty(toolType);
+		}
+	});
+
+	for (const toolType of ['shovel', 'ladder', 'wateringCan', 'birdNest'] as const) {
+		describe(toolType, () => {
+			it('has at least 1 polygon', () => {
+				expect(TOOL_SVG_DATA[toolType].polygons.length).toBeGreaterThanOrEqual(1);
+			});
+
+			it('has at most 50 polygons', () => {
+				expect(TOOL_SVG_DATA[toolType].polygons.length).toBeLessThanOrEqual(50);
+			});
+
+			it('each polygon has valid hex fill color', () => {
+				for (const polygon of TOOL_SVG_DATA[toolType].polygons) {
+					expect(polygon.fill).toMatch(/^#[0-9a-fA-F]{6}$/);
+				}
+			});
+
+			it('each polygon has a points string', () => {
+				for (const polygon of TOOL_SVG_DATA[toolType].polygons) {
+					expect(typeof polygon.points).toBe('string');
+					expect(polygon.points.length).toBeGreaterThan(0);
+				}
+			});
+
+			it('has positive width and height', () => {
+				expect(TOOL_SVG_DATA[toolType].width).toBeGreaterThan(0);
+				expect(TOOL_SVG_DATA[toolType].height).toBeGreaterThan(0);
+			});
+		});
+	}
+
+	it('shovel and ladder have at most 30 polygons (simple tools)', () => {
+		expect(TOOL_SVG_DATA.shovel.polygons.length).toBeLessThanOrEqual(30);
+		expect(TOOL_SVG_DATA.ladder.polygons.length).toBeLessThanOrEqual(30);
+	});
+});

--- a/src/lib/trees/tools/tool_svg_data.ts
+++ b/src/lib/trees/tools/tool_svg_data.ts
@@ -1,0 +1,142 @@
+import type { ToolType } from './tool_types.js';
+
+interface ToolPolygon {
+	readonly points: string;
+	readonly fill: string;
+}
+
+interface ToolSvgConfig {
+	readonly polygons: readonly ToolPolygon[];
+	readonly width: number;
+	readonly height: number;
+}
+
+// All coordinates are in local space centered near (0,0).
+// The component translates to the anchor position.
+
+export const TOOL_SVG_DATA = {
+	shovel: {
+		width: 20,
+		height: 50,
+		polygons: [
+			// Handle (long wooden shaft)
+			{ points: '-1,-24 1,-24 1,12 -1,12', fill: '#8B6914' },
+			{ points: '-1.5,-24 1.5,-24 1,-22 -1,-22', fill: '#A0782C' },
+			// Handle grip
+			{ points: '-2.5,-24 2.5,-24 2.5,-22 -2.5,-22', fill: '#5C4033' },
+			{ points: '-2.5,-22 -1.5,-22 -1.5,-24 -2.5,-24', fill: '#4A3228' },
+			{ points: '1.5,-22 2.5,-22 2.5,-24 1.5,-24', fill: '#4A3228' },
+			// Blade (spade shape - earth tones)
+			{ points: '-1,12 1,12 5,18 0,25 -5,18', fill: '#6B7B3A' },
+			{ points: '-1,12 1,12 3,16 -3,16', fill: '#7C8C4A' },
+			{ points: '-3,16 3,16 5,18 -5,18', fill: '#5A6A2E' },
+			{ points: '-5,18 5,18 3,22 -3,22', fill: '#4D5D24' },
+			{ points: '-3,22 3,22 0,25', fill: '#3F4F1C' },
+			// Blade highlight
+			{ points: '0,12 1,12 4,17 0,20', fill: '#8C9C5A' },
+			// Blade edge
+			{ points: '-5,18 -3,22 -4,20', fill: '#3A4A18' },
+			{ points: '5,18 3,22 4,20', fill: '#3A4A18' },
+			// Shaft collar (metal ring where blade meets handle)
+			{ points: '-2,11 2,11 2,13 -2,13', fill: '#888888' },
+			{ points: '-2,11 2,11 1.5,11.5 -1.5,11.5', fill: '#AAAAAA' },
+		],
+	},
+	ladder: {
+		width: 24,
+		height: 55,
+		polygons: [
+			// Left rail
+			{ points: '-10,-27 -8,-27 -8,27 -10,27', fill: '#A0782C' },
+			{ points: '-10,-27 -8,-27 -8.5,-26 -9.5,-26', fill: '#B8924A' },
+			// Right rail
+			{ points: '8,-27 10,-27 10,27 8,27', fill: '#8B6914' },
+			{ points: '8,-27 10,-27 9.5,-26 8.5,-26', fill: '#A67D30' },
+			// Rung 1 (top)
+			{ points: '-8,-20 8,-20 8,-18 -8,-18', fill: '#C4A265' },
+			{ points: '-8,-20 8,-20 7,-19 -7,-19', fill: '#D4B275' },
+			// Rung 2
+			{ points: '-8,-10 8,-10 8,-8 -8,-8', fill: '#B8924A' },
+			{ points: '-8,-10 8,-10 7,-9 -7,-9', fill: '#C4A265' },
+			// Rung 3
+			{ points: '-8,0 8,0 8,2 -8,2', fill: '#C4A265' },
+			{ points: '-8,0 8,0 7,1 -7,1', fill: '#D4B275' },
+			// Rung 4
+			{ points: '-8,10 8,10 8,12 -8,12', fill: '#B8924A' },
+			{ points: '-8,10 8,10 7,11 -7,11', fill: '#C4A265' },
+			// Rung 5 (bottom)
+			{ points: '-8,20 8,20 8,22 -8,22', fill: '#C4A265' },
+			{ points: '-8,20 8,20 7,21 -7,21', fill: '#D4B275' },
+			// Left rail shadow
+			{ points: '-10,-27 -9,-27 -9,27 -10,27', fill: '#7A5910' },
+			// Right rail highlight
+			{ points: '9,-27 10,-27 10,27 9,27', fill: '#7A5910' },
+		],
+	},
+	wateringCan: {
+		width: 30,
+		height: 28,
+		polygons: [
+			// Body (main container - metallic)
+			{ points: '-8,-4 8,-4 10,8 -10,8', fill: '#708090' },
+			{ points: '-8,-4 8,-4 6,-2 -6,-2', fill: '#8899AA' },
+			{ points: '-10,8 10,8 8,10 -8,10', fill: '#5A6A7A' },
+			// Body side panels
+			{ points: '-8,-4 -6,-2 -8,8 -10,8', fill: '#607080' },
+			{ points: '8,-4 6,-2 8,8 10,8', fill: '#607080' },
+			// Bottom
+			{ points: '-8,10 8,10 6,12 -6,12', fill: '#4A5A6A' },
+			// Handle (top arc)
+			{ points: '-3,-4 3,-4 3,-6 -3,-6', fill: '#505A64' },
+			{ points: '-3,-6 -1,-10 1,-10 3,-6', fill: '#606A74' },
+			{ points: '-1,-10 1,-10 0.5,-8 -0.5,-8', fill: '#707A84' },
+			// Spout (angled to the right)
+			{ points: '8,0 8,2 14,-6 13,-7', fill: '#8899AA' },
+			{ points: '13,-7 14,-6 15,-6 14,-7.5', fill: '#96A7B8' },
+			// Spout rose (sprinkler head)
+			{ points: '13,-8 16,-8 16,-5 13,-5', fill: '#6A7A8A' },
+			{ points: '13,-8 16,-8 15.5,-7 13.5,-7', fill: '#7A8A9A' },
+			// Spout holes (decorative dots)
+			{ points: '14,-7 14.5,-7 14.5,-6.5 14,-6.5', fill: '#4A5A6A' },
+			{ points: '15,-7 15.5,-7 15.5,-6.5 15,-6.5', fill: '#4A5A6A' },
+			{ points: '14,-6 14.5,-6 14.5,-5.5 14,-5.5', fill: '#4A5A6A' },
+			{ points: '15,-6 15.5,-6 15.5,-5.5 15,-5.5', fill: '#4A5A6A' },
+			// Band (decorative strip around body)
+			{ points: '-9,3 9,3 9,5 -9,5', fill: '#5A6A7A' },
+			{ points: '-9,3 9,3 8.5,3.5 -8.5,3.5', fill: '#6A7A8A' },
+			// Body highlight
+			{ points: '-4,-2 4,-2 3,6 -3,6', fill: '#8494A4' },
+		],
+	},
+	birdNest: {
+		width: 28,
+		height: 20,
+		polygons: [
+			// Nest base (woven twigs - brown)
+			{ points: '-12,2 12,2 14,8 -14,8', fill: '#6B4226' },
+			{ points: '-14,8 14,8 10,12 -10,12', fill: '#5A3520' },
+			{ points: '-10,12 10,12 6,14 -6,14', fill: '#4A2818' },
+			// Nest rim (top edge)
+			{ points: '-13,0 13,0 12,2 -12,2', fill: '#7C5335' },
+			{ points: '-14,0 -12,0 -12,2 -14,4', fill: '#6B4226' },
+			{ points: '12,0 14,0 14,4 12,2', fill: '#6B4226' },
+			// Twig texture (cross-hatching effect)
+			{ points: '-10,3 -6,3 -7,5 -11,5', fill: '#5A3520' },
+			{ points: '-2,3 4,3 3,5 -3,5', fill: '#5A3520' },
+			{ points: '6,3 10,3 9,5 5,5', fill: '#5A3520' },
+			{ points: '-8,6 -4,6 -5,8 -9,8', fill: '#7C5335' },
+			{ points: '2,6 8,6 7,8 1,8', fill: '#7C5335' },
+			// Egg 1 (left)
+			{ points: '-5,0 -3,0 -2,2 -3,4 -5,4 -6,2', fill: '#F5F0E8' },
+			{ points: '-5,0 -3,0 -3.5,1 -4.5,1', fill: '#FEFCF8' },
+			// Egg 2 (center)
+			{ points: '-1,-1 1,-1 2,1 1,3 -1,3 -2,1', fill: '#EDE8DF' },
+			{ points: '-1,-1 1,-1 0.5,0 -0.5,0', fill: '#F5F0E8' },
+			// Egg 3 (right)
+			{ points: '3,0 5,0 6,2 5,4 3,4 2,2', fill: '#F5F0E8' },
+			{ points: '3,0 5,0 4.5,1 3.5,1', fill: '#FEFCF8' },
+			// Nest interior shadow
+			{ points: '-10,4 10,4 8,8 -8,8', fill: '#3A1E10' },
+		],
+	},
+} as const satisfies Record<ToolType, ToolSvgConfig>;

--- a/src/lib/trees/tools/tool_types.test.ts
+++ b/src/lib/trees/tools/tool_types.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+	TOOL_TYPES,
+	TOOL_ANCHOR_MAP,
+	TOOL_OPTIONS,
+	DEFAULT_TOOL_VISIBILITY,
+} from './tool_types.js';
+
+describe('TOOL_TYPES', () => {
+	it('defines exactly 4 tools', () => {
+		const types = Object.values(TOOL_TYPES);
+		expect(types).toHaveLength(4);
+	});
+
+	it('contains shovel, ladder, wateringCan, birdNest', () => {
+		expect(TOOL_TYPES.shovel).toBe('shovel');
+		expect(TOOL_TYPES.ladder).toBe('ladder');
+		expect(TOOL_TYPES.wateringCan).toBe('wateringCan');
+		expect(TOOL_TYPES.birdNest).toBe('birdNest');
+	});
+});
+
+describe('TOOL_ANCHOR_MAP', () => {
+	it('maps every tool type to a valid TreeAnchors key', () => {
+		const validAnchors = ['trunkBase', 'trunkMiddle', 'crownCenter'];
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(validAnchors).toContain(TOOL_ANCHOR_MAP[toolType]);
+		}
+	});
+
+	it('shovel snaps to trunkBase', () => {
+		expect(TOOL_ANCHOR_MAP[TOOL_TYPES.shovel]).toBe('trunkBase');
+	});
+
+	it('ladder snaps to trunkMiddle', () => {
+		expect(TOOL_ANCHOR_MAP[TOOL_TYPES.ladder]).toBe('trunkMiddle');
+	});
+
+	it('watering can snaps to trunkBase', () => {
+		expect(TOOL_ANCHOR_MAP[TOOL_TYPES.wateringCan]).toBe('trunkBase');
+	});
+
+	it('bird nest snaps to crownCenter', () => {
+		expect(TOOL_ANCHOR_MAP[TOOL_TYPES.birdNest]).toBe('crownCenter');
+	});
+});
+
+describe('TOOL_OPTIONS', () => {
+	it('has one entry per tool type', () => {
+		expect(TOOL_OPTIONS).toHaveLength(Object.values(TOOL_TYPES).length);
+	});
+
+	it('each option has value and label', () => {
+		for (const option of TOOL_OPTIONS) {
+			expect(option).toHaveProperty('value');
+			expect(option).toHaveProperty('label');
+			expect(typeof option.label).toBe('string');
+		}
+	});
+
+	it('option values cover all tool types', () => {
+		const values = TOOL_OPTIONS.map((o) => o.value);
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(values).toContain(toolType);
+		}
+	});
+});
+
+describe('DEFAULT_TOOL_VISIBILITY', () => {
+	it('has entries for all 4 tools', () => {
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(DEFAULT_TOOL_VISIBILITY).toHaveProperty(toolType);
+		}
+	});
+
+	it('all tools start hidden', () => {
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(DEFAULT_TOOL_VISIBILITY[toolType].visible).toBe(false);
+		}
+	});
+
+	it('all tools start at size 1', () => {
+		for (const toolType of Object.values(TOOL_TYPES)) {
+			expect(DEFAULT_TOOL_VISIBILITY[toolType].size).toBe(1);
+		}
+	});
+});

--- a/src/lib/trees/tools/tool_types.ts
+++ b/src/lib/trees/tools/tool_types.ts
@@ -1,0 +1,38 @@
+import type { TreeAnchors } from '$lib/trees/types/core.js';
+
+export const TOOL_TYPES = {
+	shovel: 'shovel',
+	ladder: 'ladder',
+	wateringCan: 'wateringCan',
+	birdNest: 'birdNest',
+} as const;
+
+export type ToolType = (typeof TOOL_TYPES)[keyof typeof TOOL_TYPES];
+
+export interface ToolVisibilityEntry {
+	visible: boolean;
+	size: number;
+}
+
+export type ToolVisibility = Record<ToolType, ToolVisibilityEntry>;
+
+export const TOOL_ANCHOR_MAP = {
+	[TOOL_TYPES.shovel]: 'trunkBase',
+	[TOOL_TYPES.ladder]: 'trunkMiddle',
+	[TOOL_TYPES.wateringCan]: 'trunkBase',
+	[TOOL_TYPES.birdNest]: 'crownCenter',
+} as const satisfies Record<ToolType, keyof TreeAnchors>;
+
+export const DEFAULT_TOOL_VISIBILITY: ToolVisibility = {
+	[TOOL_TYPES.shovel]: { visible: false, size: 1 },
+	[TOOL_TYPES.ladder]: { visible: false, size: 1 },
+	[TOOL_TYPES.wateringCan]: { visible: false, size: 1 },
+	[TOOL_TYPES.birdNest]: { visible: false, size: 1 },
+};
+
+export const TOOL_OPTIONS = [
+	{ value: TOOL_TYPES.shovel, label: 'Shovel' },
+	{ value: TOOL_TYPES.ladder, label: 'Ladder' },
+	{ value: TOOL_TYPES.wateringCan, label: 'Watering Can' },
+	{ value: TOOL_TYPES.birdNest, label: 'Bird Nest' },
+] as const;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,11 @@
 	import TrunkColorCard from '$lib/components/composed/TrunkColorCard.svelte';
 	import { SHAPE_DEFAULTS } from '$lib/trees/types.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
+	import {
+		TOOL_OPTIONS,
+		DEFAULT_TOOL_VISIBILITY,
+		type ToolVisibility,
+	} from '$lib/trees/tools/tool_types.js';
 	import { createTreeConfigContext } from '$lib/trees/tree_config.context.svelte.js';
 	import { createSceneConfigContext } from '$lib/scene/scene_config.context.svelte.js';
 	import { generateSceneLayout } from '$lib/scene/scene_layout.js';
@@ -27,6 +32,8 @@
 	let animateCanopySway = $state(false);
 	let animateBranches = $state(false);
 	let animateGrowth = $state(false);
+	let toolVisibility: ToolVisibility = $state({ ...DEFAULT_TOOL_VISIBILITY });
+	let animateTools = $state(false);
 
 	const trunkCrookednessDisabled = $derived(
 		isParamDisabled('custom', 'trunkCrookedness', {
@@ -108,6 +115,8 @@
 						{animateCanopySway}
 						{animateBranches}
 						{animateGrowth}
+						{toolVisibility}
+						{animateTools}
 						class="h-auto w-full"
 					/>
 				</div>
@@ -342,6 +351,41 @@
 							bind:value={treeConfig.current.depthVariance}
 							class="w-full accent-primary"
 						/>
+					</div>
+				</SectionCard>
+
+				<SectionCard title="Tools & Accessories" contentClass="space-y-4">
+					{#each TOOL_OPTIONS as option (option.value)}
+						<div class="flex items-center gap-2">
+							<Checkbox
+								data-testid="tool-{option.value}-visible"
+								checked={toolVisibility[option.value].visible}
+								onCheckedChange={(v) =>
+									(toolVisibility[option.value] = {
+										...toolVisibility[option.value],
+										visible: v === true,
+									})}
+							/>
+							<Label>{option.label}</Label>
+						</div>
+						{#if toolVisibility[option.value].visible}
+							<LabeledRangeSlider
+								label="{option.label} Size"
+								min={0.5}
+								max={2}
+								step={0.1}
+								bind:value={toolVisibility[option.value].size}
+								id="tool-{option.value}-size"
+							/>
+						{/if}
+					{/each}
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="animate-tools"
+							checked={animateTools}
+							onCheckedChange={(v) => (animateTools = v === true)}
+						/>
+						<Label>Animate Tools</Label>
 					</div>
 				</SectionCard>
 

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -2,6 +2,7 @@
 	import LowPolyTree from '$lib/trees/LowPolyTree.svelte';
 	import LabeledSelect from '$lib/components/composed/LabeledSelect.svelte';
 	import LabeledRangeSlider from '$lib/components/composed/LabeledRangeSlider.svelte';
+	import SectionCard from '$lib/components/composed/SectionCard.svelte';
 	import CustomBlobsEditor from '$lib/components/composed/CustomBlobsEditor.svelte';
 	import CanopyColorCard from '$lib/components/composed/CanopyColorCard.svelte';
 	import TrunkColorCard from '$lib/components/composed/TrunkColorCard.svelte';
@@ -21,6 +22,11 @@
 		type TreeShape,
 		type FruitType,
 	} from '$lib/trees/types.js';
+	import {
+		TOOL_OPTIONS,
+		DEFAULT_TOOL_VISIBILITY,
+		type ToolVisibility,
+	} from '$lib/trees/tools/tool_types.js';
 	import { growCustomBlobs } from '$lib/trees/shapes.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import { getSavedTree, saveTree } from '$lib/trees/saved_trees.remote.js';
@@ -42,6 +48,8 @@
 	let animateCanopySway = $state(false);
 	let animateBranches = $state(false);
 	let animateGrowth = $state(false);
+	let toolVisibility: ToolVisibility = $state({ ...DEFAULT_TOOL_VISIBILITY });
+	let animateTools = $state(false);
 
 	const branchCountDisabled = $derived(
 		isParamDisabled(treeConfig.current.shape, 'branchCount', {}),
@@ -431,6 +439,41 @@
 					</Card.Content>
 				</Card.Root>
 
+				<SectionCard title="Tools & Accessories" contentClass="space-y-4">
+					{#each TOOL_OPTIONS as option (option.value)}
+						<div class="flex items-center gap-2">
+							<Checkbox
+								data-testid="tool-{option.value}-visible"
+								checked={toolVisibility[option.value].visible}
+								onCheckedChange={(v) =>
+									(toolVisibility[option.value] = {
+										...toolVisibility[option.value],
+										visible: v === true,
+									})}
+							/>
+							<Label>{option.label}</Label>
+						</div>
+						{#if toolVisibility[option.value].visible}
+							<LabeledRangeSlider
+								label="{option.label} Size"
+								min={0.5}
+								max={2}
+								step={0.1}
+								bind:value={toolVisibility[option.value].size}
+								id="tool-{option.value}-size"
+							/>
+						{/if}
+					{/each}
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="animate-tools"
+							checked={animateTools}
+							onCheckedChange={(v) => (animateTools = v === true)}
+						/>
+						<Label>Animate Tools</Label>
+					</div>
+				</SectionCard>
+
 				<Card.Root>
 					<Card.Header>
 						<Card.Title>Debug</Card.Title>
@@ -525,6 +568,8 @@
 					{animateCanopySway}
 					{animateBranches}
 					{animateGrowth}
+					{toolVisibility}
+					{animateTools}
 					class="h-auto w-full"
 				/>
 			</div>

--- a/tests/e2e/tools.spec.ts
+++ b/tests/e2e/tools.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Scene page (/) — tool accessories controls
+// ---------------------------------------------------------------------------
+
+test.describe('Scene page tool accessories', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/', { waitUntil: 'networkidle' });
+	});
+
+	test('has Tools & Accessories section with 4 tool checkboxes and animate toggle', async ({
+		page,
+	}) => {
+		await expect(page.locator('[data-testid="tool-shovel-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="tool-ladder-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="tool-wateringCan-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="tool-birdNest-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="animate-tools"]')).toBeVisible();
+	});
+
+	test('checking shovel makes shovel SVG group appear', async ({ page }) => {
+		// Initially no tool groups
+		await expect(page.locator('[data-tool="shovel"]')).toHaveCount(0);
+
+		// Check shovel
+		await page.locator('[data-testid="tool-shovel-visible"]').click();
+
+		// Shovel groups should appear (one per tree in scene)
+		const shovelGroups = page.locator('[data-tool="shovel"]');
+		await expect(shovelGroups.first()).toBeVisible();
+	});
+
+	test('unchecking shovel hides shovel SVG group', async ({ page }) => {
+		// Enable then disable
+		await page.locator('[data-testid="tool-shovel-visible"]').click();
+		await expect(page.locator('[data-tool="shovel"]').first()).toBeVisible();
+
+		await page.locator('[data-testid="tool-shovel-visible"]').click();
+		await expect(page.locator('[data-tool="shovel"]')).toHaveCount(0);
+	});
+
+	test('tools toggle independently', async ({ page }) => {
+		// Enable shovel and bird nest
+		await page.locator('[data-testid="tool-shovel-visible"]').click();
+		await page.locator('[data-testid="tool-birdNest-visible"]').click();
+
+		await expect(page.locator('[data-tool="shovel"]').first()).toBeVisible();
+		await expect(page.locator('[data-tool="birdNest"]').first()).toBeVisible();
+		await expect(page.locator('[data-tool="ladder"]')).toHaveCount(0);
+		await expect(page.locator('[data-tool="wateringCan"]')).toHaveCount(0);
+	});
+
+	test('animate tools checkbox toggles animation class', async ({ page }) => {
+		// Enable a tool first
+		await page.locator('[data-testid="tool-shovel-visible"]').click();
+		// Animation class is on the inner <g> child of [data-tool]
+		const animGroup = page.locator('[data-tool="shovel"] > .tool-anim').first();
+		await expect(animGroup).not.toHaveClass(/animate-tool/);
+
+		// Enable animation
+		await page.locator('[data-testid="animate-tools"]').click();
+		await expect(animGroup).toHaveClass(/animate-tool/);
+
+		// Disable animation
+		await page.locator('[data-testid="animate-tools"]').click();
+		await expect(animGroup).not.toHaveClass(/animate-tool/);
+	});
+
+	test('size slider appears when tool is visible and changes scale', async ({ page }) => {
+		// Size slider not visible initially
+		await expect(page.locator('#tool-shovel-size')).toHaveCount(0);
+
+		// Enable shovel
+		await page.locator('[data-testid="tool-shovel-visible"]').click();
+
+		// Size slider should appear
+		const sizeSlider = page.locator('#tool-shovel-size');
+		await expect(sizeSlider).toBeVisible();
+
+		// Get initial scale
+		const toolGroup = page.locator('[data-tool="shovel"]').first();
+		const initialTransform = await toolGroup.getAttribute('transform');
+		expect(initialTransform).toContain('scale(1)');
+
+		// Change size to max
+		await sizeSlider.fill('2');
+		const updatedTransform = await toolGroup.getAttribute('transform');
+		expect(updatedTransform).toContain('scale(2)');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Editor page (/editor) — tool accessories controls
+// ---------------------------------------------------------------------------
+
+test.describe('Editor page tool accessories', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/editor', { waitUntil: 'networkidle' });
+	});
+
+	test('has Tools & Accessories section with 4 tool checkboxes', async ({ page }) => {
+		await expect(page.locator('[data-testid="tool-shovel-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="tool-ladder-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="tool-wateringCan-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="tool-birdNest-visible"]')).toBeVisible();
+		await expect(page.locator('[data-testid="animate-tools"]')).toBeVisible();
+	});
+
+	test('checking ladder makes ladder SVG group appear', async ({ page }) => {
+		await expect(page.locator('[data-tool="ladder"]')).toHaveCount(0);
+		await page.locator('[data-testid="tool-ladder-visible"]').click();
+		await expect(page.locator('[data-tool="ladder"]')).toBeVisible();
+	});
+
+	test('animate tools toggles animation class on editor tree', async ({ page }) => {
+		await page.locator('[data-testid="tool-wateringCan-visible"]').click();
+		const animGroup = page.locator('[data-tool="wateringCan"] > .tool-anim');
+		await expect(animGroup).not.toHaveClass(/animate-tool/);
+
+		await page.locator('[data-testid="animate-tools"]').click();
+		await expect(animGroup).toHaveClass(/animate-tool/);
+	});
+
+	test('all 4 tools can be enabled simultaneously', async ({ page }) => {
+		await page.locator('[data-testid="tool-shovel-visible"]').click();
+		await page.locator('[data-testid="tool-ladder-visible"]').click();
+		await page.locator('[data-testid="tool-wateringCan-visible"]').click();
+		await page.locator('[data-testid="tool-birdNest-visible"]').click();
+
+		await expect(page.locator('[data-tool="shovel"]')).toBeVisible();
+		await expect(page.locator('[data-tool="ladder"]')).toBeVisible();
+		await expect(page.locator('[data-tool="wateringCan"]')).toBeVisible();
+		await expect(page.locator('[data-tool="birdNest"]')).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Description
- Add 4 decorative low-poly SVG tool accessories (shovel, ladder, watering can, bird nest) that snap to tree anchor points
- Each tool has a distinct CSS idle animation loop (oscillation, sway, tilt, bobbing)
- New "Tools & Accessories" SectionCard in sidebar on both scene and editor pages
- Individual visibility checkboxes, per-tool size sliders, global animation toggle

## Resolves
Closes #40

## Testing
- [x] 43 unit tests: tool types, SVG polygon constraints, animation params
- [x] 10 E2E tests: visibility toggle, size slider, animation class, both pages
- [x] check:all passes (format + lint + typecheck + stylelint + knip)