### PR TITLE
#65 feat(generator): potted plant + oak/PRD tree with completion tracking

### DIFF
--- a/src/lib/trees/OakTree.svelte
+++ b/src/lib/trees/OakTree.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import { generateOakPrdTree } from '$lib/trees/oak_prd_generator.js';
+	import { DEFAULT_OAK_PRD_CONFIG, type OakPrdConfig } from '$lib/trees/types.js';
+
+	interface Props {
+		completionRatio?: number;
+		issueCount?: number;
+		seed?: number;
+		name?: string;
+		class?: string;
+	}
+
+	let {
+		completionRatio = DEFAULT_OAK_PRD_CONFIG.completionRatio,
+		issueCount = DEFAULT_OAK_PRD_CONFIG.issueCount,
+		seed = DEFAULT_OAK_PRD_CONFIG.seed,
+		name,
+		class: className = '',
+	}: Props = $props();
+
+	const config = $derived<OakPrdConfig>({
+		completionRatio,
+		issueCount,
+		seed,
+		name,
+	});
+
+	const geometry = $derived(generateOakPrdTree(config));
+
+	const NAMEPLATE_HEIGHT = 24;
+	const NAMEPLATE_PADDING_X = 12;
+	const NAMEPLATE_PADDING_Y = 4;
+	const NAMEPLATE_RADIUS = 4;
+	const NAMEPLATE_FILL = '#8B8B8B';
+	const NAMEPLATE_STROKE = '#6B6B6B';
+	const NAMEPLATE_FONT_SIZE = 12;
+	const NAMEPLATE_CHAR_WIDTH_RATIO = 0.6;
+	const NAMEPLATE_OFFSET_Y = 20;
+	const NAMEPLATE_EXTRA_HEIGHT = NAMEPLATE_OFFSET_Y + NAMEPLATE_HEIGHT + 10;
+
+	const viewBoxHeight = $derived(
+		name !== undefined && name !== ''
+			? geometry.viewBox.height + NAMEPLATE_EXTRA_HEIGHT
+			: geometry.viewBox.height,
+	);
+</script>
+
+<svg
+	viewBox="0 0 {geometry.viewBox.width} {viewBoxHeight}"
+	xmlns="http://www.w3.org/2000/svg"
+	class={className}
+>
+	<g class="oak-tree-root">
+		<!-- Trunk quads -->
+		<g class="trunk">
+			{#each geometry.trunkQuads as quad (quad)}
+				<polygon
+					points="{quad.points[0].x},{quad.points[0].y} {quad.points[1].x},{quad.points[1]
+						.y} {quad.points[2].x},{quad.points[2].y} {quad.points[3].x},{quad.points[3]
+						.y}"
+					fill={quad.color}
+					stroke={quad.color}
+					stroke-width="0.5"
+				/>
+			{/each}
+		</g>
+
+		<!-- Branch groups -->
+		<g class="branches">
+			{#each geometry.branchGroups as group (group)}
+				<g class="branch-group">
+					{#each group.quads as quad (quad)}
+						<polygon
+							points="{quad.points[0].x},{quad.points[0].y} {quad.points[1].x},{quad
+								.points[1].y} {quad.points[2].x},{quad.points[2].y} {quad.points[3]
+								.x},{quad.points[3].y}"
+							fill={quad.color}
+							stroke={quad.color}
+							stroke-width="0.5"
+						/>
+					{/each}
+					{#each group.junctionFills as fill (fill)}
+						<polygon
+							points="{fill.points[0].x},{fill.points[0].y} {fill.points[1].x},{fill
+								.points[1].y} {fill.points[2].x},{fill.points[2].y} {fill.points[3]
+								.x},{fill.points[3].y}"
+							fill={fill.color}
+							stroke={fill.color}
+							stroke-width="0.5"
+						/>
+					{/each}
+				</g>
+			{/each}
+		</g>
+
+		<!-- Canopy blobs (only those with triangles — bare branches have empty blobs) -->
+		<g class="canopy">
+			{#each geometry.canopyBlobs as blob (blob)}
+				{#if blob.triangles.length > 0}
+					<g class="canopy-blob">
+						{#each blob.triangles as tri (tri)}
+							<polygon
+								points="{tri.points[0].x},{tri.points[0].y} {tri.points[1].x},{tri
+									.points[1].y} {tri.points[2].x},{tri.points[2].y}"
+								fill={tri.color}
+								stroke={tri.color}
+								stroke-width="0.5"
+							/>
+						{/each}
+					</g>
+				{/if}
+			{/each}
+		</g>
+
+		<!-- Stone nameplate (oak only, when name is provided) -->
+		{#if name !== undefined && name !== ''}
+			<g class="nameplate">
+				<rect
+					x={geometry.viewBox.width / 2 -
+						(name.length * NAMEPLATE_FONT_SIZE * NAMEPLATE_CHAR_WIDTH_RATIO) / 2 -
+						NAMEPLATE_PADDING_X}
+					y={geometry.anchors.trunkBase.y + NAMEPLATE_OFFSET_Y}
+					width={name.length * NAMEPLATE_FONT_SIZE * NAMEPLATE_CHAR_WIDTH_RATIO +
+						NAMEPLATE_PADDING_X * 2}
+					height={NAMEPLATE_HEIGHT}
+					rx={NAMEPLATE_RADIUS}
+					ry={NAMEPLATE_RADIUS}
+					fill={NAMEPLATE_FILL}
+					stroke={NAMEPLATE_STROKE}
+					stroke-width="1.5"
+				/>
+				<text
+					x={geometry.viewBox.width / 2}
+					y={geometry.anchors.trunkBase.y +
+						NAMEPLATE_OFFSET_Y +
+						NAMEPLATE_HEIGHT / 2 +
+						NAMEPLATE_PADDING_Y}
+					text-anchor="middle"
+					font-size={NAMEPLATE_FONT_SIZE}
+					font-family="sans-serif"
+					font-weight="600"
+					fill="white"
+				>
+					{name}
+				</text>
+			</g>
+		{/if}
+	</g>
+</svg>

--- a/src/lib/trees/PottedPlant.svelte
+++ b/src/lib/trees/PottedPlant.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { generatePottedPlant } from '$lib/trees/potted_plant_generator.js';
+	import {
+		DEFAULT_POTTED_PLANT_CONFIG,
+		POTTED_PLANT_STAGES,
+		type PottedPlantConfig,
+		type PottedPlantStage,
+	} from '$lib/trees/types.js';
+
+	interface Props {
+		stage?: PottedPlantStage;
+		seed?: number;
+		canopyLightColor?: string;
+		canopyDarkColor?: string;
+		class?: string;
+	}
+
+	let {
+		stage = DEFAULT_POTTED_PLANT_CONFIG.stage,
+		seed = DEFAULT_POTTED_PLANT_CONFIG.seed,
+		canopyLightColor,
+		canopyDarkColor,
+		class: className = '',
+	}: Props = $props();
+
+	const config = $derived<PottedPlantConfig>({
+		stage,
+		seed,
+		canopyLightColor,
+		canopyDarkColor,
+	});
+
+	const geometry = $derived(generatePottedPlant(config));
+	const isDried = $derived(stage === POTTED_PLANT_STAGES.dried);
+</script>
+
+<svg
+	viewBox="0 0 {geometry.viewBox.width} {geometry.viewBox.height}"
+	xmlns="http://www.w3.org/2000/svg"
+	class={className}
+>
+	<g class="potted-plant-root">
+		<!-- Pot + stem (trunk triangles) -->
+		<g class="pot-and-stem">
+			{#each geometry.trunkTriangles as tri (tri)}
+				<polygon
+					points="{tri.points[0].x},{tri.points[0].y} {tri.points[1].x},{tri.points[1]
+						.y} {tri.points[2].x},{tri.points[2].y}"
+					fill={tri.color}
+					stroke={tri.color}
+					stroke-width="0.5"
+				/>
+			{/each}
+		</g>
+
+		<!-- Canopy blobs -->
+		{#if geometry.canopyBlobs.length > 0}
+			<g class="canopy" class:dried-canopy={isDried}>
+				{#each geometry.canopyBlobs as blob (blob)}
+					<g class="canopy-blob">
+						{#each blob.triangles as tri (tri)}
+							<polygon
+								points="{tri.points[0].x},{tri.points[0].y} {tri.points[1].x},{tri
+									.points[1].y} {tri.points[2].x},{tri.points[2].y}"
+								fill={tri.color}
+								stroke={tri.color}
+								stroke-width="0.5"
+							/>
+						{/each}
+					</g>
+				{/each}
+			</g>
+		{/if}
+
+		<!-- Fruit (flowers) -->
+		{#if geometry.fruitTriangles.length > 0}
+			<g class="fruit">
+				{#each geometry.fruitTriangles as tri (tri)}
+					<polygon
+						points="{tri.points[0].x},{tri.points[0].y} {tri.points[1].x},{tri.points[1]
+							.y} {tri.points[2].x},{tri.points[2].y}"
+						fill={tri.color}
+						stroke={tri.color}
+						stroke-width="0.5"
+					/>
+				{/each}
+			</g>
+		{/if}
+	</g>
+</svg>
+
+<style>
+	.dried-canopy {
+		transform: skewY(3deg);
+		transform-origin: center bottom;
+	}
+</style>

--- a/src/lib/trees/oak_prd_generator.test.ts
+++ b/src/lib/trees/oak_prd_generator.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { generateOakPrdTree } from './oak_prd_generator.js';
+import type { OakPrdConfig } from './types/oak_prd_types.js';
+import { DEFAULT_OAK_PRD_CONFIG, OAK_PRD_VIEWBOX } from './types/oak_prd_types.js';
+
+function makeConfig(overrides: Partial<OakPrdConfig> = {}): OakPrdConfig {
+	return { ...DEFAULT_OAK_PRD_CONFIG, ...overrides };
+}
+
+describe('generateOakPrdTree', () => {
+	it('returns TreeGeometry with OAK_PRD_VIEWBOX (300x450)', () => {
+		const geo = generateOakPrdTree(makeConfig());
+		expect(geo.viewBox.width).toBe(OAK_PRD_VIEWBOX.width);
+		expect(geo.viewBox.height).toBe(OAK_PRD_VIEWBOX.height);
+		expect(Array.isArray(geo.trunkQuads)).toBe(true);
+		expect(Array.isArray(geo.trunkTriangles)).toBe(true);
+		expect(Array.isArray(geo.branchGroups)).toBe(true);
+		expect(Array.isArray(geo.canopyBlobs)).toBe(true);
+		expect(Array.isArray(geo.fruitTriangles)).toBe(true);
+		expect(Array.isArray(geo.stakeTriangles)).toBe(true);
+		expect(Array.isArray(geo.fruitSlots)).toBe(true);
+	});
+
+	it('completionRatio=1 produces all canopyBlobs with triangles', () => {
+		const geo = generateOakPrdTree(makeConfig({ completionRatio: 1 }));
+		expect(geo.canopyBlobs.length).toBeGreaterThan(0);
+		for (const blob of geo.canopyBlobs) {
+			expect(blob.triangles.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('completionRatio=0 produces all canopyBlobs with zero triangles', () => {
+		const geo = generateOakPrdTree(makeConfig({ completionRatio: 0 }));
+		expect(geo.canopyBlobs.length).toBeGreaterThan(0);
+		for (const blob of geo.canopyBlobs) {
+			expect(blob.triangles.length).toBe(0);
+		}
+	});
+
+	it('completionRatio=0.6 with issueCount=20 splits blobs proportionally', () => {
+		const geo = generateOakPrdTree(makeConfig({ completionRatio: 0.6, issueCount: 20 }));
+		const total = geo.canopyBlobs.length;
+		const filledCount = geo.canopyBlobs.filter((b) => b.triangles.length > 0).length;
+		const emptyCount = total - filledCount;
+		const expectedFilled = Math.floor(total * 0.6);
+		expect(filledCount).toBe(expectedFilled);
+		expect(emptyCount).toBe(total - expectedFilled);
+	});
+
+	it('branchGroups have non-empty quads even when completionRatio=0', () => {
+		const geo = generateOakPrdTree(makeConfig({ completionRatio: 0 }));
+		expect(geo.branchGroups.length).toBeGreaterThan(0);
+		const totalBranchQuads = geo.branchGroups.reduce((sum, g) => sum + g.quads.length, 0);
+		expect(totalBranchQuads).toBeGreaterThan(0);
+	});
+
+	it('all geometry points fall within [0, 300] x [0, 450] bounds', () => {
+		const geo = generateOakPrdTree(makeConfig({ completionRatio: 1 }));
+		const allPoints: { x: number; y: number }[] = [];
+
+		for (const quad of geo.trunkQuads) {
+			allPoints.push(...quad.points);
+		}
+		for (const tri of geo.trunkTriangles) {
+			allPoints.push(...tri.points);
+		}
+		for (const group of geo.branchGroups) {
+			for (const quad of group.quads) {
+				allPoints.push(...quad.points);
+			}
+		}
+		for (const blob of geo.canopyBlobs) {
+			for (const tri of blob.triangles) {
+				allPoints.push(...tri.points);
+			}
+		}
+
+		expect(allPoints.length).toBeGreaterThan(0);
+		for (const point of allPoints) {
+			expect(point.x).toBeGreaterThanOrEqual(0);
+			expect(point.x).toBeLessThanOrEqual(OAK_PRD_VIEWBOX.width);
+			expect(point.y).toBeGreaterThanOrEqual(0);
+			expect(point.y).toBeLessThanOrEqual(OAK_PRD_VIEWBOX.height);
+		}
+	});
+
+	it('same config produces identical output (deterministic)', () => {
+		const config = makeConfig({ completionRatio: 0.5, issueCount: 12, seed: 99 });
+		const geo1 = generateOakPrdTree(config);
+		const geo2 = generateOakPrdTree(config);
+		expect(geo1).toEqual(geo2);
+	});
+
+	it('higher issueCount produces more canopyBlobs', () => {
+		const geoSmall = generateOakPrdTree(makeConfig({ issueCount: 4, completionRatio: 1 }));
+		const geoLarge = generateOakPrdTree(makeConfig({ issueCount: 20, completionRatio: 1 }));
+		expect(geoLarge.canopyBlobs.length).toBeGreaterThan(geoSmall.canopyBlobs.length);
+	});
+
+	it('anchors are within viewBox bounds', () => {
+		const geo = generateOakPrdTree(makeConfig({ completionRatio: 0.5 }));
+		const { anchors } = geo;
+		const namedPoints = [
+			anchors.trunkTop,
+			anchors.trunkMiddle,
+			anchors.trunkBase,
+			anchors.crownCenter,
+			anchors.crownTop,
+			anchors.roots,
+		];
+		for (const point of namedPoints) {
+			expect(point.x).toBeGreaterThanOrEqual(0);
+			expect(point.x).toBeLessThanOrEqual(OAK_PRD_VIEWBOX.width);
+			expect(point.y).toBeGreaterThanOrEqual(0);
+			expect(point.y).toBeLessThanOrEqual(OAK_PRD_VIEWBOX.height);
+		}
+		for (const tip of anchors.branchTips) {
+			expect(tip.x).toBeGreaterThanOrEqual(0);
+			expect(tip.x).toBeLessThanOrEqual(OAK_PRD_VIEWBOX.width);
+			expect(tip.y).toBeGreaterThanOrEqual(0);
+			expect(tip.y).toBeLessThanOrEqual(OAK_PRD_VIEWBOX.height);
+		}
+	});
+});

--- a/src/lib/trees/oak_prd_generator.ts
+++ b/src/lib/trees/oak_prd_generator.ts
@@ -1,0 +1,143 @@
+import { generateTree } from './generate.js';
+import { DEFAULT_TREE_CONFIG, SHAPE_DEFAULTS, TREE_SHAPES, TREE_STAGES } from './types.js';
+import type {
+	TreeGeometry,
+	TreeConfig,
+	Point2D,
+	Triangle,
+	Quad,
+	BlobGeometry,
+	BranchGeometry,
+	TreeAnchors,
+} from './types.js';
+import type { OakPrdConfig } from './types/oak_prd_types.js';
+import { OAK_PRD_VIEWBOX } from './types/oak_prd_types.js';
+import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types.js';
+
+const SCALE_X = OAK_PRD_VIEWBOX.width / VIEWBOX_WIDTH;
+const SCALE_Y = OAK_PRD_VIEWBOX.height / VIEWBOX_HEIGHT;
+const MAX_BLOB_COUNT = 15;
+const MIN_BLOB_COUNT = 3;
+
+function scalePoint(point: Point2D): Point2D {
+	return { x: point.x * SCALE_X, y: point.y * SCALE_Y };
+}
+
+function scaleTriangle(tri: Triangle): Triangle {
+	return {
+		points: [scalePoint(tri.points[0]), scalePoint(tri.points[1]), scalePoint(tri.points[2])],
+		color: tri.color,
+		group: tri.group,
+	};
+}
+
+function scaleQuad(quad: Quad): Quad {
+	return {
+		points: [
+			scalePoint(quad.points[0]),
+			scalePoint(quad.points[1]),
+			scalePoint(quad.points[2]),
+			scalePoint(quad.points[3]),
+		],
+		color: quad.color,
+		group: quad.group,
+	};
+}
+
+function scaleBranchGeometry(branch: BranchGeometry): BranchGeometry {
+	return {
+		quads: branch.quads.map(scaleQuad),
+		junctionFills: branch.junctionFills.map(scaleQuad),
+		origin: scalePoint(branch.origin),
+		depth: branch.depth,
+	};
+}
+
+function scaleBlobGeometry(blob: BlobGeometry): BlobGeometry {
+	return {
+		triangles: blob.triangles.map(scaleTriangle),
+		center: scalePoint(blob.center),
+		depth: blob.depth,
+	};
+}
+
+function scaleAnchors(anchors: TreeAnchors): TreeAnchors {
+	return {
+		trunkTop: scalePoint(anchors.trunkTop),
+		trunkMiddle: scalePoint(anchors.trunkMiddle),
+		trunkBase: scalePoint(anchors.trunkBase),
+		crownCenter: scalePoint(anchors.crownCenter),
+		crownTop: scalePoint(anchors.crownTop),
+		roots: scalePoint(anchors.roots),
+		branchTips: anchors.branchTips.map(scalePoint),
+		fruitSlots: anchors.fruitSlots.map(scalePoint),
+	};
+}
+
+function scaleGeometry(geometry: TreeGeometry): TreeGeometry {
+	return {
+		trunkQuads: geometry.trunkQuads.map(scaleQuad),
+		trunkTriangles: geometry.trunkTriangles.map(scaleTriangle),
+		branchGroups: geometry.branchGroups.map(scaleBranchGeometry),
+		canopyBlobs: geometry.canopyBlobs.map(scaleBlobGeometry),
+		fruitTriangles: geometry.fruitTriangles.map(scaleTriangle),
+		stakeTriangles: geometry.stakeTriangles.map(scaleTriangle),
+		fruitSlots: geometry.fruitSlots.map(scalePoint),
+		anchors: scaleAnchors(geometry.anchors),
+		viewBox: OAK_PRD_VIEWBOX,
+	};
+}
+
+function computeBlobCount(issueCount: number): number {
+	return Math.min(MAX_BLOB_COUNT, Math.max(MIN_BLOB_COUNT, Math.ceil(issueCount / 2)));
+}
+
+function applyCompletionRatio(
+	canopyBlobs: readonly BlobGeometry[],
+	completionRatio: number,
+): readonly BlobGeometry[] {
+	const totalBlobs = canopyBlobs.length;
+	const completedCount = Math.floor(totalBlobs * completionRatio);
+
+	const sortedIndices = [...Array(totalBlobs).keys()].sort((a, b) => {
+		const blobA = canopyBlobs[a]!;
+		const blobB = canopyBlobs[b]!;
+		return blobA.center.y - blobB.center.y || blobA.center.x - blobB.center.x;
+	});
+
+	const rankOf = Array.from<number>({ length: totalBlobs });
+	sortedIndices.forEach((originalIndex, rank) => {
+		rankOf[originalIndex] = rank;
+	});
+
+	return canopyBlobs.map((blob, i) => {
+		if (rankOf[i]! < completedCount) {
+			return blob;
+		}
+		return { triangles: [], center: blob.center, depth: blob.depth };
+	});
+}
+
+export function generateOakPrdTree(config: OakPrdConfig): TreeGeometry {
+	const blobCount = computeBlobCount(config.issueCount);
+
+	const treeConfig: TreeConfig = {
+		...DEFAULT_TREE_CONFIG,
+		...SHAPE_DEFAULTS.oak,
+		shape: TREE_SHAPES.oak,
+		stage: TREE_STAGES.leafy,
+		seed: config.seed,
+		blobCount,
+		branchesLevel1Range: [Math.min(blobCount, 5), Math.min(blobCount + 1, 8)] as const,
+	};
+
+	const baseGeometry = generateTree(treeConfig);
+	const scaledGeometry = scaleGeometry(baseGeometry);
+
+	const processedBlobs = applyCompletionRatio(scaledGeometry.canopyBlobs, config.completionRatio);
+
+	return {
+		...scaledGeometry,
+		canopyBlobs: processedBlobs,
+	};
+}

--- a/src/lib/trees/potted_plant_generator.test.ts
+++ b/src/lib/trees/potted_plant_generator.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import { generatePottedPlant } from './potted_plant_generator.js';
+import type { TreeGeometry } from './types.js';
+import { GEOMETRY_GROUPS } from './types.js';
+import { POTTED_PLANT_STAGES, type PottedPlantConfig } from './types/potted_plant_types.js';
+
+function makeConfig(overrides: Partial<PottedPlantConfig> = {}): PottedPlantConfig {
+	return {
+		stage: POTTED_PLANT_STAGES.flowering,
+		seed: 42,
+		...overrides,
+	};
+}
+
+function hasValidAnchors(geo: TreeGeometry): boolean {
+	const { anchors } = geo;
+	return (
+		typeof anchors.trunkTop.x === 'number' &&
+		typeof anchors.trunkTop.y === 'number' &&
+		typeof anchors.trunkMiddle.x === 'number' &&
+		typeof anchors.trunkMiddle.y === 'number' &&
+		typeof anchors.trunkBase.x === 'number' &&
+		typeof anchors.trunkBase.y === 'number' &&
+		typeof anchors.crownCenter.x === 'number' &&
+		typeof anchors.crownCenter.y === 'number' &&
+		typeof anchors.crownTop.x === 'number' &&
+		typeof anchors.crownTop.y === 'number' &&
+		typeof anchors.roots.x === 'number' &&
+		typeof anchors.roots.y === 'number' &&
+		Array.isArray(anchors.branchTips) &&
+		Array.isArray(anchors.fruitSlots)
+	);
+}
+
+describe('potted plant — all stages return valid TreeGeometry', () => {
+	const allStages = Object.values(POTTED_PLANT_STAGES);
+
+	for (const stage of allStages) {
+		it(`${stage}: viewBox 200x300, valid anchors, all arrays present`, () => {
+			const geo = generatePottedPlant(makeConfig({ stage }));
+			expect(geo.viewBox.width).toBe(200);
+			expect(geo.viewBox.height).toBe(300);
+			expect(hasValidAnchors(geo)).toBe(true);
+			expect(Array.isArray(geo.trunkQuads)).toBe(true);
+			expect(Array.isArray(geo.trunkTriangles)).toBe(true);
+			expect(Array.isArray(geo.branchGroups)).toBe(true);
+			expect(Array.isArray(geo.canopyBlobs)).toBe(true);
+			expect(Array.isArray(geo.fruitTriangles)).toBe(true);
+			expect(Array.isArray(geo.stakeTriangles)).toBe(true);
+			expect(Array.isArray(geo.fruitSlots)).toBe(true);
+		});
+	}
+});
+
+describe('pot-with-soil stage', () => {
+	it('has pot triangles with group "pot"', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.potWithSoil }));
+		const potTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.pot);
+		expect(potTriangles.length).toBeGreaterThan(0);
+	});
+
+	it('has soil triangles (brown trunk triangles at pot top)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.potWithSoil }));
+		// Soil is part of trunkTriangles but distinct from pot
+		const allTriangles = geo.trunkTriangles;
+		expect(allTriangles.length).toBeGreaterThanOrEqual(3); // pot + soil
+	});
+
+	it('has NO canopy blobs', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.potWithSoil }));
+		expect(geo.canopyBlobs).toHaveLength(0);
+	});
+
+	it('has NO fruit triangles', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.potWithSoil }));
+		expect(geo.fruitTriangles).toHaveLength(0);
+	});
+});
+
+describe('sprout stage', () => {
+	it('has pot triangles with group "pot"', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.sprout }));
+		const potTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.pot);
+		expect(potTriangles.length).toBeGreaterThan(0);
+	});
+
+	it('has a stem (trunk triangles with group "trunk")', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.sprout }));
+		const stemTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.trunk);
+		expect(stemTriangles.length).toBeGreaterThan(0);
+	});
+
+	it('has exactly 1 canopy blob with 2 leaf triangles', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.sprout }));
+		expect(geo.canopyBlobs).toHaveLength(1);
+		expect(geo.canopyBlobs[0].triangles).toHaveLength(2);
+		for (const tri of geo.canopyBlobs[0].triangles) {
+			expect(tri.group).toBe(GEOMETRY_GROUPS.canopy);
+		}
+	});
+
+	it('has NO fruit triangles', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.sprout }));
+		expect(geo.fruitTriangles).toHaveLength(0);
+	});
+});
+
+describe('small-plant stage', () => {
+	it('has pot triangles and stem', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.smallPlant }));
+		const potTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.pot);
+		const stemTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.trunk);
+		expect(potTriangles.length).toBeGreaterThan(0);
+		expect(stemTriangles.length).toBeGreaterThan(0);
+	});
+
+	it('has 1-2 canopy blobs with triangulated triangles (more than 2 each)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.smallPlant }));
+		expect(geo.canopyBlobs.length).toBeGreaterThanOrEqual(1);
+		expect(geo.canopyBlobs.length).toBeLessThanOrEqual(2);
+		for (const blob of geo.canopyBlobs) {
+			expect(blob.triangles.length).toBeGreaterThan(2);
+		}
+	});
+
+	it('has 1-2 fruitSlots on anchors', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.smallPlant }));
+		expect(geo.anchors.fruitSlots.length).toBeGreaterThanOrEqual(1);
+		expect(geo.anchors.fruitSlots.length).toBeLessThanOrEqual(2);
+	});
+});
+
+describe('flowering stage', () => {
+	it('has pot + stem + canopy blobs', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.flowering }));
+		const potTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.pot);
+		const stemTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.trunk);
+		expect(potTriangles.length).toBeGreaterThan(0);
+		expect(stemTriangles.length).toBeGreaterThan(0);
+		expect(geo.canopyBlobs.length).toBeGreaterThan(0);
+	});
+
+	it('has fruitTriangles (flowers)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.flowering }));
+		expect(geo.fruitTriangles.length).toBeGreaterThan(0);
+		for (const tri of geo.fruitTriangles) {
+			expect(tri.group).toBe(GEOMETRY_GROUPS.fruit);
+		}
+	});
+
+	it('has more fruitSlots than small-plant (3-5)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.flowering }));
+		expect(geo.anchors.fruitSlots.length).toBeGreaterThanOrEqual(3);
+		expect(geo.anchors.fruitSlots.length).toBeLessThanOrEqual(5);
+	});
+});
+
+describe('dried stage', () => {
+	it('has same structure as flowering (pot + stem + canopy + fruit)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.dried }));
+		const potTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.pot);
+		const stemTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.trunk);
+		expect(potTriangles.length).toBeGreaterThan(0);
+		expect(stemTriangles.length).toBeGreaterThan(0);
+		expect(geo.canopyBlobs.length).toBeGreaterThan(0);
+		expect(geo.fruitTriangles.length).toBeGreaterThan(0);
+	});
+
+	it('canopy colors are brown/yellow tones (not green)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.dried }));
+		const canopyColors = geo.canopyBlobs.flatMap((b) => b.triangles.map((t) => t.color));
+		// Should not contain default green colors
+		for (const color of canopyColors) {
+			expect(color).not.toBe('#a8d84e');
+			expect(color).not.toBe('#1a472a');
+		}
+		// Should contain brown/yellow tones
+		expect(canopyColors.length).toBeGreaterThan(0);
+	});
+});
+
+describe('pot is wide planter style', () => {
+	it('pot geometry spans ~120px wide (60% of viewBox width)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.potWithSoil }));
+		const potTriangles = geo.trunkTriangles.filter((t) => t.group === GEOMETRY_GROUPS.pot);
+		const allX = potTriangles.flatMap((t) => t.points.map((p) => p.x));
+		const minX = Math.min(...allX);
+		const maxX = Math.max(...allX);
+		const potWidth = maxX - minX;
+		expect(potWidth).toBeGreaterThanOrEqual(100);
+		expect(potWidth).toBeLessThanOrEqual(140);
+	});
+});
+
+describe('anchors are pot-relative', () => {
+	it('trunkBase is at pot rim (where stem emerges)', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.sprout }));
+		// potTopY = GROUND_LINE_Y - 40 = 285 - 40 = 245
+		expect(geo.anchors.trunkBase.y).toBe(245);
+		expect(geo.anchors.trunkBase.x).toBe(100); // cx = 200/2
+	});
+
+	it('roots at pot bottom', () => {
+		const geo = generatePottedPlant(makeConfig({ stage: POTTED_PLANT_STAGES.sprout }));
+		// potBottomY = GROUND_LINE_Y = 285
+		expect(geo.anchors.roots.y).toBe(285);
+	});
+});
+
+describe('deterministic output', () => {
+	const allStages = Object.values(POTTED_PLANT_STAGES);
+
+	for (const stage of allStages) {
+		it(`${stage}: same seed produces identical output`, () => {
+			const config = makeConfig({ stage, seed: 123 });
+			const geo1 = generatePottedPlant(config);
+			const geo2 = generatePottedPlant(config);
+			expect(geo1).toEqual(geo2);
+		});
+	}
+});

--- a/src/lib/trees/potted_plant_generator.ts
+++ b/src/lib/trees/potted_plant_generator.ts
@@ -1,0 +1,267 @@
+import type { TreeGeometry, Triangle, BlobGeometry, Point2D, TreeAnchors } from './types.js';
+import { GEOMETRY_GROUPS, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, FRUIT_TYPES } from './types.js';
+import { GROUND_LINE_Y } from './stages/constants.js';
+import type { PottedPlantConfig } from './types/potted_plant_types.js';
+import { POTTED_PLANT_STAGES } from './types/potted_plant_types.js';
+import { createPrng, randomInRange } from './prng.js';
+import { generateFruitAtSlots } from './shapes/fruit_geometry.js';
+
+const POT_COLOR = '#c2754a';
+const POT_DARK_COLOR = '#a0603d';
+const SOIL_COLOR = '#6B4226';
+const STEM_COLOR = '#5C4400';
+
+const DEFAULT_CANOPY_LIGHT = '#a8d84e';
+const DEFAULT_CANOPY_DARK = '#1a472a';
+
+const DRIED_CANOPY_LIGHT = '#b8860b';
+const DRIED_CANOPY_DARK = '#8b6914';
+
+const POT_TOP_WIDTH = 120;
+const POT_BOTTOM_WIDTH = 100;
+const POT_HEIGHT = 40;
+const STEM_HEIGHT = 50;
+
+/** Build the trapezoidal pot + soil surface triangles. */
+function buildPotTriangles(cx: number, potTopY: number, potBottomY: number): Triangle[] {
+	const halfTopW = POT_TOP_WIDTH / 2;
+	const halfBotW = POT_BOTTOM_WIDTH / 2;
+
+	return [
+		{
+			points: [
+				{ x: cx - halfTopW, y: potTopY },
+				{ x: cx + halfTopW, y: potTopY },
+				{ x: cx + halfBotW, y: potBottomY },
+			],
+			color: POT_COLOR,
+			group: GEOMETRY_GROUPS.pot,
+		},
+		{
+			points: [
+				{ x: cx - halfTopW, y: potTopY },
+				{ x: cx + halfBotW, y: potBottomY },
+				{ x: cx - halfBotW, y: potBottomY },
+			],
+			color: POT_DARK_COLOR,
+			group: GEOMETRY_GROUPS.pot,
+		},
+		{
+			points: [
+				{ x: cx - halfTopW + 4, y: potTopY },
+				{ x: cx + halfTopW - 4, y: potTopY },
+				{ x: cx, y: potTopY - 4 },
+			],
+			color: SOIL_COLOR,
+			group: GEOMETRY_GROUPS.pot,
+		},
+	];
+}
+
+/** Build a thin stem triangle from pot rim upward. */
+function buildStemTriangle(cx: number, potTopY: number, stemTopY: number): Triangle {
+	return {
+		points: [
+			{ x: cx - 2, y: potTopY },
+			{ x: cx + 2, y: potTopY },
+			{ x: cx, y: stemTopY },
+		],
+		color: STEM_COLOR,
+		group: GEOMETRY_GROUPS.trunk,
+	};
+}
+
+/** Build 2 leaf triangles (sprout-style) as a single BlobGeometry. */
+function buildSproutLeaves(
+	cx: number,
+	stemTopY: number,
+	lightColor: string,
+	darkColor: string,
+): BlobGeometry {
+	const leafTriangles: Triangle[] = [
+		{
+			points: [
+				{ x: cx, y: stemTopY + 4 },
+				{ x: cx - 12, y: stemTopY - 4 },
+				{ x: cx - 2, y: stemTopY - 10 },
+			],
+			color: lightColor,
+			group: GEOMETRY_GROUPS.canopy,
+		},
+		{
+			points: [
+				{ x: cx, y: stemTopY + 4 },
+				{ x: cx + 12, y: stemTopY - 4 },
+				{ x: cx + 2, y: stemTopY - 10 },
+			],
+			color: darkColor,
+			group: GEOMETRY_GROUPS.canopy,
+		},
+	];
+
+	return {
+		triangles: leafTriangles,
+		center: { x: cx, y: stemTopY - 3 },
+		depth: 0,
+	};
+}
+
+/** Build a fan-shaped canopy blob with triangles radiating from center. */
+function buildCanopyBlob(
+	center: Point2D,
+	radius: number,
+	triangleCount: number,
+	lightColor: string,
+	darkColor: string,
+	rng: () => number,
+	depth: number,
+): BlobGeometry {
+	const triangles: Triangle[] = [];
+	const angleStep = (Math.PI * 2) / triangleCount;
+
+	for (let i = 0; i < triangleCount; i++) {
+		const angle1 = i * angleStep;
+		const angle2 = (i + 1) * angleStep;
+		const r1 = radius * (0.8 + rng() * 0.4);
+		const r2 = radius * (0.8 + rng() * 0.4);
+		const color = rng() > 0.5 ? lightColor : darkColor;
+
+		triangles.push({
+			points: [
+				{ x: center.x, y: center.y },
+				{
+					x: center.x + Math.cos(angle1) * r1,
+					y: center.y + Math.sin(angle1) * r1,
+				},
+				{
+					x: center.x + Math.cos(angle2) * r2,
+					y: center.y + Math.sin(angle2) * r2,
+				},
+			],
+			color,
+			group: GEOMETRY_GROUPS.canopy,
+		});
+	}
+
+	return { triangles, center, depth };
+}
+
+/** Generate fruit slot positions around the canopy area. */
+function generateFruitSlotPositions(
+	cx: number,
+	stemTopY: number,
+	count: number,
+	rng: () => number,
+): Point2D[] {
+	const slots: Point2D[] = [];
+	const radius = 20;
+
+	for (let i = 0; i < count; i++) {
+		const angle = (i / count) * Math.PI * 2;
+		const r = radius * (0.6 + rng() * 0.4);
+		slots.push({
+			x: cx + Math.cos(angle) * r,
+			y: stemTopY - 10 + Math.sin(angle) * r,
+		});
+	}
+
+	return slots;
+}
+
+export function generatePottedPlant(config: PottedPlantConfig): TreeGeometry {
+	const rng = createPrng(config.seed);
+	const cx = VIEWBOX_WIDTH / 2;
+	const potBottomY = GROUND_LINE_Y;
+	const potTopY = potBottomY - POT_HEIGHT;
+	const stemTopY = potTopY - STEM_HEIGHT;
+
+	const isDried = config.stage === POTTED_PLANT_STAGES.dried;
+	const canopyLight = isDried
+		? DRIED_CANOPY_LIGHT
+		: (config.canopyLightColor ?? DEFAULT_CANOPY_LIGHT);
+	const canopyDark = isDried
+		? DRIED_CANOPY_DARK
+		: (config.canopyDarkColor ?? DEFAULT_CANOPY_DARK);
+
+	const trunkTriangles: Triangle[] = buildPotTriangles(cx, potTopY, potBottomY);
+	const canopyBlobs: BlobGeometry[] = [];
+	let fruitTriangles: Triangle[] = [];
+	let fruitSlots: Point2D[] = [];
+
+	const hasStem = config.stage !== POTTED_PLANT_STAGES.potWithSoil;
+
+	if (hasStem) {
+		trunkTriangles.push(buildStemTriangle(cx, potTopY, stemTopY));
+	}
+
+	if (config.stage === POTTED_PLANT_STAGES.sprout) {
+		canopyBlobs.push(buildSproutLeaves(cx, stemTopY, canopyLight, canopyDark));
+	}
+
+	if (config.stage === POTTED_PLANT_STAGES.smallPlant) {
+		// 1-2 small canopy blobs with ~6 triangles each
+		const blobCount = rng() > 0.5 ? 2 : 1;
+		for (let i = 0; i < blobCount; i++) {
+			const offsetX = blobCount === 2 ? (i === 0 ? -15 : 15) : 0;
+			const offsetY = blobCount === 2 ? randomInRange(rng, -5, 5) : 0;
+			const blobCenter: Point2D = { x: cx + offsetX, y: stemTopY - 10 + offsetY };
+			canopyBlobs.push(buildCanopyBlob(blobCenter, 18, 6, canopyLight, canopyDark, rng, i));
+		}
+		// 1-2 fruit slots
+		const slotCount = rng() > 0.5 ? 2 : 1;
+		fruitSlots = generateFruitSlotPositions(cx, stemTopY, slotCount, rng);
+	}
+
+	if (
+		config.stage === POTTED_PLANT_STAGES.flowering ||
+		config.stage === POTTED_PLANT_STAGES.dried
+	) {
+		// 2-3 canopy blobs
+		const blobCount = rng() > 0.5 ? 3 : 2;
+		for (let i = 0; i < blobCount; i++) {
+			const angle = (i / blobCount) * Math.PI * 2;
+			const offsetX = Math.cos(angle) * 15;
+			const offsetY = Math.sin(angle) * 10;
+			const blobCenter: Point2D = { x: cx + offsetX, y: stemTopY - 15 + offsetY };
+			canopyBlobs.push(buildCanopyBlob(blobCenter, 22, 7, canopyLight, canopyDark, rng, i));
+		}
+		// 3-5 fruit slots
+		const slotCount = 3 + Math.floor(rng() * 3); // 3, 4, or 5
+		fruitSlots = generateFruitSlotPositions(cx, stemTopY, slotCount, rng);
+		// Generate flower fruit triangles at slots
+		fruitTriangles = generateFruitAtSlots(FRUIT_TYPES.flower, fruitSlots, rng);
+	}
+
+	// Compute anchors
+	const effectiveStemTop = hasStem ? stemTopY : potTopY;
+	const hasCanopy = canopyBlobs.length > 0;
+	const crownCenterY = hasCanopy
+		? canopyBlobs.reduce((sum, b) => sum + b.center.y, 0) / canopyBlobs.length
+		: effectiveStemTop;
+	const crownTopY = hasCanopy
+		? Math.min(...canopyBlobs.map((b) => b.center.y - 20))
+		: effectiveStemTop;
+
+	const anchors: TreeAnchors = {
+		trunkTop: { x: cx, y: effectiveStemTop },
+		trunkMiddle: { x: cx, y: (potTopY + effectiveStemTop) / 2 },
+		trunkBase: { x: cx, y: potTopY },
+		crownCenter: { x: cx, y: crownCenterY },
+		crownTop: { x: cx, y: crownTopY },
+		roots: { x: cx, y: potBottomY },
+		branchTips: [],
+		fruitSlots,
+	};
+
+	return {
+		trunkQuads: [],
+		trunkTriangles,
+		branchGroups: [],
+		canopyBlobs,
+		fruitTriangles,
+		stakeTriangles: [],
+		fruitSlots,
+		anchors,
+		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
+	};
+}

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -42,3 +42,12 @@ export {
 	CUSTOM_BLOB_POSITION_STEP,
 	CUSTOM_BLOB_DEFAULT,
 } from './types/custom.js';
+
+export {
+	POTTED_PLANT_STAGES,
+	type PottedPlantStage,
+	type PottedPlantConfig,
+	DEFAULT_POTTED_PLANT_CONFIG,
+} from './types/potted_plant_types.js';
+
+export { type OakPrdConfig, DEFAULT_OAK_PRD_CONFIG } from './types/oak_prd_types.js';

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -4,6 +4,7 @@ export const GEOMETRY_GROUPS = {
 	branch: 'branch',
 	fruit: 'fruit',
 	stake: 'stake',
+	pot: 'pot',
 } as const;
 
 export type GeometryGroup = (typeof GEOMETRY_GROUPS)[keyof typeof GEOMETRY_GROUPS];

--- a/src/lib/trees/types/oak_prd_types.ts
+++ b/src/lib/trees/types/oak_prd_types.ts
@@ -1,0 +1,17 @@
+export interface OakPrdConfig {
+	readonly completionRatio: number;
+	readonly issueCount: number;
+	readonly seed: number;
+	readonly name?: string;
+}
+
+export const OAK_PRD_VIEWBOX = {
+	width: 300,
+	height: 450,
+} as const;
+
+export const DEFAULT_OAK_PRD_CONFIG: OakPrdConfig = {
+	completionRatio: 0,
+	issueCount: 10,
+	seed: 42,
+} as const;

--- a/src/lib/trees/types/potted_plant_types.ts
+++ b/src/lib/trees/types/potted_plant_types.ts
@@ -1,0 +1,23 @@
+export const POTTED_PLANT_STAGES = {
+	potWithSoil: 'pot-with-soil',
+	sprout: 'sprout',
+	smallPlant: 'small-plant',
+	flowering: 'flowering',
+	dried: 'dried',
+} as const;
+
+export type PottedPlantStage = (typeof POTTED_PLANT_STAGES)[keyof typeof POTTED_PLANT_STAGES];
+
+export interface PottedPlantConfig {
+	readonly stage: PottedPlantStage;
+	readonly seed: number;
+	readonly canopyLightColor?: string;
+	readonly canopyDarkColor?: string;
+}
+
+export const DEFAULT_POTTED_PLANT_CONFIG: PottedPlantConfig = {
+	stage: POTTED_PLANT_STAGES.flowering,
+	seed: 42,
+	canopyLightColor: '#a8d84e',
+	canopyDarkColor: '#1a472a',
+} as const;

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import LowPolyTree from '$lib/trees/LowPolyTree.svelte';
+	import PottedPlant from '$lib/trees/PottedPlant.svelte';
+	import OakTree from '$lib/trees/OakTree.svelte';
 	import LabeledSelect from '$lib/components/composed/LabeledSelect.svelte';
 	import {
 		DEFAULT_TREE_CONFIG,
@@ -7,6 +9,7 @@
 		TREE_SHAPES,
 		TREE_STAGES,
 		TREE_STAGE_OPTIONS,
+		POTTED_PLANT_STAGES,
 		isTreeStage,
 		type TreeConfig,
 		type TreeShape,
@@ -17,6 +20,7 @@
 	const allShapes = Object.values(TREE_SHAPES).filter(
 		(s): s is Exclude<TreeShape, 'custom'> => s !== 'custom',
 	);
+	const allPlantStages = Object.values(POTTED_PLANT_STAGES);
 
 	const stageConfigs: ReadonlyMap<TreeStage, TreeConfig> = new Map(
 		allStages.map((stage) => [stage, { ...DEFAULT_TREE_CONFIG, stage }]),
@@ -39,6 +43,8 @@
 	}
 
 	const selectedConfig = $derived(stageConfigs.get(selectedStage)!);
+
+	const oakCompletionRatios = [0, 0.25, 0.5, 0.75, 1.0];
 </script>
 
 <svelte:head>
@@ -94,6 +100,51 @@
 					>
 				</div>
 			{/each}
+		</div>
+
+		<h2 class="text-xl font-semibold">Potted Plants</h2>
+
+		<div class="grid grid-cols-3 gap-4 sm:grid-cols-5">
+			{#each allPlantStages as plantStage (plantStage)}
+				<div class="flex flex-col items-center gap-2">
+					<div class="w-full rounded-lg border border-border bg-muted/20 p-2">
+						<PottedPlant stage={plantStage} class="h-auto w-full" />
+					</div>
+					<span class="text-xs font-medium capitalize text-muted-foreground"
+						>{plantStage}</span
+					>
+				</div>
+			{/each}
+		</div>
+
+		<h2 class="text-xl font-semibold">Oak PRD Tree (Completion Tracking)</h2>
+
+		<div class="grid grid-cols-3 gap-4 sm:grid-cols-5">
+			{#each oakCompletionRatios as ratio (ratio)}
+				<div class="flex flex-col items-center gap-2">
+					<div class="w-full rounded-lg border border-border bg-muted/20 p-2">
+						<OakTree completionRatio={ratio} issueCount={10} class="h-auto w-full" />
+					</div>
+					<span class="text-xs font-medium text-muted-foreground"
+						>{Math.round(ratio * 100)}%</span
+					>
+				</div>
+			{/each}
+		</div>
+
+		<h2 class="text-xl font-semibold">Oak PRD Tree with Nameplate</h2>
+
+		<div
+			class="flex items-center justify-center rounded-xl border border-border bg-muted/30 p-8"
+		>
+			<div class="w-full max-w-xs">
+				<OakTree
+					completionRatio={0.7}
+					issueCount={15}
+					name="My PRD"
+					class="h-auto w-full"
+				/>
+			</div>
 		</div>
 	</div>
 </main>


### PR DESCRIPTION
## Description
- Add `generatePottedPlant` standalone generator with 5 stages (pot-with-soil, sprout, small-plant, flowering, dried) returning standard `TreeGeometry`
- Add `generateOakPrdTree` wrapper around `generateTree` with `completionRatio`/`issueCount` props, geometry scaling to 300x450 viewBox, and deterministic blob-to-branch completion mapping
- Add `PottedPlant.svelte` and `OakTree.svelte` components with stone nameplate support (oak-only)
- Add `pot` geometry group, potted plant types, and oak PRD types
- Showcase sections demonstrate all 5 potted plant stages and oak tree at various completion ratios with nameplate

## Resolves
Closes #65

## Testing
- [x] 21 unit tests covering all potted plant stages and oak PRD completion ratio logic
- [x] All 2012 existing tests pass
- [x] `check:all` passes (format, lint, typecheck, stylelint, knip)
- [x] Svelte autofixer clean on both components