### PR TITLE
#41 feat(environment): rain, lightning, snow, fireflies, wind, sun rays, clouds

### DIFF
--- a/src/lib/environment/EnvironmentOverlay.svelte
+++ b/src/lib/environment/EnvironmentOverlay.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import type { EnvironmentConfig } from './environment_config.js';
+	import CloudsEffect from './effects/CloudsEffect.svelte';
+	import SunRaysEffect from './effects/SunRaysEffect.svelte';
+	import RainEffect from './effects/RainEffect.svelte';
+	import SnowEffect from './effects/SnowEffect.svelte';
+	import WindParticlesEffect from './effects/WindParticlesEffect.svelte';
+	import FirefliesEffect from './effects/FirefliesEffect.svelte';
+	import LightningEffect from './effects/LightningEffect.svelte';
+
+	interface Props {
+		config: EnvironmentConfig;
+		lightAngle: number;
+	}
+
+	const { config, lightAngle }: Props = $props();
+</script>
+
+<div
+	data-testid="environment-overlay"
+	style="position: absolute; inset: 0; pointer-events: none; overflow: hidden; z-index: 10;"
+>
+	{#if config.cloudsEnabled}
+		<CloudsEffect />
+	{/if}
+	{#if config.sunRaysEnabled}
+		<SunRaysEffect {lightAngle} />
+	{/if}
+	{#if config.rainEnabled}
+		<RainEffect intensity={config.rainIntensity} />
+	{/if}
+	{#if config.snowEnabled}
+		<SnowEffect />
+	{/if}
+	{#if config.windParticlesEnabled}
+		<WindParticlesEffect />
+	{/if}
+	{#if config.firefliesEnabled}
+		<FirefliesEffect />
+	{/if}
+	{#if config.lightningEnabled}
+		<LightningEffect />
+	{/if}
+</div>

--- a/src/lib/environment/effects/CloudsEffect.svelte
+++ b/src/lib/environment/effects/CloudsEffect.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { generateCloudShapes } from '../environment_generators.js';
+	import { ENVIRONMENT_SEEDS, ENVIRONMENT_VIEW_WIDTH } from '../environment_config.js';
+
+	const clouds = generateCloudShapes(5, ENVIRONMENT_SEEDS.clouds, ENVIRONMENT_VIEW_WIDTH);
+</script>
+
+<svg
+	data-testid="clouds-overlay"
+	class="clouds-container"
+	viewBox="0 0 800 200"
+	preserveAspectRatio="xMidYMin slice"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	{#each clouds as cloud, i (i)}
+		<g
+			data-testid="cloud"
+			class="cloud-group"
+			style="--x: {cloud.x}px; --y: {cloud.y * 5}px; animation-delay: {i * 2}s;"
+		>
+			{#each cloud.triangles as pts, ti (ti)}
+				<polygon points={pts} fill="rgba(220,220,230,{cloud.opacity})" />
+			{/each}
+		</g>
+	{/each}
+</svg>
+
+<style>
+	.clouds-container {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 30%;
+	}
+
+	.cloud-group {
+		animation: cloud-drift 30s linear infinite;
+		will-change: transform;
+	}
+
+	@keyframes cloud-drift {
+		0% {
+			transform: translate(var(--x), var(--y));
+		}
+
+		100% {
+			transform: translate(calc(var(--x) + 100px), var(--y));
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.cloud-group {
+			animation: none;
+			transform: translate(var(--x), var(--y));
+		}
+	}
+</style>

--- a/src/lib/environment/effects/FirefliesEffect.svelte
+++ b/src/lib/environment/effects/FirefliesEffect.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { generateFireflyPositions } from '../environment_generators.js';
+	import {
+		ENVIRONMENT_SEEDS,
+		ENVIRONMENT_VIEW_HEIGHT,
+		ENVIRONMENT_VIEW_WIDTH,
+	} from '../environment_config.js';
+
+	const fireflies = generateFireflyPositions(
+		20,
+		ENVIRONMENT_SEEDS.fireflies,
+		ENVIRONMENT_VIEW_WIDTH,
+		ENVIRONMENT_VIEW_HEIGHT,
+	);
+</script>
+
+<svg
+	data-testid="fireflies-overlay"
+	class="fireflies-container"
+	viewBox="0 0 {ENVIRONMENT_VIEW_WIDTH} {ENVIRONMENT_VIEW_HEIGHT}"
+	preserveAspectRatio="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<defs>
+		<filter id="firefly-glow">
+			<feGaussianBlur stdDeviation="3" result="blur" />
+			<feMerge>
+				<feMergeNode in="blur" />
+				<feMergeNode in="SourceGraphic" />
+			</feMerge>
+		</filter>
+	</defs>
+	{#each fireflies as ff, index (index)}
+		<circle
+			data-testid="firefly"
+			cx={ff.x}
+			cy={ff.y}
+			r="3"
+			fill="#9FFF50"
+			filter="url(#firefly-glow)"
+			class="firefly"
+			style="animation-delay: {ff.delay}s; animation-duration: {ff.duration}s;"
+		/>
+	{/each}
+</svg>
+
+<style>
+	.fireflies-container {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+	}
+
+	.firefly {
+		animation: firefly-pulse ease-in-out infinite alternate;
+		will-change: transform;
+	}
+
+	@keyframes firefly-pulse {
+		0% {
+			opacity: 0.2;
+			transform: scale(0.8) translate(0, 0);
+		}
+
+		50% {
+			opacity: 1;
+			transform: scale(1.2) translate(5px, -3px);
+		}
+
+		100% {
+			opacity: 0.3;
+			transform: scale(0.9) translate(-4px, 2px);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.firefly {
+			animation: none;
+			opacity: 0.6;
+		}
+	}
+</style>

--- a/src/lib/environment/effects/LightningEffect.svelte
+++ b/src/lib/environment/effects/LightningEffect.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	let flashOpacity = $state(0);
+
+	$effect(() => {
+		let timeoutId: ReturnType<typeof setTimeout>;
+		let flashTimeoutId: ReturnType<typeof setTimeout>;
+		let active = true;
+
+		function scheduleFlash() {
+			if (!active) {
+				return;
+			}
+			const delay = 5000 + Math.random() * 10000;
+			timeoutId = setTimeout(() => {
+				if (!active) {
+					return;
+				}
+				flashOpacity = 0.3;
+				flashTimeoutId = setTimeout(
+					() => {
+						if (!active) {
+							return;
+						}
+						flashOpacity = 0;
+						scheduleFlash();
+					},
+					100 + Math.random() * 100,
+				);
+			}, delay);
+		}
+
+		scheduleFlash();
+
+		return () => {
+			active = false;
+			clearTimeout(timeoutId);
+			clearTimeout(flashTimeoutId);
+		};
+	});
+</script>
+
+<div data-testid="lightning-overlay" class="lightning-container" style="opacity: {flashOpacity};">
+	<div class="lightning-flash"></div>
+</div>
+
+<style>
+	.lightning-container {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		transition: opacity 0.05s ease-out;
+		will-change: opacity;
+	}
+
+	.lightning-flash {
+		position: absolute;
+		inset: 0;
+		background: white;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.lightning-container {
+			display: none;
+		}
+	}
+</style>

--- a/src/lib/environment/effects/RainEffect.svelte
+++ b/src/lib/environment/effects/RainEffect.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { generateRainDrops } from '../environment_generators.js';
+	import {
+		ENVIRONMENT_SEEDS,
+		ENVIRONMENT_VIEW_HEIGHT,
+		ENVIRONMENT_VIEW_WIDTH,
+	} from '../environment_config.js';
+
+	interface Props {
+		intensity: number;
+	}
+
+	const { intensity }: Props = $props();
+
+	const drops = $derived(
+		generateRainDrops(
+			intensity,
+			ENVIRONMENT_SEEDS.rain,
+			ENVIRONMENT_VIEW_WIDTH,
+			ENVIRONMENT_VIEW_HEIGHT,
+		),
+	);
+</script>
+
+<svg
+	data-testid="rain-overlay"
+	class="rain-container"
+	viewBox="0 0 {ENVIRONMENT_VIEW_WIDTH} {ENVIRONMENT_VIEW_HEIGHT}"
+	preserveAspectRatio="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	{#each drops as drop, index (index)}
+		<line
+			data-testid="rain-drop"
+			x1={drop.x}
+			y1={drop.y}
+			x2={drop.x + 2}
+			y2={drop.y + drop.length}
+			stroke="rgba(174,194,224,0.5)"
+			stroke-width="1.5"
+			class="rain-drop"
+			style="animation-delay: {drop.delay}s; animation-duration: {drop.speed}s;"
+		/>
+	{/each}
+</svg>
+
+<style>
+	.rain-container {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+	}
+
+	.rain-drop {
+		animation: rain-fall linear infinite;
+		will-change: transform;
+	}
+
+	@keyframes rain-fall {
+		0% {
+			transform: translateY(-20px) translateX(-5px);
+			opacity: 1;
+		}
+
+		100% {
+			transform: translateY(620px) translateX(15px);
+			opacity: 0.3;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.rain-drop {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/environment/effects/SnowEffect.svelte
+++ b/src/lib/environment/effects/SnowEffect.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { generateSnowflakes } from '../environment_generators.js';
+	import {
+		ENVIRONMENT_SEEDS,
+		ENVIRONMENT_VIEW_HEIGHT,
+		ENVIRONMENT_VIEW_WIDTH,
+	} from '../environment_config.js';
+
+	const flakes = generateSnowflakes(
+		40,
+		ENVIRONMENT_SEEDS.snow,
+		ENVIRONMENT_VIEW_WIDTH,
+		ENVIRONMENT_VIEW_HEIGHT,
+	);
+</script>
+
+<svg
+	data-testid="snow-overlay"
+	class="snow-container"
+	viewBox="0 0 {ENVIRONMENT_VIEW_WIDTH} {ENVIRONMENT_VIEW_HEIGHT}"
+	preserveAspectRatio="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	{#each flakes as flake, index (index)}
+		<circle
+			data-testid="snow-particle"
+			cx={flake.x}
+			cy={flake.y}
+			r={flake.size}
+			fill="white"
+			fill-opacity="0.8"
+			class="snow-flake"
+			style="animation-delay: {flake.delay}s; animation-duration: {flake.speed}s; --drift: {flake.drift}px;"
+		/>
+	{/each}
+</svg>
+
+<style>
+	.snow-container {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+	}
+
+	.snow-flake {
+		animation: snow-fall linear infinite;
+		will-change: transform;
+	}
+
+	@keyframes snow-fall {
+		0% {
+			transform: translateY(-20px) translateX(0);
+			opacity: 0.9;
+		}
+
+		100% {
+			transform: translateY(620px) translateX(var(--drift, 10px));
+			opacity: 0.3;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.snow-flake {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/environment/effects/SunRaysEffect.svelte
+++ b/src/lib/environment/effects/SunRaysEffect.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	interface Props {
+		lightAngle: number;
+	}
+
+	const { lightAngle }: Props = $props();
+
+	const rayAngle = $derived(lightAngle - 90);
+</script>
+
+<div data-testid="sun-rays-overlay" class="sun-rays-container">
+	{#each [0, 1, 2] as rayIndex (rayIndex)}
+		<div
+			class="sun-ray"
+			style="
+				transform: rotate({rayAngle}deg);
+				left: {20 + rayIndex * 25}%;
+				animation-delay: {rayIndex * 0.5}s;
+			"
+		></div>
+	{/each}
+</div>
+
+<style>
+	.sun-rays-container {
+		position: absolute;
+		inset: 0;
+		overflow: hidden;
+	}
+
+	.sun-ray {
+		position: absolute;
+		top: -20%;
+		width: 80px;
+		height: 140%;
+		background: linear-gradient(
+			180deg,
+			rgb(255 215 0 / 15%) 0%,
+			rgb(255 215 0 / 5%) 50%,
+			transparent 100%
+		);
+		transform-origin: top center;
+		animation: ray-shimmer 4s ease-in-out infinite alternate;
+	}
+
+	@keyframes ray-shimmer {
+		0% {
+			opacity: 0.5;
+		}
+
+		100% {
+			opacity: 0.8;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.sun-ray {
+			animation: none;
+			opacity: 0.6;
+		}
+	}
+</style>

--- a/src/lib/environment/effects/WindParticlesEffect.svelte
+++ b/src/lib/environment/effects/WindParticlesEffect.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { generateWindParticles } from '../environment_generators.js';
+	import {
+		ENVIRONMENT_SEEDS,
+		ENVIRONMENT_VIEW_HEIGHT,
+		ENVIRONMENT_VIEW_WIDTH,
+	} from '../environment_config.js';
+
+	const particles = generateWindParticles(
+		15,
+		ENVIRONMENT_SEEDS.wind,
+		ENVIRONMENT_VIEW_WIDTH,
+		ENVIRONMENT_VIEW_HEIGHT,
+	);
+</script>
+
+<svg
+	data-testid="wind-overlay"
+	class="wind-container"
+	viewBox="0 0 {ENVIRONMENT_VIEW_WIDTH} {ENVIRONMENT_VIEW_HEIGHT}"
+	preserveAspectRatio="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	{#each particles as particle, index (index)}
+		<path
+			data-testid="wind-particle"
+			d="M0,-{particle.size} C{particle.size / 2},-{particle.size / 2} {particle.size /
+				2},{particle.size / 2} 0,{particle.size} C-{particle.size / 3},0 -{particle.size /
+				3},0 0,-{particle.size}Z"
+			fill="rgba(139,119,101,0.4)"
+			class="wind-particle"
+			style="
+				transform: translate({particle.x}px, {particle.y}px) rotate({particle.rotation}deg);
+				animation-delay: {particle.delay}s;
+			"
+		/>
+	{/each}
+</svg>
+
+<style>
+	.wind-container {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+	}
+
+	.wind-particle {
+		animation: wind-drift 4s ease-in-out infinite;
+		opacity: 0.6;
+		will-change: transform;
+	}
+
+	@keyframes wind-drift {
+		0% {
+			translate: 0 0;
+		}
+
+		25% {
+			translate: 60px -15px;
+		}
+
+		50% {
+			translate: 120px 5px;
+		}
+
+		75% {
+			translate: 180px -10px;
+		}
+
+		100% {
+			translate: 240px 0;
+			opacity: 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.wind-particle {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/environment/environment_config.context.svelte.ts
+++ b/src/lib/environment/environment_config.context.svelte.ts
@@ -1,0 +1,16 @@
+import { ENVIRONMENT_DEFAULTS } from './environment_config.js';
+
+class EnvironmentConfigState {
+	rainEnabled = $state(ENVIRONMENT_DEFAULTS.rainEnabled);
+	lightningEnabled = $state(ENVIRONMENT_DEFAULTS.lightningEnabled);
+	firefliesEnabled = $state(ENVIRONMENT_DEFAULTS.firefliesEnabled);
+	windParticlesEnabled = $state(ENVIRONMENT_DEFAULTS.windParticlesEnabled);
+	snowEnabled = $state(ENVIRONMENT_DEFAULTS.snowEnabled);
+	sunRaysEnabled = $state(ENVIRONMENT_DEFAULTS.sunRaysEnabled);
+	cloudsEnabled = $state(ENVIRONMENT_DEFAULTS.cloudsEnabled);
+	rainIntensity = $state(ENVIRONMENT_DEFAULTS.rainIntensity);
+}
+
+export function createEnvironmentConfigContext() {
+	return new EnvironmentConfigState();
+}

--- a/src/lib/environment/environment_config.test.ts
+++ b/src/lib/environment/environment_config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+	ENVIRONMENT_DEFAULTS,
+	ENVIRONMENT_LIMITS,
+	type EnvironmentConfig,
+} from './environment_config.js';
+
+describe('EnvironmentConfig', () => {
+	it('defaults all toggles to false', () => {
+		const toggleKeys: (keyof EnvironmentConfig)[] = [
+			'rainEnabled',
+			'lightningEnabled',
+			'firefliesEnabled',
+			'windParticlesEnabled',
+			'snowEnabled',
+			'sunRaysEnabled',
+			'cloudsEnabled',
+		];
+		for (const key of toggleKeys) {
+			expect(ENVIRONMENT_DEFAULTS[key]).toBe(false);
+		}
+	});
+
+	it('defaults rainIntensity to 50', () => {
+		expect(ENVIRONMENT_DEFAULTS.rainIntensity).toBe(50);
+	});
+
+	it('defines rain intensity limits', () => {
+		expect(ENVIRONMENT_LIMITS.rainIntensityMin).toBe(10);
+		expect(ENVIRONMENT_LIMITS.rainIntensityMax).toBe(200);
+	});
+
+	it('has exactly 7 toggle keys plus rainIntensity', () => {
+		const keys = Object.keys(ENVIRONMENT_DEFAULTS);
+		expect(keys).toHaveLength(8);
+		expect(keys.filter((k) => k.endsWith('Enabled'))).toHaveLength(7);
+		expect(keys).toContain('rainIntensity');
+	});
+});

--- a/src/lib/environment/environment_config.ts
+++ b/src/lib/environment/environment_config.ts
@@ -1,0 +1,39 @@
+export interface EnvironmentConfig {
+	readonly rainEnabled: boolean;
+	readonly lightningEnabled: boolean;
+	readonly firefliesEnabled: boolean;
+	readonly windParticlesEnabled: boolean;
+	readonly snowEnabled: boolean;
+	readonly sunRaysEnabled: boolean;
+	readonly cloudsEnabled: boolean;
+	readonly rainIntensity: number;
+}
+
+export const ENVIRONMENT_DEFAULTS: EnvironmentConfig = {
+	rainEnabled: false,
+	lightningEnabled: false,
+	firefliesEnabled: false,
+	windParticlesEnabled: false,
+	snowEnabled: false,
+	sunRaysEnabled: false,
+	cloudsEnabled: false,
+	rainIntensity: 50,
+} as const;
+
+export const ENVIRONMENT_LIMITS = {
+	rainIntensityMin: 10,
+	rainIntensityMax: 200,
+} as const;
+
+/** Shared viewport dimensions for all environment effect SVGs. */
+export const ENVIRONMENT_VIEW_WIDTH = 800;
+export const ENVIRONMENT_VIEW_HEIGHT = 600;
+
+/** Per-effect seeds for deterministic generation. */
+export const ENVIRONMENT_SEEDS = {
+	rain: 123,
+	snow: 99,
+	fireflies: 77,
+	wind: 55,
+	clouds: 33,
+} as const;

--- a/src/lib/environment/environment_generators.test.ts
+++ b/src/lib/environment/environment_generators.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+	generateRainDrops,
+	generateSnowflakes,
+	generateCloudShapes,
+	generateFireflyPositions,
+	generateWindParticles,
+} from './environment_generators.js';
+
+const VIEW_WIDTH = 800;
+const VIEW_HEIGHT = 600;
+
+describe('generateRainDrops', () => {
+	it('is deterministic — same seed produces same output', () => {
+		const a = generateRainDrops(50, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		const b = generateRainDrops(50, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(a).toEqual(b);
+	});
+
+	it('count scales with intensity', () => {
+		const low = generateRainDrops(20, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		const high = generateRainDrops(150, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(high.length).toBeGreaterThan(low.length);
+	});
+
+	it('all values within valid ranges', () => {
+		const drops = generateRainDrops(100, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		for (const drop of drops) {
+			expect(drop.x).toBeGreaterThanOrEqual(0);
+			expect(drop.x).toBeLessThanOrEqual(VIEW_WIDTH);
+			expect(drop.y).toBeGreaterThanOrEqual(0);
+			expect(drop.y).toBeLessThanOrEqual(VIEW_HEIGHT);
+			expect(drop.length).toBeGreaterThan(0);
+			expect(drop.delay).toBeGreaterThanOrEqual(0);
+			expect(drop.speed).toBeGreaterThan(0);
+		}
+	});
+
+	it('returns objects with correct shape', () => {
+		const drops = generateRainDrops(50, 1, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(drops.length).toBeGreaterThan(0);
+		const drop = drops[0];
+		expect(drop).toHaveProperty('x');
+		expect(drop).toHaveProperty('y');
+		expect(drop).toHaveProperty('length');
+		expect(drop).toHaveProperty('delay');
+		expect(drop).toHaveProperty('speed');
+	});
+});
+
+describe('generateSnowflakes', () => {
+	it('is deterministic', () => {
+		const a = generateSnowflakes(30, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		const b = generateSnowflakes(30, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(a).toEqual(b);
+	});
+
+	it('returns requested count', () => {
+		const flakes = generateSnowflakes(25, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(flakes).toHaveLength(25);
+	});
+
+	it('all values within valid ranges', () => {
+		const flakes = generateSnowflakes(50, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		for (const flake of flakes) {
+			expect(flake.x).toBeGreaterThanOrEqual(0);
+			expect(flake.x).toBeLessThanOrEqual(VIEW_WIDTH);
+			expect(flake.y).toBeGreaterThanOrEqual(0);
+			expect(flake.y).toBeLessThanOrEqual(VIEW_HEIGHT);
+			expect(flake.size).toBeGreaterThanOrEqual(2);
+			expect(flake.size).toBeLessThanOrEqual(6);
+			expect(flake.delay).toBeGreaterThanOrEqual(0);
+			expect(flake.drift).toBeDefined();
+		}
+	});
+});
+
+describe('generateCloudShapes', () => {
+	it('is deterministic', () => {
+		const a = generateCloudShapes(5, 42, VIEW_WIDTH);
+		const b = generateCloudShapes(5, 42, VIEW_WIDTH);
+		expect(a).toEqual(b);
+	});
+
+	it('returns requested count', () => {
+		const clouds = generateCloudShapes(4, 42, VIEW_WIDTH);
+		expect(clouds).toHaveLength(4);
+	});
+
+	it('clouds positioned in upper 30% of viewport', () => {
+		const clouds = generateCloudShapes(10, 42, VIEW_WIDTH);
+		for (const cloud of clouds) {
+			// y should be in 0..30 range (percentage of viewport)
+			expect(cloud.y).toBeGreaterThanOrEqual(0);
+			expect(cloud.y).toBeLessThanOrEqual(30);
+		}
+	});
+
+	it('each cloud has triangles array, x, y, width, opacity', () => {
+		const clouds = generateCloudShapes(3, 42, VIEW_WIDTH);
+		for (const cloud of clouds) {
+			expect(Array.isArray(cloud.triangles)).toBe(true);
+			expect(cloud.triangles.length).toBeGreaterThanOrEqual(3);
+			expect(cloud.triangles.length).toBeLessThanOrEqual(5);
+			expect(cloud.x).toBeGreaterThanOrEqual(0);
+			expect(cloud.width).toBeGreaterThan(0);
+			expect(cloud.opacity).toBeGreaterThan(0);
+			expect(cloud.opacity).toBeLessThanOrEqual(1);
+		}
+	});
+});
+
+describe('generateFireflyPositions', () => {
+	it('is deterministic', () => {
+		const a = generateFireflyPositions(20, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		const b = generateFireflyPositions(20, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(a).toEqual(b);
+	});
+
+	it('returns requested count', () => {
+		const fireflies = generateFireflyPositions(15, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(fireflies).toHaveLength(15);
+	});
+
+	it('all values within valid ranges', () => {
+		const fireflies = generateFireflyPositions(30, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		for (const ff of fireflies) {
+			expect(ff.x).toBeGreaterThanOrEqual(0);
+			expect(ff.x).toBeLessThanOrEqual(VIEW_WIDTH);
+			expect(ff.y).toBeGreaterThanOrEqual(0);
+			expect(ff.y).toBeLessThanOrEqual(VIEW_HEIGHT);
+			expect(ff.delay).toBeGreaterThanOrEqual(0);
+			expect(ff.duration).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe('generateWindParticles', () => {
+	it('is deterministic', () => {
+		const a = generateWindParticles(20, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		const b = generateWindParticles(20, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(a).toEqual(b);
+	});
+
+	it('returns requested count', () => {
+		const particles = generateWindParticles(12, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		expect(particles).toHaveLength(12);
+	});
+
+	it('all values within valid ranges', () => {
+		const particles = generateWindParticles(30, 42, VIEW_WIDTH, VIEW_HEIGHT);
+		for (const p of particles) {
+			expect(p.x).toBeGreaterThanOrEqual(0);
+			expect(p.x).toBeLessThanOrEqual(VIEW_WIDTH);
+			expect(p.y).toBeGreaterThanOrEqual(0);
+			expect(p.y).toBeLessThanOrEqual(VIEW_HEIGHT);
+			expect(p.size).toBeGreaterThan(0);
+			expect(p.rotation).toBeGreaterThanOrEqual(0);
+			expect(p.rotation).toBeLessThanOrEqual(360);
+			expect(p.delay).toBeGreaterThanOrEqual(0);
+		}
+	});
+});

--- a/src/lib/environment/environment_generators.ts
+++ b/src/lib/environment/environment_generators.ts
@@ -1,0 +1,165 @@
+import { createPrng, randomInRange } from '$lib/trees/prng.js';
+
+interface RainDrop {
+	readonly x: number;
+	readonly y: number;
+	readonly length: number;
+	readonly delay: number;
+	readonly speed: number;
+}
+
+interface Snowflake {
+	readonly x: number;
+	readonly y: number;
+	readonly size: number;
+	readonly delay: number;
+	readonly drift: number;
+	readonly speed: number;
+}
+
+interface CloudShape {
+	readonly triangles: readonly string[];
+	readonly x: number;
+	readonly y: number;
+	readonly width: number;
+	readonly opacity: number;
+}
+
+interface Firefly {
+	readonly x: number;
+	readonly y: number;
+	readonly delay: number;
+	readonly duration: number;
+}
+
+interface WindParticle {
+	readonly x: number;
+	readonly y: number;
+	readonly size: number;
+	readonly rotation: number;
+	readonly delay: number;
+}
+
+export function generateRainDrops(
+	intensity: number,
+	seed: number,
+	viewWidth: number,
+	viewHeight: number,
+): RainDrop[] {
+	const rng = createPrng(seed);
+	const count = Math.round(intensity * 1.5);
+	const drops: RainDrop[] = [];
+
+	for (let i = 0; i < count; i++) {
+		drops.push({
+			x: randomInRange(rng, 0, viewWidth),
+			y: randomInRange(rng, 0, viewHeight),
+			length: randomInRange(rng, 10, 30),
+			delay: randomInRange(rng, 0, 2),
+			speed: randomInRange(rng, 0.3, 1.0),
+		});
+	}
+
+	return drops;
+}
+
+export function generateSnowflakes(
+	count: number,
+	seed: number,
+	viewWidth: number,
+	viewHeight: number,
+): Snowflake[] {
+	const rng = createPrng(seed);
+	const flakes: Snowflake[] = [];
+
+	for (let i = 0; i < count; i++) {
+		flakes.push({
+			x: randomInRange(rng, 0, viewWidth),
+			y: randomInRange(rng, 0, viewHeight),
+			size: randomInRange(rng, 2, 6),
+			delay: randomInRange(rng, 0, 5),
+			drift: randomInRange(rng, -20, 20),
+			speed: randomInRange(rng, 4, 8),
+		});
+	}
+
+	return flakes;
+}
+
+export function generateCloudShapes(count: number, seed: number, viewWidth: number): CloudShape[] {
+	const rng = createPrng(seed);
+	const clouds: CloudShape[] = [];
+
+	for (let i = 0; i < count; i++) {
+		const cloudWidth = randomInRange(rng, 80, 200);
+		const cloudHeight = randomInRange(rng, 30, 60);
+		const triangleCount = Math.round(randomInRange(rng, 3, 5));
+
+		const trianglePoints: string[] = [];
+		for (let t = 0; t < triangleCount; t++) {
+			const cx = randomInRange(rng, 0, cloudWidth);
+			const cy = randomInRange(rng, 0, cloudHeight);
+			const size = randomInRange(rng, 20, 50);
+			const x1 = cx - size / 2;
+			const y1 = cy + size / 3;
+			const x2 = cx + size / 2;
+			const y2 = cy + size / 3;
+			const x3 = cx;
+			const y3 = cy - size / 2;
+			trianglePoints.push(`${x1},${y1} ${x2},${y2} ${x3},${y3}`);
+		}
+
+		clouds.push({
+			triangles: trianglePoints,
+			x: randomInRange(rng, 0, viewWidth - cloudWidth),
+			y: randomInRange(rng, 0, 30),
+			width: cloudWidth,
+			opacity: randomInRange(rng, 0.3, 0.7),
+		});
+	}
+
+	return clouds;
+}
+
+export function generateFireflyPositions(
+	count: number,
+	seed: number,
+	viewWidth: number,
+	viewHeight: number,
+): Firefly[] {
+	const rng = createPrng(seed);
+	const fireflies: Firefly[] = [];
+
+	for (let i = 0; i < count; i++) {
+		fireflies.push({
+			x: randomInRange(rng, 0, viewWidth),
+			y: randomInRange(rng, 0, viewHeight),
+			delay: randomInRange(rng, 0, 5),
+			duration: randomInRange(rng, 2, 6),
+		});
+	}
+
+	return fireflies;
+}
+
+export function generateWindParticles(
+	count: number,
+	seed: number,
+	viewWidth: number,
+	viewHeight: number,
+): WindParticle[] {
+	const rng = createPrng(seed);
+	const particles: WindParticle[] = [];
+
+	for (let i = 0; i < count; i++) {
+		particles.push({
+			x: randomInRange(rng, 0, viewWidth),
+			y: randomInRange(rng, 0, viewHeight),
+			size: randomInRange(rng, 3, 10),
+			rotation: randomInRange(rng, 0, 360),
+			delay: randomInRange(rng, 0, 4),
+		});
+	}
+
+	return particles;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,10 +14,14 @@
 	import { createSceneConfigContext } from '$lib/scene/scene_config.context.svelte.js';
 	import { generateSceneLayout } from '$lib/scene/scene_layout.js';
 	import { SCENE_LIMITS } from '$lib/scene/scene_config.js';
+	import { createEnvironmentConfigContext } from '$lib/environment/environment_config.context.svelte.js';
+	import { ENVIRONMENT_LIMITS } from '$lib/environment/environment_config.js';
+	import EnvironmentOverlay from '$lib/environment/EnvironmentOverlay.svelte';
 	import Shuffle from '@lucide/svelte/icons/shuffle';
 
 	const treeConfig = createTreeConfigContext();
 	const sceneConfig = createSceneConfigContext();
+	const environmentConfig = createEnvironmentConfigContext();
 
 	let usePerShapeDefaults = $state(false);
 	let showAnchors = $state(false);
@@ -112,6 +116,10 @@
 					/>
 				</div>
 			{/each}
+			<EnvironmentOverlay
+				config={environmentConfig}
+				lightAngle={treeConfig.current.lightAngle}
+			/>
 		</div>
 
 		<!-- Shared Controls -->
@@ -342,6 +350,77 @@
 							bind:value={treeConfig.current.depthVariance}
 							class="w-full accent-primary"
 						/>
+					</div>
+				</SectionCard>
+
+				<SectionCard title="Environment" contentClass="space-y-4">
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="env-rain-toggle"
+							checked={environmentConfig.rainEnabled}
+							onCheckedChange={(v) => (environmentConfig.rainEnabled = v === true)}
+						/>
+						<Label>Rain</Label>
+					</div>
+					{#if environmentConfig.rainEnabled}
+						<LabeledRangeSlider
+							label="Rain Intensity"
+							min={ENVIRONMENT_LIMITS.rainIntensityMin}
+							max={ENVIRONMENT_LIMITS.rainIntensityMax}
+							bind:value={environmentConfig.rainIntensity}
+							id="rain-intensity"
+						/>
+					{/if}
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="env-lightning-toggle"
+							checked={environmentConfig.lightningEnabled}
+							onCheckedChange={(v) =>
+								(environmentConfig.lightningEnabled = v === true)}
+						/>
+						<Label>Lightning</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="env-snow-toggle"
+							checked={environmentConfig.snowEnabled}
+							onCheckedChange={(v) => (environmentConfig.snowEnabled = v === true)}
+						/>
+						<Label>Snow</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="env-fireflies-toggle"
+							checked={environmentConfig.firefliesEnabled}
+							onCheckedChange={(v) =>
+								(environmentConfig.firefliesEnabled = v === true)}
+						/>
+						<Label>Fireflies</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="env-wind-toggle"
+							checked={environmentConfig.windParticlesEnabled}
+							onCheckedChange={(v) =>
+								(environmentConfig.windParticlesEnabled = v === true)}
+						/>
+						<Label>Wind Particles</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="env-sun-rays-toggle"
+							checked={environmentConfig.sunRaysEnabled}
+							onCheckedChange={(v) => (environmentConfig.sunRaysEnabled = v === true)}
+						/>
+						<Label>Sun Rays</Label>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox
+							data-testid="env-clouds-toggle"
+							checked={environmentConfig.cloudsEnabled}
+							onCheckedChange={(v) => (environmentConfig.cloudsEnabled = v === true)}
+						/>
+						<Label>Clouds</Label>
 					</div>
 				</SectionCard>
 

--- a/tests/e2e/environment_effects.spec.ts
+++ b/tests/e2e/environment_effects.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Environment effects (#41)', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+	});
+
+	test('all 7 checkboxes visible and default unchecked', async ({ page }) => {
+		const toggleIds = [
+			'env-rain-toggle',
+			'env-lightning-toggle',
+			'env-snow-toggle',
+			'env-fireflies-toggle',
+			'env-wind-toggle',
+			'env-sun-rays-toggle',
+			'env-clouds-toggle',
+		];
+
+		for (const testId of toggleIds) {
+			const toggle = page.locator(`[data-testid="${testId}"]`);
+			await expect(toggle).toBeVisible();
+			await expect(toggle).toHaveAttribute('data-state', 'unchecked');
+		}
+	});
+
+	test('no environment effect overlays visible by default', async ({ page }) => {
+		await expect(page.locator('[data-testid="rain-overlay"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="snow-overlay"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="clouds-overlay"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="lightning-overlay"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="fireflies-overlay"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="wind-overlay"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="sun-rays-overlay"]')).toHaveCount(0);
+	});
+
+	test('toggling rain adds rain overlay with rain drops', async ({ page }) => {
+		const rainToggle = page.locator('[data-testid="env-rain-toggle"]');
+		await rainToggle.click();
+
+		await expect(page.locator('[data-testid="rain-overlay"]')).toHaveCount(1);
+		const drops = page.locator('[data-testid="rain-drop"]');
+		await expect(drops.first()).toBeVisible();
+		expect(await drops.count()).toBeGreaterThan(0);
+	});
+
+	test('rain intensity slider only visible when rain enabled', async ({ page }) => {
+		await expect(page.locator('#rain-intensity')).toHaveCount(0);
+
+		const rainToggle = page.locator('[data-testid="env-rain-toggle"]');
+		await rainToggle.click();
+
+		await expect(page.locator('#rain-intensity')).toBeVisible();
+	});
+
+	test('changing rain intensity changes number of rain drops', async ({ page }) => {
+		const rainToggle = page.locator('[data-testid="env-rain-toggle"]');
+		await rainToggle.click();
+
+		const slider = page.locator('#rain-intensity');
+		await expect(slider).toBeVisible();
+
+		// Default intensity = 50
+		const defaultDropCount = await page.locator('[data-testid="rain-drop"]').count();
+
+		// Increase intensity
+		await slider.fill('180');
+		await slider.dispatchEvent('input');
+
+		const highDropCount = await page.locator('[data-testid="rain-drop"]').count();
+		expect(highDropCount).toBeGreaterThan(defaultDropCount);
+	});
+
+	test('multiple effects can be enabled simultaneously', async ({ page }) => {
+		await page.locator('[data-testid="env-rain-toggle"]').click();
+		await page.locator('[data-testid="env-snow-toggle"]').click();
+		await page.locator('[data-testid="env-clouds-toggle"]').click();
+
+		await expect(page.locator('[data-testid="rain-overlay"]')).toHaveCount(1);
+		await expect(page.locator('[data-testid="snow-overlay"]')).toHaveCount(1);
+		await expect(page.locator('[data-testid="clouds-overlay"]')).toHaveCount(1);
+	});
+
+	test('environment overlay has pointer-events-none', async ({ page }) => {
+		const overlay = page.locator('[data-testid="environment-overlay"]');
+		await expect(overlay).toBeVisible();
+		await expect(overlay).toHaveCSS('pointer-events', 'none');
+	});
+
+	test('toggling lightning adds lightning overlay', async ({ page }) => {
+		await page.locator('[data-testid="env-lightning-toggle"]').click();
+		await expect(page.locator('[data-testid="lightning-overlay"]')).toHaveCount(1);
+	});
+
+	test('toggling fireflies adds firefly elements', async ({ page }) => {
+		await page.locator('[data-testid="env-fireflies-toggle"]').click();
+		await expect(page.locator('[data-testid="fireflies-overlay"]')).toHaveCount(1);
+		expect(await page.locator('[data-testid="firefly"]').count()).toBeGreaterThan(0);
+	});
+
+	test('toggling wind adds wind particle elements', async ({ page }) => {
+		await page.locator('[data-testid="env-wind-toggle"]').click();
+		await expect(page.locator('[data-testid="wind-overlay"]')).toHaveCount(1);
+		expect(await page.locator('[data-testid="wind-particle"]').count()).toBeGreaterThan(0);
+	});
+
+	test('toggling sun rays adds sun rays overlay', async ({ page }) => {
+		await page.locator('[data-testid="env-sun-rays-toggle"]').click();
+		await expect(page.locator('[data-testid="sun-rays-overlay"]')).toHaveCount(1);
+	});
+
+	test('snow and rain are distinct and can coexist', async ({ page }) => {
+		await page.locator('[data-testid="env-rain-toggle"]').click();
+		await page.locator('[data-testid="env-snow-toggle"]').click();
+
+		const rainDrops = page.locator('[data-testid="rain-drop"]');
+		const snowParticles = page.locator('[data-testid="snow-particle"]');
+
+		expect(await rainDrops.count()).toBeGreaterThan(0);
+		expect(await snowParticles.count()).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Description
- Add 7 scene-wide environment effects, all independently toggleable via checkboxes
- Rain (with intensity slider), lightning (random flash, capped at 0.3 opacity), snow, fireflies, wind particles, sun rays (lightAngle-aware), clouds (low-poly polygon shapes)
- SVG + CSS animation overlay layer above trees with `pointer-events: none`
- Deterministic generators using seeded PRNG for all particle positions
- `prefers-reduced-motion` support disables all animations

## Resolves
Closes #41

## Testing
- [x] 4 unit test suites: config defaults, rain generator (deterministic, intensity-scaled), snow/cloud/firefly/wind generators
- [x] 12 E2E tests: all 7 checkboxes visible + default unchecked, no overlays by default, rain toggle + drops, rain intensity slider conditional + density change, lightning/fireflies/wind/sun-rays toggle, multiple effects combinable, pointer-events-none, snow+rain coexistence
- [x] `check:all` clean (format + lint + typecheck + stylelint + knip)
- [x] 439 unit tests passing, 72 E2E tests passing (1 pre-existing auth failure unrelated)