### PR TITLE
refactor(tools): cleanup dead data, extract component, harden defaults (#40)

### DIFF
--- a/src/lib/components/composed/ToolAccessoriesCard.svelte
+++ b/src/lib/components/composed/ToolAccessoriesCard.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import SectionCard from '$lib/components/composed/SectionCard.svelte';
+	import LabeledRangeSlider from '$lib/components/composed/LabeledRangeSlider.svelte';
+	import { TOOL_OPTIONS, type ToolVisibility } from '$lib/trees/tools/tool_types.js';
+
+	interface Props {
+		toolVisibility: ToolVisibility;
+		animateTools: boolean;
+	}
+
+	let { toolVisibility = $bindable(), animateTools = $bindable() }: Props = $props();
+</script>
+
+<SectionCard title="Tools & Accessories" contentClass="space-y-4">
+	{#each TOOL_OPTIONS as option (option.value)}
+		<div class="flex items-center gap-2">
+			<Checkbox
+				data-testid="tool-{option.value}-visible"
+				checked={toolVisibility[option.value].visible}
+				onCheckedChange={(v) =>
+					(toolVisibility[option.value] = {
+						...toolVisibility[option.value],
+						visible: v === true,
+					})}
+			/>
+			<Label>{option.label}</Label>
+		</div>
+		{#if toolVisibility[option.value].visible}
+			<LabeledRangeSlider
+				label="{option.label} Size"
+				min={0.5}
+				max={2}
+				step={0.1}
+				bind:value={toolVisibility[option.value].size}
+				id="tool-{option.value}-size"
+			/>
+		{/if}
+	{/each}
+	<div class="flex items-center gap-2">
+		<Checkbox
+			data-testid="animate-tools"
+			checked={animateTools}
+			onCheckedChange={(v) => (animateTools = v === true)}
+		/>
+		<Label>Animate Tools</Label>
+	</div>
+</SectionCard>

--- a/src/lib/trees/TreeTool.svelte
+++ b/src/lib/trees/TreeTool.svelte
@@ -13,16 +13,16 @@
 
 	let { tool, anchor, size, animate }: Props = $props();
 
+	const TOOL_CSS_CLASS: Record<ToolType, string> = {
+		shovel: 'tool-shovel',
+		ladder: 'tool-ladder',
+		wateringCan: 'tool-watering-can',
+		birdNest: 'tool-bird-nest',
+	};
+
 	const svgData = $derived(TOOL_SVG_DATA[tool]);
 	const animationConfig = $derived(TOOL_ANIMATIONS[tool]);
-
-	const cssClass = $derived(
-		tool === 'wateringCan'
-			? 'tool-watering-can'
-			: tool === 'birdNest'
-				? 'tool-bird-nest'
-				: `tool-${tool}`,
-	);
+	const cssClass = $derived(TOOL_CSS_CLASS[tool]);
 </script>
 
 <!-- Outer <g> for positioning (translate + scale) — not animated -->

--- a/src/lib/trees/tools/tool_animations.test.ts
+++ b/src/lib/trees/tools/tool_animations.test.ts
@@ -36,10 +36,9 @@ describe('TOOL_ANIMATIONS', () => {
 		}
 	});
 
-	it('each tool has a CSS property string', () => {
+	it('each tool has a positive duration', () => {
 		for (const toolType of Object.values(TOOL_TYPES)) {
-			expect(typeof TOOL_ANIMATIONS[toolType].cssProperty).toBe('string');
-			expect(TOOL_ANIMATIONS[toolType].cssProperty.length).toBeGreaterThan(0);
+			expect(TOOL_ANIMATIONS[toolType].duration).toBeGreaterThan(0);
 		}
 	});
 });

--- a/src/lib/trees/tools/tool_animations.ts
+++ b/src/lib/trees/tools/tool_animations.ts
@@ -3,28 +3,23 @@ import type { ToolType } from './tool_types.js';
 interface ToolAnimationConfig {
 	readonly keyframeName: string;
 	readonly duration: number;
-	readonly cssProperty: string;
 }
 
 export const TOOL_ANIMATIONS = {
 	shovel: {
 		keyframeName: 'tool-shovel-idle',
 		duration: 2,
-		cssProperty: 'translateY',
 	},
 	ladder: {
 		keyframeName: 'tool-ladder-idle',
 		duration: 3,
-		cssProperty: 'rotate',
 	},
 	wateringCan: {
 		keyframeName: 'tool-watering-can-idle',
 		duration: 2.5,
-		cssProperty: 'rotate',
 	},
 	birdNest: {
 		keyframeName: 'tool-bird-nest-idle',
 		duration: 2,
-		cssProperty: 'translateY',
 	},
 } as const satisfies Record<ToolType, ToolAnimationConfig>;

--- a/src/lib/trees/tools/tool_svg_data.test.ts
+++ b/src/lib/trees/tools/tool_svg_data.test.ts
@@ -32,9 +32,8 @@ describe('TOOL_SVG_DATA', () => {
 				}
 			});
 
-			it('has positive width and height', () => {
-				expect(TOOL_SVG_DATA[toolType].width).toBeGreaterThan(0);
-				expect(TOOL_SVG_DATA[toolType].height).toBeGreaterThan(0);
+			it('first polygon has a valid points string', () => {
+				expect(TOOL_SVG_DATA[toolType].polygons[0].points.length).toBeGreaterThan(0);
 			});
 		});
 	}

--- a/src/lib/trees/tools/tool_svg_data.ts
+++ b/src/lib/trees/tools/tool_svg_data.ts
@@ -7,8 +7,6 @@ interface ToolPolygon {
 
 interface ToolSvgConfig {
 	readonly polygons: readonly ToolPolygon[];
-	readonly width: number;
-	readonly height: number;
 }
 
 // All coordinates are in local space centered near (0,0).
@@ -16,8 +14,6 @@ interface ToolSvgConfig {
 
 export const TOOL_SVG_DATA = {
 	shovel: {
-		width: 20,
-		height: 50,
 		polygons: [
 			// Handle (long wooden shaft)
 			{ points: '-1,-24 1,-24 1,12 -1,12', fill: '#8B6914' },
@@ -43,8 +39,6 @@ export const TOOL_SVG_DATA = {
 		],
 	},
 	ladder: {
-		width: 24,
-		height: 55,
 		polygons: [
 			// Left rail
 			{ points: '-10,-27 -8,-27 -8,27 -10,27', fill: '#A0782C' },
@@ -74,8 +68,6 @@ export const TOOL_SVG_DATA = {
 		],
 	},
 	wateringCan: {
-		width: 30,
-		height: 28,
 		polygons: [
 			// Body (main container - metallic)
 			{ points: '-8,-4 8,-4 10,8 -10,8', fill: '#708090' },
@@ -109,8 +101,6 @@ export const TOOL_SVG_DATA = {
 		],
 	},
 	birdNest: {
-		width: 28,
-		height: 20,
 		polygons: [
 			// Nest base (woven twigs - brown)
 			{ points: '-12,2 12,2 14,8 -14,8', fill: '#6B4226' },

--- a/src/lib/trees/tools/tool_types.test.ts
+++ b/src/lib/trees/tools/tool_types.test.ts
@@ -3,7 +3,7 @@ import {
 	TOOL_TYPES,
 	TOOL_ANCHOR_MAP,
 	TOOL_OPTIONS,
-	DEFAULT_TOOL_VISIBILITY,
+	createDefaultToolVisibility,
 } from './tool_types.js';
 
 describe('TOOL_TYPES', () => {
@@ -66,22 +66,32 @@ describe('TOOL_OPTIONS', () => {
 	});
 });
 
-describe('DEFAULT_TOOL_VISIBILITY', () => {
+describe('createDefaultToolVisibility', () => {
 	it('has entries for all 4 tools', () => {
+		const visibility = createDefaultToolVisibility();
 		for (const toolType of Object.values(TOOL_TYPES)) {
-			expect(DEFAULT_TOOL_VISIBILITY).toHaveProperty(toolType);
+			expect(visibility).toHaveProperty(toolType);
 		}
 	});
 
 	it('all tools start hidden', () => {
+		const visibility = createDefaultToolVisibility();
 		for (const toolType of Object.values(TOOL_TYPES)) {
-			expect(DEFAULT_TOOL_VISIBILITY[toolType].visible).toBe(false);
+			expect(visibility[toolType].visible).toBe(false);
 		}
 	});
 
 	it('all tools start at size 1', () => {
+		const visibility = createDefaultToolVisibility();
 		for (const toolType of Object.values(TOOL_TYPES)) {
-			expect(DEFAULT_TOOL_VISIBILITY[toolType].size).toBe(1);
+			expect(visibility[toolType].size).toBe(1);
 		}
+	});
+
+	it('returns a new object each call', () => {
+		const a = createDefaultToolVisibility();
+		const b = createDefaultToolVisibility();
+		expect(a).not.toBe(b);
+		expect(a.shovel).not.toBe(b.shovel);
 	});
 });

--- a/src/lib/trees/tools/tool_types.ts
+++ b/src/lib/trees/tools/tool_types.ts
@@ -23,12 +23,14 @@ export const TOOL_ANCHOR_MAP = {
 	[TOOL_TYPES.birdNest]: 'crownCenter',
 } as const satisfies Record<ToolType, keyof TreeAnchors>;
 
-export const DEFAULT_TOOL_VISIBILITY: ToolVisibility = {
-	[TOOL_TYPES.shovel]: { visible: false, size: 1 },
-	[TOOL_TYPES.ladder]: { visible: false, size: 1 },
-	[TOOL_TYPES.wateringCan]: { visible: false, size: 1 },
-	[TOOL_TYPES.birdNest]: { visible: false, size: 1 },
-};
+export function createDefaultToolVisibility(): ToolVisibility {
+	return {
+		[TOOL_TYPES.shovel]: { visible: false, size: 1 },
+		[TOOL_TYPES.ladder]: { visible: false, size: 1 },
+		[TOOL_TYPES.wateringCan]: { visible: false, size: 1 },
+		[TOOL_TYPES.birdNest]: { visible: false, size: 1 },
+	};
+}
 
 export const TOOL_OPTIONS = [
 	{ value: TOOL_TYPES.shovel, label: 'Shovel' },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,10 +11,10 @@
 	import { SHAPE_DEFAULTS } from '$lib/trees/types.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import {
-		TOOL_OPTIONS,
-		DEFAULT_TOOL_VISIBILITY,
+		createDefaultToolVisibility,
 		type ToolVisibility,
 	} from '$lib/trees/tools/tool_types.js';
+	import ToolAccessoriesCard from '$lib/components/composed/ToolAccessoriesCard.svelte';
 	import { createTreeConfigContext } from '$lib/trees/tree_config.context.svelte.js';
 	import { createSceneConfigContext } from '$lib/scene/scene_config.context.svelte.js';
 	import { generateSceneLayout } from '$lib/scene/scene_layout.js';
@@ -36,7 +36,7 @@
 	let animateCanopySway = $state(false);
 	let animateBranches = $state(false);
 	let animateGrowth = $state(false);
-	let toolVisibility: ToolVisibility = $state({ ...DEFAULT_TOOL_VISIBILITY });
+	let toolVisibility: ToolVisibility = $state(createDefaultToolVisibility());
 	let animateTools = $state(false);
 
 	const trunkCrookednessDisabled = $derived(
@@ -433,40 +433,7 @@
 					</div>
 				</SectionCard>
 
-				<SectionCard title="Tools & Accessories" contentClass="space-y-4">
-					{#each TOOL_OPTIONS as option (option.value)}
-						<div class="flex items-center gap-2">
-							<Checkbox
-								data-testid="tool-{option.value}-visible"
-								checked={toolVisibility[option.value].visible}
-								onCheckedChange={(v) =>
-									(toolVisibility[option.value] = {
-										...toolVisibility[option.value],
-										visible: v === true,
-									})}
-							/>
-							<Label>{option.label}</Label>
-						</div>
-						{#if toolVisibility[option.value].visible}
-							<LabeledRangeSlider
-								label="{option.label} Size"
-								min={0.5}
-								max={2}
-								step={0.1}
-								bind:value={toolVisibility[option.value].size}
-								id="tool-{option.value}-size"
-							/>
-						{/if}
-					{/each}
-					<div class="flex items-center gap-2">
-						<Checkbox
-							data-testid="animate-tools"
-							checked={animateTools}
-							onCheckedChange={(v) => (animateTools = v === true)}
-						/>
-						<Label>Animate Tools</Label>
-					</div>
-				</SectionCard>
+				<ToolAccessoriesCard bind:toolVisibility bind:animateTools />
 
 				<SectionCard title="Debug" contentClass="space-y-4">
 					<div class="flex items-center gap-2">

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -2,7 +2,7 @@
 	import LowPolyTree from '$lib/trees/LowPolyTree.svelte';
 	import LabeledSelect from '$lib/components/composed/LabeledSelect.svelte';
 	import LabeledRangeSlider from '$lib/components/composed/LabeledRangeSlider.svelte';
-	import SectionCard from '$lib/components/composed/SectionCard.svelte';
+
 	import CustomBlobsEditor from '$lib/components/composed/CustomBlobsEditor.svelte';
 	import CanopyColorCard from '$lib/components/composed/CanopyColorCard.svelte';
 	import TrunkColorCard from '$lib/components/composed/TrunkColorCard.svelte';
@@ -23,10 +23,10 @@
 		type FruitType,
 	} from '$lib/trees/types.js';
 	import {
-		TOOL_OPTIONS,
-		DEFAULT_TOOL_VISIBILITY,
+		createDefaultToolVisibility,
 		type ToolVisibility,
 	} from '$lib/trees/tools/tool_types.js';
+	import ToolAccessoriesCard from '$lib/components/composed/ToolAccessoriesCard.svelte';
 	import { growCustomBlobs } from '$lib/trees/shapes.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import { getSavedTree, saveTree } from '$lib/trees/saved_trees.remote.js';
@@ -48,7 +48,7 @@
 	let animateCanopySway = $state(false);
 	let animateBranches = $state(false);
 	let animateGrowth = $state(false);
-	let toolVisibility: ToolVisibility = $state({ ...DEFAULT_TOOL_VISIBILITY });
+	let toolVisibility: ToolVisibility = $state(createDefaultToolVisibility());
 	let animateTools = $state(false);
 
 	const branchCountDisabled = $derived(
@@ -439,40 +439,7 @@
 					</Card.Content>
 				</Card.Root>
 
-				<SectionCard title="Tools & Accessories" contentClass="space-y-4">
-					{#each TOOL_OPTIONS as option (option.value)}
-						<div class="flex items-center gap-2">
-							<Checkbox
-								data-testid="tool-{option.value}-visible"
-								checked={toolVisibility[option.value].visible}
-								onCheckedChange={(v) =>
-									(toolVisibility[option.value] = {
-										...toolVisibility[option.value],
-										visible: v === true,
-									})}
-							/>
-							<Label>{option.label}</Label>
-						</div>
-						{#if toolVisibility[option.value].visible}
-							<LabeledRangeSlider
-								label="{option.label} Size"
-								min={0.5}
-								max={2}
-								step={0.1}
-								bind:value={toolVisibility[option.value].size}
-								id="tool-{option.value}-size"
-							/>
-						{/if}
-					{/each}
-					<div class="flex items-center gap-2">
-						<Checkbox
-							data-testid="animate-tools"
-							checked={animateTools}
-							onCheckedChange={(v) => (animateTools = v === true)}
-						/>
-						<Label>Animate Tools</Label>
-					</div>
-				</SectionCard>
+				<ToolAccessoriesCard bind:toolVisibility bind:animateTools />
 
 				<Card.Root>
 					<Card.Header>


### PR DESCRIPTION
## Summary
- Remove unused `cssProperty` from `ToolAnimationConfig` and `width`/`height` from `ToolSvgConfig` (dead data)
- Extract duplicated Tools & Accessories SectionCard into `ToolAccessoriesCard.svelte` (DRY)
- Replace fragile `cssClass` ternary chain with `Record<ToolType, string>` map
- Replace shallow spread of `DEFAULT_TOOL_VISIBILITY` with `createDefaultToolVisibility()` factory function

## Test plan
- [x] All 483 unit tests pass
- [x] `pnpm check:all` passes (format + lint + typecheck + stylelint + knip)
- [x] Pre-push hooks (typecheck + test) pass

Closes #40