### PR TITLE
#64 feat(content): fruit SVGs, flower system, lifecycle stages cleanup

### DIFF
--- a/src/lib/components/composed/LabeledSelect.svelte
+++ b/src/lib/components/composed/LabeledSelect.svelte
@@ -17,6 +17,7 @@
 		value: string;
 		onValueChange?: (value: string) => void;
 		placeholder?: string;
+		disabled?: boolean;
 		class?: string;
 		triggerClass?: string;
 		customItems?: Snippet;
@@ -28,6 +29,7 @@
 		value,
 		onValueChange,
 		placeholder = 'Select\u2026',
+		disabled = false,
 		class: className,
 		triggerClass = 'w-full',
 		customItems,
@@ -41,7 +43,7 @@
 <div class="space-y-2 {className ?? ''}">
 	<Label>{labelText}</Label>
 	{#if browser}
-		<Select.Root type="single" {value} {onValueChange}>
+		<Select.Root type="single" {value} {onValueChange} {disabled}>
 			<Select.Trigger class={triggerClass}>{triggerText}</Select.Trigger>
 			<Select.Content>
 				{#if customItems}

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -3,8 +3,11 @@
 	import {
 		DEFAULT_TREE_CONFIG,
 		TREE_STAGES,
+		TREE_SHAPES,
+		FRUIT_TYPES,
 		type TreeConfig,
 		type TreeAnchors,
+		type TreeShape,
 	} from '$lib/trees/types.js';
 	import {
 		computeAnimationDelay,
@@ -17,6 +20,9 @@
 		TOOL_ANCHOR_MAP,
 		type ToolVisibility,
 	} from '$lib/trees/tools/tool_types.js';
+	import { FRUIT_SVG_COMPONENTS } from '$lib/trees/shapes/fruit_geometry.js';
+	import { FLOWER_SVG_COMPONENTS } from '$lib/trees/shapes/flower_geometry.js';
+	import { createPrng, randomInRange } from '$lib/trees/prng.js';
 
 	interface Props {
 		config?: TreeConfig;
@@ -28,6 +34,7 @@
 		animateCanopySway?: boolean;
 		animateBranches?: boolean;
 		animateGrowth?: boolean;
+		growthProgress?: number;
 		toolVisibility?: ToolVisibility;
 		animateTools?: boolean;
 		reviewerCount?: number;
@@ -45,6 +52,7 @@
 		animateCanopySway = false,
 		animateBranches = false,
 		animateGrowth = false,
+		growthProgress = 1,
 		toolVisibility,
 		animateTools = false,
 		reviewerCount = 0,
@@ -65,6 +73,50 @@
 		geometry.branchGroups.map((_, i) => computeBranchDelay(config.seed, i)),
 	);
 
+	const fruitComponent = $derived(
+		config.fruitType !== FRUIT_TYPES.none ? FRUIT_SVG_COMPONENTS[config.fruitType] : null,
+	);
+
+	const flowerComponent = $derived.by(() => {
+		if (config.shape === TREE_SHAPES.custom || geometry.flowerSlots.length === 0) {
+			return null;
+		}
+		return FLOWER_SVG_COMPONENTS[config.shape as Exclude<TreeShape, 'custom'>];
+	});
+
+	/** Falling leaf particle data for autumn stage. */
+	const fallingLeaves = $derived.by(() => {
+		if (!geometry.showFallingLeaves) {
+			return [];
+		}
+		const rng = createPrng(config.seed + 99999);
+		const count = 8;
+		const leaves: {
+			x: number;
+			y: number;
+			delay: number;
+			duration: number;
+			rotation: number;
+			color: string;
+		}[] = [];
+		const bounds = geometry.anchors;
+		const minX = bounds.crownCenter.x - 30;
+		const maxX = bounds.crownCenter.x + 30;
+		const startY = bounds.crownTop.y;
+		const colors = ['#E8A028', '#C47020', '#8B2010', '#A05020', '#D08030'];
+		for (let i = 0; i < count; i++) {
+			leaves.push({
+				x: randomInRange(rng, minX, maxX),
+				y: startY + randomInRange(rng, -5, 15),
+				delay: randomInRange(rng, 0, 4),
+				duration: randomInRange(rng, 2, 4),
+				rotation: randomInRange(rng, -180, 180),
+				color: colors[Math.floor(rng() * colors.length)]!,
+			});
+		}
+		return leaves;
+	});
+
 	$effect(() => {
 		onanchors?.(geometry.anchors);
 	});
@@ -80,7 +132,7 @@
 		class="tree-root"
 		class:animate-growth={animateGrowth}
 		style="--growth-origin-x: {geometry.anchors.trunkBase.x}px; --growth-origin-y: {geometry
-			.anchors.trunkBase.y}px;"
+			.anchors.trunkBase.y}px; --growth-progress: {growthProgress};"
 	>
 		{#if showTrunk}
 			<g class="trunk">
@@ -182,16 +234,37 @@
 			</g>
 		{/if}
 
-		{#if showFruit}
+		{#if showFruit && fruitComponent && geometry.fruitSlots.length > 0}
+			{@const FruitSvg = fruitComponent}
 			<g class="fruit">
-				{#each geometry.fruitTriangles as tri (tri)}
-					<polygon
-						points="{tri.points[0].x},{tri.points[0].y} {tri.points[1].x},{tri.points[1]
-							.y} {tri.points[2].x},{tri.points[2].y}"
-						fill={tri.color}
-						stroke={tri.color}
-						stroke-width="0.5"
-					/>
+				{#each geometry.fruitSlots as slot (slot)}
+					<g transform="translate({slot.x},{slot.y})">
+						<FruitSvg />
+					</g>
+				{/each}
+			</g>
+		{/if}
+
+		{#if flowerComponent && geometry.flowerSlots.length > 0}
+			{@const FlowerSvg = flowerComponent}
+			<g class="flowers">
+				{#each geometry.flowerSlots as slot (slot)}
+					<g transform="translate({slot.x},{slot.y})">
+						<FlowerSvg />
+					</g>
+				{/each}
+			</g>
+		{/if}
+
+		{#if fallingLeaves.length > 0}
+			<g class="falling-leaves">
+				{#each fallingLeaves as leaf, i (i)}
+					<g
+						class="falling-leaf"
+						style="--leaf-start-x: {leaf.x}px; --leaf-start-y: {leaf.y}px; --leaf-delay: {leaf.delay}s; --leaf-duration: {leaf.duration}s; --leaf-rotation: {leaf.rotation}deg;"
+					>
+						<path d="M0,-2 L1.5,0 L0,2 L-1.5,0 Z" fill={leaf.color} opacity="0.85" />
+					</g>
 				{/each}
 			</g>
 		{/if}
@@ -316,11 +389,28 @@
 
 	@keyframes tree-growth {
 		0% {
-			transform: scale(0.05);
+			transform: scaleY(0.05) scaleX(1);
 		}
 
 		100% {
-			transform: scale(1);
+			transform: scaleY(1) scaleX(1);
+		}
+	}
+
+	@keyframes leaf-fall {
+		0% {
+			transform: translate(var(--leaf-start-x), var(--leaf-start-y)) rotate(0deg);
+			opacity: 0.85;
+		}
+
+		50% {
+			opacity: 0.7;
+		}
+
+		100% {
+			transform: translate(calc(var(--leaf-start-x) + 10px), calc(var(--leaf-start-y) + 60px))
+				rotate(var(--leaf-rotation));
+			opacity: 0;
 		}
 	}
 
@@ -342,5 +432,11 @@
 		animation: tree-growth 2s ease-in-out infinite alternate;
 		transform-origin: var(--growth-origin-x) var(--growth-origin-y);
 		will-change: transform;
+	}
+
+	.falling-leaf {
+		animation: leaf-fall var(--leaf-duration) ease-in-out infinite;
+		animation-delay: var(--leaf-delay);
+		will-change: transform, opacity;
 	}
 </style>

--- a/src/lib/trees/assets/flowers/AcaciaFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/AcaciaFlowerSvg.svelte
@@ -1,0 +1,18 @@
+<!--
+	Acacia Flower — Yellow puffball.
+	Centered at origin, ~5 units radius.
+-->
+<g>
+	<!-- Puffball core -->
+	<circle cx="0" cy="0" r="2.5" fill="#FFD700" />
+	<!-- Fluffy outer puffs -->
+	<circle cx="2.2" cy="1.5" r="1.5" fill="#E8B800" />
+	<circle cx="-2.2" cy="1.5" r="1.5" fill="#E8B800" />
+	<circle cx="2.2" cy="-1.5" r="1.5" fill="#FFD700" />
+	<circle cx="-2.2" cy="-1.5" r="1.5" fill="#FFD700" />
+	<circle cx="0" cy="2.8" r="1.3" fill="#FFD700" />
+	<circle cx="0" cy="-2.8" r="1.3" fill="#E8B800" />
+	<!-- Texture dots -->
+	<circle cx="1" cy="0" r="0.3" fill="#E8B800" />
+	<circle cx="-1" cy="-0.5" r="0.3" fill="#E8B800" />
+</g>

--- a/src/lib/trees/assets/flowers/AppleFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/AppleFlowerSvg.svelte
@@ -1,0 +1,25 @@
+<!--
+	Apple Flower — White-pink 5-petal blossom.
+	Centered at origin, ~5 units radius.
+-->
+<g>
+	<!-- Five petals arranged around center -->
+	<ellipse cx="0" cy="-3.5" rx="2" ry="1.5" fill="#FFFFFF" transform="rotate(0, 0, 0)" />
+	<ellipse cx="3.3" cy="-1.1" rx="2" ry="1.5" fill="#FFE0E8" transform="rotate(72, 3.3, -1.1)" />
+	<ellipse cx="2" cy="2.8" rx="2" ry="1.5" fill="#FFFFFF" transform="rotate(144, 2, 2.8)" />
+	<ellipse cx="-2" cy="2.8" rx="2" ry="1.5" fill="#FFE0E8" transform="rotate(216, -2, 2.8)" />
+	<ellipse
+		cx="-3.3"
+		cy="-1.1"
+		rx="2"
+		ry="1.5"
+		fill="#FFFFFF"
+		transform="rotate(288, -3.3, -1.1)"
+	/>
+	<!-- Center pistil -->
+	<circle cx="0" cy="0" r="1.2" fill="#E8A0B0" />
+	<!-- Stamens -->
+	<circle cx="0.6" cy="-0.6" r="0.3" fill="#FFE0E8" />
+	<circle cx="-0.6" cy="-0.6" r="0.3" fill="#FFE0E8" />
+	<circle cx="0" cy="0.7" r="0.3" fill="#FFE0E8" />
+</g>

--- a/src/lib/trees/assets/flowers/BaobabFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/BaobabFlowerSvg.svelte
@@ -1,0 +1,23 @@
+<!--
+	Baobab Flower — Large white pendulous flower.
+	Centered at origin, ~6 units tall.
+-->
+<g>
+	<!-- Pendulous petals curling back -->
+	<path d="M0,-5 Q-3,-3 -2,0 Q-1,-1 0,-2 Z" fill="#FFFFFF" />
+	<path d="M0,-5 Q3,-3 2,0 Q1,-1 0,-2 Z" fill="#F0E8D0" />
+	<path d="M0,-5 Q-1,-2 -3,1 Q-1,0 0,-1 Z" fill="#F0E8D0" />
+	<path d="M0,-5 Q1,-2 3,1 Q1,0 0,-1 Z" fill="#FFFFFF" />
+	<!-- Stamen burst -->
+	<line x1="0" y1="0" x2="-2" y2="4" stroke="#F0E8D0" stroke-width="0.4" />
+	<line x1="0" y1="0" x2="0" y2="5" stroke="#F0E8D0" stroke-width="0.4" />
+	<line x1="0" y1="0" x2="2" y2="4" stroke="#F0E8D0" stroke-width="0.4" />
+	<line x1="0" y1="0" x2="-1" y2="5" stroke="#FFFFFF" stroke-width="0.4" />
+	<line x1="0" y1="0" x2="1" y2="5" stroke="#FFFFFF" stroke-width="0.4" />
+	<!-- Stamen tips -->
+	<circle cx="-2" cy="4" r="0.5" fill="#FFFFFF" />
+	<circle cx="0" cy="5" r="0.5" fill="#F0E8D0" />
+	<circle cx="2" cy="4" r="0.5" fill="#FFFFFF" />
+	<circle cx="-1" cy="5" r="0.5" fill="#F0E8D0" />
+	<circle cx="1" cy="5" r="0.5" fill="#FFFFFF" />
+</g>

--- a/src/lib/trees/assets/flowers/BirchFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/BirchFlowerSvg.svelte
@@ -1,0 +1,14 @@
+<!--
+	Birch Flower — Tiny green-yellow catkin flowers.
+	Centered at origin, ~5 units tall.
+-->
+<g>
+	<!-- Catkin stem -->
+	<line x1="0" y1="-4" x2="0" y2="4" stroke="#A8C848" stroke-width="0.6" />
+	<!-- Catkin buds along stem -->
+	<ellipse cx="0" cy="-3" rx="1.2" ry="0.8" fill="#D4E87C" />
+	<ellipse cx="0" cy="-1.5" rx="1.4" ry="0.9" fill="#A8C848" />
+	<ellipse cx="0" cy="0" rx="1.5" ry="1" fill="#D4E87C" />
+	<ellipse cx="0" cy="1.5" rx="1.4" ry="0.9" fill="#A8C848" />
+	<ellipse cx="0" cy="3" rx="1.2" ry="0.8" fill="#D4E87C" />
+</g>

--- a/src/lib/trees/assets/flowers/BushFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/BushFlowerSvg.svelte
@@ -1,0 +1,13 @@
+<!--
+	Bush Flower — Small white wildflower.
+	Centered at origin, ~4 units radius.
+-->
+<g>
+	<!-- Four simple petals -->
+	<ellipse cx="0" cy="-2.5" rx="1.5" ry="1.8" fill="#FFFFFF" />
+	<ellipse cx="2.5" cy="0" rx="1.8" ry="1.5" fill="#E8E8D0" />
+	<ellipse cx="0" cy="2.5" rx="1.5" ry="1.8" fill="#FFFFFF" />
+	<ellipse cx="-2.5" cy="0" rx="1.8" ry="1.5" fill="#E8E8D0" />
+	<!-- Center -->
+	<circle cx="0" cy="0" r="1" fill="#E8E8D0" />
+</g>

--- a/src/lib/trees/assets/flowers/CherryFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/CherryFlowerSvg.svelte
@@ -1,0 +1,18 @@
+<!--
+	Cherry Flower — Pink sakura blossom (iconic 5 petals).
+	Centered at origin, ~5 units radius.
+-->
+<g>
+	<!-- Five sakura petals with notched tips -->
+	<path d="M0,-1 L-1.2,-4.5 L0,-3.8 L1.2,-4.5 Z" fill="#FFB7C5" />
+	<path d="M0,-1 L3.5,-2.8 L3,-1.5 L4.5,-1 Z" fill="#FF8CA0" />
+	<path d="M0,-1 L3,2.5 L1.8,2 L2.8,3.8 Z" fill="#FFB7C5" />
+	<path d="M0,-1 L-3,2.5 L-1.8,2 L-2.8,3.8 Z" fill="#FF8CA0" />
+	<path d="M0,-1 L-3.5,-2.8 L-3,-1.5 L-4.5,-1 Z" fill="#FFB7C5" />
+	<!-- Center -->
+	<circle cx="0" cy="-0.5" r="1.2" fill="#FF8CA0" />
+	<!-- Stamens -->
+	<circle cx="0" cy="-1.5" r="0.25" fill="#FFB7C5" />
+	<circle cx="0.8" cy="0" r="0.25" fill="#FFB7C5" />
+	<circle cx="-0.8" cy="0" r="0.25" fill="#FFB7C5" />
+</g>

--- a/src/lib/trees/assets/flowers/CypressFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/CypressFlowerSvg.svelte
@@ -1,0 +1,12 @@
+<!--
+	Cypress Flower — Tiny yellow-green bud.
+	Centered at origin, ~4 units tall.
+-->
+<g>
+	<!-- Bud body -->
+	<path d="M-1.5,2 Q-2,0 0,-3 Q2,0 1.5,2 Z" fill="#C8D44A" />
+	<!-- Inner shading -->
+	<path d="M-0.8,1.5 Q-1,0 0,-2 Q1,0 0.8,1.5 Z" fill="#A0B030" />
+	<!-- Base -->
+	<ellipse cx="0" cy="2" rx="1.8" ry="0.6" fill="#A0B030" />
+</g>

--- a/src/lib/trees/assets/flowers/FirFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/FirFlowerSvg.svelte
@@ -1,0 +1,13 @@
+<!--
+	Fir Flower — Small purple-pink cone flower.
+	Centered at origin, ~5 units tall.
+-->
+<g>
+	<!-- Cone body -->
+	<path d="M-2,3 Q-2.5,0 0,-4 Q2.5,0 2,3 Z" fill="#C87CA8" />
+	<!-- Scale lines -->
+	<path d="M-1.5,2 L0,1 L1.5,2" fill="none" stroke="#A05880" stroke-width="0.4" />
+	<path d="M-1.8,0 L0,-1 L1.8,0" fill="none" stroke="#A05880" stroke-width="0.4" />
+	<!-- Tip highlight -->
+	<circle cx="0" cy="-3.5" r="0.6" fill="#A05880" />
+</g>

--- a/src/lib/trees/assets/flowers/MapleFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/MapleFlowerSvg.svelte
@@ -1,0 +1,17 @@
+<!--
+	Maple Flower — Small red-yellow cluster.
+	Centered at origin, ~5 units radius.
+-->
+<g>
+	<!-- Center -->
+	<circle cx="0" cy="0" r="1.2" fill="#D4543A" />
+	<!-- Petal clusters radiating outward -->
+	<circle cx="3" cy="0" r="1" fill="#E8C44A" />
+	<circle cx="-3" cy="0" r="1" fill="#E8C44A" />
+	<circle cx="0" cy="3" r="1" fill="#D4543A" />
+	<circle cx="0" cy="-3" r="1" fill="#D4543A" />
+	<circle cx="2" cy="2" r="0.8" fill="#E8C44A" />
+	<circle cx="-2" cy="-2" r="0.8" fill="#E8C44A" />
+	<circle cx="2" cy="-2" r="0.8" fill="#D4543A" />
+	<circle cx="-2" cy="2" r="0.8" fill="#D4543A" />
+</g>

--- a/src/lib/trees/assets/flowers/OakFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/OakFlowerSvg.svelte
@@ -1,0 +1,15 @@
+<!--
+	Oak Flower — Small white blossom cluster.
+	Centered at origin, ~5 units radius.
+-->
+<g>
+	<!-- Center cluster -->
+	<circle cx="0" cy="0" r="1.5" fill="#FFFFFF" />
+	<!-- Surrounding blossoms -->
+	<circle cx="2.5" cy="0" r="1.2" fill="#E8E0D0" />
+	<circle cx="-2.5" cy="0" r="1.2" fill="#E8E0D0" />
+	<circle cx="0" cy="2.5" r="1.2" fill="#FFFFFF" />
+	<circle cx="0" cy="-2.5" r="1.2" fill="#FFFFFF" />
+	<circle cx="1.8" cy="1.8" r="1" fill="#E8E0D0" />
+	<circle cx="-1.8" cy="-1.8" r="1" fill="#E8E0D0" />
+</g>

--- a/src/lib/trees/assets/flowers/PineFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/PineFlowerSvg.svelte
@@ -1,0 +1,15 @@
+<!--
+	Pine Flower — Tiny yellow pollen cluster.
+	Centered at origin, ~4 units radius.
+-->
+<g>
+	<!-- Central pollen mass -->
+	<ellipse cx="0" cy="0" rx="2" ry="1.5" fill="#E8D44A" />
+	<!-- Pollen bumps -->
+	<circle cx="-1.5" cy="-1" r="1" fill="#C4A830" />
+	<circle cx="1.5" cy="-1" r="1" fill="#C4A830" />
+	<circle cx="0" cy="1.5" r="1.2" fill="#E8D44A" />
+	<!-- Tiny pollen dots -->
+	<circle cx="-0.5" cy="-0.5" r="0.4" fill="#C4A830" />
+	<circle cx="0.8" cy="0.3" r="0.4" fill="#C4A830" />
+</g>

--- a/src/lib/trees/assets/flowers/WillowFlowerSvg.svelte
+++ b/src/lib/trees/assets/flowers/WillowFlowerSvg.svelte
@@ -1,0 +1,16 @@
+<!--
+	Willow Flower — Fuzzy silver-white catkin.
+	Centered at origin, ~5 units tall.
+-->
+<g>
+	<!-- Catkin stem -->
+	<line x1="0" y1="-4" x2="0" y2="4" stroke="#C8C8B0" stroke-width="0.5" />
+	<!-- Fuzzy oval clusters -->
+	<ellipse cx="0" cy="-2.5" rx="1.8" ry="1.2" fill="#E0E0D0" />
+	<ellipse cx="0" cy="0" rx="2" ry="1.4" fill="#C8C8B0" />
+	<ellipse cx="0" cy="2.5" rx="1.8" ry="1.2" fill="#E0E0D0" />
+	<!-- Fuzzy texture dots -->
+	<circle cx="1" cy="-2" r="0.3" fill="#C8C8B0" />
+	<circle cx="-0.8" cy="0.5" r="0.3" fill="#E0E0D0" />
+	<circle cx="0.5" cy="2" r="0.3" fill="#C8C8B0" />
+</g>

--- a/src/lib/trees/assets/flowers/index.ts
+++ b/src/lib/trees/assets/flowers/index.ts
@@ -1,0 +1,12 @@
+export { default as OakFlowerSvg } from './OakFlowerSvg.svelte';
+export { default as BirchFlowerSvg } from './BirchFlowerSvg.svelte';
+export { default as MapleFlowerSvg } from './MapleFlowerSvg.svelte';
+export { default as PineFlowerSvg } from './PineFlowerSvg.svelte';
+export { default as FirFlowerSvg } from './FirFlowerSvg.svelte';
+export { default as WillowFlowerSvg } from './WillowFlowerSvg.svelte';
+export { default as CypressFlowerSvg } from './CypressFlowerSvg.svelte';
+export { default as AppleFlowerSvg } from './AppleFlowerSvg.svelte';
+export { default as CherryFlowerSvg } from './CherryFlowerSvg.svelte';
+export { default as BushFlowerSvg } from './BushFlowerSvg.svelte';
+export { default as BaobabFlowerSvg } from './BaobabFlowerSvg.svelte';
+export { default as AcaciaFlowerSvg } from './AcaciaFlowerSvg.svelte';

--- a/src/lib/trees/assets/fruits/AcornSvg.svelte
+++ b/src/lib/trees/assets/fruits/AcornSvg.svelte
@@ -1,0 +1,12 @@
+<!--
+	Acorn (Oak) — Small brown nut with light cap.
+	Centered at origin, ~8 units tall.
+-->
+<g>
+	<!-- Cap -->
+	<path d="M-3,-1 Q-3,-3 0,-4 Q3,-3 3,-1 Z" fill="#C4A265" />
+	<!-- Cap texture lines -->
+	<path d="M-2,-2.5 L0,-3.5 L2,-2.5" fill="none" stroke="#5C4400" stroke-width="0.4" />
+	<!-- Nut body -->
+	<path d="M-2.5,-1 Q-3,2 0,4 Q3,2 2.5,-1 Z" fill="#8B6914" />
+</g>

--- a/src/lib/trees/assets/fruits/AppleSvg.svelte
+++ b/src/lib/trees/assets/fruits/AppleSvg.svelte
@@ -1,0 +1,16 @@
+<!--
+	Apple (Apple tree) — Red round fruit with small stem.
+	Centered at origin, ~8 units diameter.
+-->
+<g>
+	<!-- Fruit body -->
+	<circle cx="0" cy="0.5" r="3.5" fill="#e53e3e" />
+	<!-- Stem -->
+	<path
+		d="M0,-3 L0.5,-5"
+		stroke="#5C4400"
+		stroke-width="0.6"
+		fill="none"
+		stroke-linecap="round"
+	/>
+</g>

--- a/src/lib/trees/assets/fruits/BaobabFruitSvg.svelte
+++ b/src/lib/trees/assets/fruits/BaobabFruitSvg.svelte
@@ -1,0 +1,10 @@
+<!--
+	Baobab Fruit (Baobab) — Large oblong brown pod hanging down.
+	Centered at origin, ~12 units tall.
+-->
+<g>
+	<!-- Stem -->
+	<path d="M0,-6 L0,-4" stroke="#6B5B3A" stroke-width="0.6" fill="none" stroke-linecap="round" />
+	<!-- Pod body (oblong, wider at bottom) -->
+	<path d="M-2,-4 Q-2.5,0 -2,4 Q0,6 2,4 Q2.5,0 2,-4 Q0,-5 -2,-4 Z" fill="#8B7355" />
+</g>

--- a/src/lib/trees/assets/fruits/BerrySvg.svelte
+++ b/src/lib/trees/assets/fruits/BerrySvg.svelte
@@ -1,0 +1,8 @@
+<!--
+	Berry (Bush) — Small round blueberry.
+	Centered at origin, ~6 units diameter.
+-->
+<g>
+	<!-- Berry body -->
+	<circle cx="0" cy="0" r="3" fill="#4A5899" />
+</g>

--- a/src/lib/trees/assets/fruits/CatkinBirchSvg.svelte
+++ b/src/lib/trees/assets/fruits/CatkinBirchSvg.svelte
@@ -1,0 +1,10 @@
+<!--
+	Catkin (Birch) — Tiny elongated yellow-green dangling cluster.
+	Centered at origin, ~10 units tall.
+-->
+<g>
+	<!-- Stem -->
+	<path d="M0,-5 Q0.5,-2 0,3" fill="none" stroke="#8FA04A" stroke-width="0.5" />
+	<!-- Catkin body -->
+	<path d="M-1.5,-3 Q-2,0 -1.5,4 Q0,5 1.5,4 Q2,0 1.5,-3 Q0,-4 -1.5,-3 Z" fill="#B5C36A" />
+</g>

--- a/src/lib/trees/assets/fruits/CatkinWillowSvg.svelte
+++ b/src/lib/trees/assets/fruits/CatkinWillowSvg.svelte
@@ -1,0 +1,10 @@
+<!--
+	Catkin (Willow) — Slender elongated fuzzy cluster.
+	Centered at origin, ~10 units tall.
+-->
+<g>
+	<!-- Stem -->
+	<path d="M0,-5 Q0.3,-3 0,-1" fill="none" stroke="#A0A070" stroke-width="0.4" />
+	<!-- Catkin body (slender, fuzzy) -->
+	<path d="M-1,-4 Q-1.5,0 -1,4 Q0,5 1,4 Q1.5,0 1,-4 Q0,-5 -1,-4 Z" fill="#C8C898" />
+</g>

--- a/src/lib/trees/assets/fruits/CherryPairSvg.svelte
+++ b/src/lib/trees/assets/fruits/CherryPairSvg.svelte
@@ -1,0 +1,13 @@
+<!--
+	Cherry Pair (Cherry tree) — Two red berries connected by stems.
+	Centered at origin, ~10 units wide.
+-->
+<g>
+	<!-- Stems (V-shape from top center) -->
+	<path d="M0,-4 L-3,0" stroke="#5C4400" stroke-width="0.5" fill="none" stroke-linecap="round" />
+	<path d="M0,-4 L3,0" stroke="#5C4400" stroke-width="0.5" fill="none" stroke-linecap="round" />
+	<!-- Left cherry -->
+	<circle cx="-3" cy="1.5" r="2.5" fill="#9b2c2c" />
+	<!-- Right cherry -->
+	<circle cx="3" cy="1.5" r="2.5" fill="#9b2c2c" />
+</g>

--- a/src/lib/trees/assets/fruits/FirConeSvg.svelte
+++ b/src/lib/trees/assets/fruits/FirConeSvg.svelte
@@ -1,0 +1,17 @@
+<!--
+	Fir Cone (Fir) — Upright cone (fir cones point UP).
+	Centered at origin, ~10 units tall. Tip points up.
+-->
+<g>
+	<!-- Stem -->
+	<rect x="-0.5" y="3" width="1" height="2" fill="#A08060" />
+	<!-- Cone body (upright, tip at top) -->
+	<path d="M0,-5 Q-3,-1 -2.5,3 Q0,4 2.5,3 Q3,-1 0,-5 Z" fill="#6B5B3A" />
+	<!-- Scale pattern -->
+	<path
+		d="M-1,-3 L0,-2 L1,-3 M-1.5,-1 L0,0 L1.5,-1 M-2,1 L0,2 L2,1"
+		fill="none"
+		stroke="#8B7355"
+		stroke-width="0.4"
+	/>
+</g>

--- a/src/lib/trees/assets/fruits/PineConeSvg.svelte
+++ b/src/lib/trees/assets/fruits/PineConeSvg.svelte
@@ -1,0 +1,17 @@
+<!--
+	Pine Cone (Pine) — Small brown cone, downward-hanging.
+	Centered at origin, ~10 units tall. Tip points down.
+-->
+<g>
+	<!-- Stem -->
+	<rect x="-0.5" y="-5" width="1" height="2" fill="#A08060" />
+	<!-- Cone body -->
+	<path d="M-3,-3 Q-3.5,0 -2,3 Q0,5 2,3 Q3.5,0 3,-3 Q0,-4 -3,-3 Z" fill="#8B6914" />
+	<!-- Scale pattern -->
+	<path
+		d="M-1.5,-2 L0,-1 L1.5,-2 M-2,0 L0,1 L2,0 M-1.5,2 L0,3 L1.5,2"
+		fill="none"
+		stroke="#5C4400"
+		stroke-width="0.4"
+	/>
+</g>

--- a/src/lib/trees/assets/fruits/SamaraSvg.svelte
+++ b/src/lib/trees/assets/fruits/SamaraSvg.svelte
@@ -1,0 +1,12 @@
+<!--
+	Samara (Maple) — Winged seed pair (helicopter shape), tan/brown.
+	Centered at origin, ~10 units wide.
+-->
+<g>
+	<!-- Left wing -->
+	<path d="M0,0 L-5,-3 L-4,0 Z" fill="#C4A265" />
+	<!-- Right wing -->
+	<path d="M0,0 L5,-3 L4,0 Z" fill="#C4A265" />
+	<!-- Seed center -->
+	<circle cx="0" cy="0" r="1.2" fill="#8B7355" />
+</g>

--- a/src/lib/trees/assets/fruits/SeedPodSvg.svelte
+++ b/src/lib/trees/assets/fruits/SeedPodSvg.svelte
@@ -1,0 +1,10 @@
+<!--
+	Seed Pod (Acacia) — Long flat brown pod.
+	Centered at origin, ~12 units long.
+-->
+<g>
+	<!-- Pod body (long, flat, slightly curved) -->
+	<path d="M-6,-1 Q-4,-2 0,-1.5 Q4,-2 6,-1 Q4,1 0,1.5 Q-4,1 -6,-1 Z" fill="#8B6914" />
+	<!-- Center seam -->
+	<path d="M-5,0 Q0,-0.5 5,0" fill="none" stroke="#6B5B3A" stroke-width="0.3" />
+</g>

--- a/src/lib/trees/assets/fruits/SmallConeSvg.svelte
+++ b/src/lib/trees/assets/fruits/SmallConeSvg.svelte
@@ -1,0 +1,15 @@
+<!--
+	Small Cone (Cypress) — Tiny round dark brown cone.
+	Centered at origin, ~6 units diameter.
+-->
+<g>
+	<!-- Cone body (round) -->
+	<circle cx="0" cy="0" r="3" fill="#5C4A32" />
+	<!-- Surface texture -->
+	<path
+		d="M-1.5,-1 L0,0 L1.5,-1 M-1,1 L0,2 L1,1"
+		fill="none"
+		stroke="#8B7355"
+		stroke-width="0.4"
+	/>
+</g>

--- a/src/lib/trees/assets/fruits/index.ts
+++ b/src/lib/trees/assets/fruits/index.ts
@@ -1,0 +1,12 @@
+export { default as AcornSvg } from './AcornSvg.svelte';
+export { default as AppleSvg } from './AppleSvg.svelte';
+export { default as BaobabFruitSvg } from './BaobabFruitSvg.svelte';
+export { default as BerrySvg } from './BerrySvg.svelte';
+export { default as CatkinBirchSvg } from './CatkinBirchSvg.svelte';
+export { default as CatkinWillowSvg } from './CatkinWillowSvg.svelte';
+export { default as CherryPairSvg } from './CherryPairSvg.svelte';
+export { default as FirConeSvg } from './FirConeSvg.svelte';
+export { default as PineConeSvg } from './PineConeSvg.svelte';
+export { default as SamaraSvg } from './SamaraSvg.svelte';
+export { default as SeedPodSvg } from './SeedPodSvg.svelte';
+export { default as SmallConeSvg } from './SmallConeSvg.svelte';

--- a/src/lib/trees/disabled_params.test.ts
+++ b/src/lib/trees/disabled_params.test.ts
@@ -132,8 +132,22 @@ describe('isParamDisabled', () => {
 			expect(isParamDisabled('oak', 'fruitCount', { fruitType: 'apple' })).toBe(false);
 		});
 
-		it('does not disable fruitCount when fruitType is cherry', () => {
-			expect(isParamDisabled('oak', 'fruitCount', { fruitType: 'cherry' })).toBe(false);
+		it('does not disable fruitCount when fruitType is cherry_pair', () => {
+			expect(isParamDisabled('oak', 'fruitCount', { fruitType: 'cherry_pair' })).toBe(false);
+		});
+	});
+
+	describe('fruitType locked for non-custom shapes', () => {
+		it('disables fruitType for oak', () => {
+			expect(isParamDisabled('oak', 'fruitType', {})).toBe(true);
+		});
+
+		it('disables fruitType for pine', () => {
+			expect(isParamDisabled('pine', 'fruitType', {})).toBe(true);
+		});
+
+		it('does not disable fruitType for custom', () => {
+			expect(isParamDisabled('custom', 'fruitType', {})).toBe(false);
 		});
 	});
 });

--- a/src/lib/trees/disabled_params.ts
+++ b/src/lib/trees/disabled_params.ts
@@ -110,5 +110,10 @@ export function isParamDisabled(
 		return true;
 	}
 
+	// Fruit type is locked for non-custom shapes (auto-set from SHAPE_FRUIT_MAP)
+	if (param === 'fruitType' && shape !== TREE_SHAPES.custom) {
+		return true;
+	}
+
 	return false;
 }

--- a/src/lib/trees/fruit_geometry.test.ts
+++ b/src/lib/trees/fruit_geometry.test.ts
@@ -1,202 +1,88 @@
 import { describe, it, expect } from 'vitest';
-import { FRUIT_TYPES, FRUIT_TYPE_OPTIONS, FRUIT_SPECS } from './types.js';
+import { FRUIT_TYPES, FRUIT_TYPE_OPTIONS } from './types.js';
 import { GEOMETRY_GROUPS } from './types.js';
-import { createPrng } from './prng.js';
 
 // ============================================================================
 // Fruit type definitions
 // ============================================================================
 
 describe('Fruit type definitions', () => {
-	it('FRUIT_TYPES has none, apple, cherry, flower', () => {
+	it('FRUIT_TYPES has 13 entries (none + 12 fruit types)', () => {
+		expect(Object.keys(FRUIT_TYPES)).toHaveLength(13);
+	});
+
+	it('FRUIT_TYPES includes all expected keys', () => {
 		expect(FRUIT_TYPES).toEqual({
 			none: 'none',
+			acorn: 'acorn',
+			catkin_birch: 'catkin_birch',
+			samara: 'samara',
+			pine_cone: 'pine_cone',
+			fir_cone: 'fir_cone',
+			catkin_willow: 'catkin_willow',
+			small_cone: 'small_cone',
 			apple: 'apple',
-			cherry: 'cherry',
-			flower: 'flower',
+			cherry_pair: 'cherry_pair',
+			berry: 'berry',
+			baobab_fruit: 'baobab_fruit',
+			seed_pod: 'seed_pod',
 		});
 	});
 
-	it('FRUIT_TYPE_OPTIONS provides labeled options for LabeledSelect', () => {
-		expect(FRUIT_TYPE_OPTIONS).toEqual([
-			{ value: 'none', label: 'None' },
-			{ value: 'apple', label: 'Apple' },
-			{ value: 'cherry', label: 'Cherry' },
-			{ value: 'flower', label: 'Flower' },
-		]);
+	it('FRUIT_TYPE_OPTIONS has 13 entries', () => {
+		expect(FRUIT_TYPE_OPTIONS).toHaveLength(13);
 	});
 
-	it('FRUIT_SPECS maps non-none types to color and generateShape', () => {
-		expect(FRUIT_SPECS.apple.color).toBe('#e53e3e');
-		expect(FRUIT_SPECS.cherry.color).toBe('#9b2c2c');
-		expect(FRUIT_SPECS.flower.color).toBe('#ed64a6');
-		expect(typeof FRUIT_SPECS.apple.generateShape).toBe('function');
-		expect(typeof FRUIT_SPECS.cherry.generateShape).toBe('function');
-		expect(typeof FRUIT_SPECS.flower.generateShape).toBe('function');
+	it('FRUIT_TYPE_OPTIONS provides labeled options for LabeledSelect', () => {
+		for (const option of FRUIT_TYPE_OPTIONS) {
+			expect(typeof option.value).toBe('string');
+			expect(typeof option.label).toBe('string');
+		}
+		// Verify first and last
+		expect(FRUIT_TYPE_OPTIONS[0]).toEqual({ value: 'none', label: 'None' });
+		expect(FRUIT_TYPE_OPTIONS[FRUIT_TYPE_OPTIONS.length - 1]).toEqual({
+			value: 'seed_pod',
+			label: 'Seed Pod',
+		});
 	});
 });
 
 // ============================================================================
-// GEOMETRY_GROUPS includes fruit
+// GEOMETRY_GROUPS includes fruit and flower
 // ============================================================================
 
-describe('GEOMETRY_GROUPS includes fruit', () => {
+describe('GEOMETRY_GROUPS includes fruit and flower', () => {
 	it('has a fruit group', () => {
 		expect(GEOMETRY_GROUPS.fruit).toBe('fruit');
 	});
+
+	it('has a flower group', () => {
+		expect(GEOMETRY_GROUPS.flower).toBe('flower');
+	});
 });
 
 // ============================================================================
-// Fruit geometry generation
+// FRUIT_SVG_COMPONENTS map
 // ============================================================================
 
-describe('generateApple', () => {
-	it('returns array of triangles (each 3 Point2D), 5-6 total', async () => {
-		const { generateApple } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const result = generateApple(50, 50, 4, rng);
-		expect(result.length).toBeGreaterThanOrEqual(5);
-		expect(result.length).toBeLessThanOrEqual(6);
-		for (const tri of result) {
-			expect(tri).toHaveLength(3);
-			for (const pt of tri) {
-				expect(typeof pt.x).toBe('number');
-				expect(typeof pt.y).toBe('number');
-			}
+describe('FRUIT_SVG_COMPONENTS', () => {
+	it('has exactly 12 entries (all non-none fruit types)', async () => {
+		const mod = await import('./shapes/fruit_geometry.js');
+		expect(Object.keys(mod.FRUIT_SVG_COMPONENTS)).toHaveLength(12);
+	});
+
+	it('every key corresponds to a non-none FRUIT_TYPES value', async () => {
+		const mod = await import('./shapes/fruit_geometry.js');
+		const nonNoneTypes = Object.values(FRUIT_TYPES).filter((t) => t !== 'none');
+		for (const fruitType of nonNoneTypes) {
+			expect(mod.FRUIT_SVG_COMPONENTS).toHaveProperty(fruitType);
 		}
 	});
 
-	it('all points lie within reasonable radius of anchor', async () => {
-		const { generateApple } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const cx = 100;
-		const cy = 100;
-		const size = 4;
-		const result = generateApple(cx, cy, size, rng);
-		const maxRadius = size * 2;
-		for (const tri of result) {
-			for (const pt of tri) {
-				const dx = pt.x - cx;
-				const dy = pt.y - cy;
-				expect(Math.sqrt(dx * dx + dy * dy)).toBeLessThan(maxRadius);
-			}
-		}
-	});
-});
-
-describe('generateCherry', () => {
-	it('returns two groups of 3-4 triangles each', async () => {
-		const { generateCherry } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const result = generateCherry(50, 50, 3, rng);
-		// Two cherries = 6-8 triangles total, plus stem triangles
-		expect(result.length).toBeGreaterThanOrEqual(6);
-		expect(result.length).toBeLessThanOrEqual(12);
-		for (const tri of result) {
-			expect(tri).toHaveLength(3);
-		}
-	});
-
-	it('all points lie within reasonable radius of anchor', async () => {
-		const { generateCherry } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const cx = 100;
-		const cy = 100;
-		const size = 3;
-		const result = generateCherry(cx, cy, size, rng);
-		const maxRadius = size * 4;
-		for (const tri of result) {
-			for (const pt of tri) {
-				const dx = pt.x - cx;
-				const dy = pt.y - cy;
-				expect(Math.sqrt(dx * dx + dy * dy)).toBeLessThan(maxRadius);
-			}
-		}
-	});
-});
-
-describe('generateFlower', () => {
-	it('returns 4 triangles in diamond arrangement', async () => {
-		const { generateFlower } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const result = generateFlower(50, 50, 4, rng);
-		expect(result).toHaveLength(4);
-		for (const tri of result) {
-			expect(tri).toHaveLength(3);
-		}
-	});
-
-	it('all points lie within reasonable radius of anchor', async () => {
-		const { generateFlower } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const cx = 100;
-		const cy = 100;
-		const size = 4;
-		const result = generateFlower(cx, cy, size, rng);
-		const maxRadius = size * 2;
-		for (const tri of result) {
-			for (const pt of tri) {
-				const dx = pt.x - cx;
-				const dy = pt.y - cy;
-				expect(Math.sqrt(dx * dx + dy * dy)).toBeLessThan(maxRadius);
-			}
-		}
-	});
-});
-
-describe('generateFruitAtSlots', () => {
-	it('with apple produces triangles with red color and fruit group', async () => {
-		const { generateFruitAtSlots } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const slots = [
-			{ x: 50, y: 50 },
-			{ x: 80, y: 80 },
-		];
-		const result = generateFruitAtSlots('apple', slots, rng);
-		expect(result.length).toBeGreaterThan(0);
-		for (const tri of result) {
-			expect(tri.color).toBe('#e53e3e');
-			expect(tri.group).toBe(GEOMETRY_GROUPS.fruit);
-			expect(tri.points).toHaveLength(3);
-		}
-	});
-
-	it('with none returns empty array', async () => {
-		const { generateFruitAtSlots } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const slots = [{ x: 50, y: 50 }];
-		const result = generateFruitAtSlots('none', slots, rng);
-		expect(result).toEqual([]);
-	});
-
-	it('with empty slots returns empty array', async () => {
-		const { generateFruitAtSlots } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const result = generateFruitAtSlots('apple', [], rng);
-		expect(result).toEqual([]);
-	});
-
-	it('cherry triangles have cherry color', async () => {
-		const { generateFruitAtSlots } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const slots = [{ x: 50, y: 50 }];
-		const result = generateFruitAtSlots('cherry', slots, rng);
-		expect(result.length).toBeGreaterThan(0);
-		for (const tri of result) {
-			expect(tri.color).toBe('#9b2c2c');
-			expect(tri.group).toBe(GEOMETRY_GROUPS.fruit);
-		}
-	});
-
-	it('flower triangles have flower color', async () => {
-		const { generateFruitAtSlots } = await import('./shapes/fruit_geometry.js');
-		const rng = createPrng(42);
-		const slots = [{ x: 50, y: 50 }];
-		const result = generateFruitAtSlots('flower', slots, rng);
-		expect(result.length).toBeGreaterThan(0);
-		for (const tri of result) {
-			expect(tri.color).toBe('#ed64a6');
-			expect(tri.group).toBe(GEOMETRY_GROUPS.fruit);
+	it('each entry is a Svelte component (function)', async () => {
+		const mod = await import('./shapes/fruit_geometry.js');
+		for (const component of Object.values(mod.FRUIT_SVG_COMPONENTS)) {
+			expect(typeof component).toBe('function');
 		}
 	});
 });

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -1506,62 +1506,61 @@ describe('Issue #10: custom tree shape', () => {
 // Fruit generation integration
 // ============================================================================
 
-describe('Fruit generation', () => {
-	it('fruitType apple with fruitCount 5 produces fruitTriangles', () => {
-		const geo = generateTree(makeConfig({ fruitType: 'apple', fruitCount: 5 }));
-		expect(geo.fruitTriangles.length).toBeGreaterThan(0);
-		for (const tri of geo.fruitTriangles) {
-			expect(tri.group).toBe('fruit');
-			expect(tri.color).toBe('#e53e3e');
-		}
-	});
-
-	it('fruitCount 0 produces zero fruitTriangles regardless of fruitType', () => {
-		const geo = generateTree(makeConfig({ fruitType: 'apple', fruitCount: 0 }));
+describe('Fruit generation (SVG-based)', () => {
+	it('fruitTriangles is always empty (SVG-based rendering)', () => {
+		const geo = generateTree(
+			makeConfig({ stage: 'fruiting', fruitType: 'apple', fruitCount: 5 }),
+		);
 		expect(geo.fruitTriangles).toHaveLength(0);
 	});
 
-	it('fruitType none produces zero fruitTriangles regardless of fruitCount', () => {
-		const geo = generateTree(makeConfig({ fruitType: 'none', fruitCount: 10 }));
-		expect(geo.fruitTriangles).toHaveLength(0);
-	});
-
-	it('fruitCount 20 (exceeds default slots) still produces fruitTriangles without error', () => {
-		const geo = generateTree(makeConfig({ fruitType: 'cherry', fruitCount: 20 }));
-		expect(geo.fruitTriangles.length).toBeGreaterThan(0);
-	});
-
-	it('all fruit triangle centroids lie within canopy bounds', () => {
-		const geo = generateTree(makeConfig({ fruitType: 'apple', fruitCount: 5 }));
-		const canopyTris = geo.canopyBlobs.flatMap((b) => b.triangles);
-		const allCanopyX = canopyTris.flatMap((t) => t.points.map((p) => p.x));
-		const allCanopyY = canopyTris.flatMap((t) => t.points.map((p) => p.y));
-		const canopyMinX = Math.min(...allCanopyX);
-		const canopyMaxX = Math.max(...allCanopyX);
-		const canopyMinY = Math.min(...allCanopyY);
-		const canopyMaxY = Math.max(...allCanopyY);
-		// Fruit anchor centroids should be within canopy bounds (with margin for fruit shape radius)
-		const margin = 10;
-		for (const tri of geo.fruitTriangles) {
-			const cx = (tri.points[0].x + tri.points[1].x + tri.points[2].x) / 3;
-			const cy = (tri.points[0].y + tri.points[1].y + tri.points[2].y) / 3;
-			expect(cx).toBeGreaterThan(canopyMinX - margin);
-			expect(cx).toBeLessThan(canopyMaxX + margin);
-			expect(cy).toBeGreaterThan(canopyMinY - margin);
-			expect(cy).toBeLessThan(canopyMaxY + margin);
+	it('fruiting stage with fruitCount 5 produces fruitSlots', () => {
+		const geo = generateTree(
+			makeConfig({ stage: 'fruiting', fruitType: 'apple', fruitCount: 5 }),
+		);
+		expect(geo.fruitSlots.length).toBeGreaterThanOrEqual(1);
+		for (const slot of geo.fruitSlots) {
+			expect(typeof slot.x).toBe('number');
+			expect(typeof slot.y).toBe('number');
 		}
 	});
 
-	it('deterministic: same seed + config = same fruitTriangles', () => {
-		const config = makeConfig({ seed: 999, fruitType: 'flower', fruitCount: 5 });
+	it('fruiting stage with fruitCount 0 produces zero fruitSlots', () => {
+		const geo = generateTree(
+			makeConfig({ stage: 'fruiting', fruitType: 'apple', fruitCount: 0 }),
+		);
+		expect(geo.fruitSlots).toHaveLength(0);
+	});
+
+	it('leafy stage produces zero fruitSlots regardless of fruitType', () => {
+		const geo = generateTree(
+			makeConfig({ stage: 'leafy', fruitType: 'apple', fruitCount: 10 }),
+		);
+		expect(geo.fruitSlots).toHaveLength(0);
+	});
+
+	it('fruiting stage with fruitCount 20 (exceeds default slots) produces fruitSlots without error', () => {
+		const geo = generateTree(
+			makeConfig({ stage: 'fruiting', fruitType: 'cherry_pair', fruitCount: 20 }),
+		);
+		expect(geo.fruitSlots.length).toBeGreaterThan(0);
+	});
+
+	it('deterministic: same seed + config = same fruitSlots', () => {
+		const config = makeConfig({
+			seed: 999,
+			stage: 'fruiting',
+			fruitType: 'apple',
+			fruitCount: 5,
+		});
 		const geo1 = generateTree(config);
 		const geo2 = generateTree(config);
-		expect(geo1.fruitTriangles).toEqual(geo2.fruitTriangles);
+		expect(geo1.fruitSlots).toEqual(geo2.fruitSlots);
 	});
 
-	it('default config (no fruitType/fruitCount) produces zero fruitTriangles', () => {
+	it('default config (no fruitType/fruitCount) produces zero fruitSlots', () => {
 		const geo = generateTree(makeConfig());
-		expect(geo.fruitTriangles).toHaveLength(0);
+		expect(geo.fruitSlots).toHaveLength(0);
 	});
 });
 

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -11,13 +11,7 @@ import type {
 	Tier,
 	TreeShape,
 } from './types.js';
-import {
-	GEOMETRY_GROUPS,
-	VIEWBOX_WIDTH,
-	VIEWBOX_HEIGHT,
-	TREE_SHAPES,
-	FRUIT_TYPES,
-} from './types.js';
+import { GEOMETRY_GROUPS, VIEWBOX_WIDTH, VIEWBOX_HEIGHT, TREE_SHAPES } from './types.js';
 import { applyStageModifiers, generateStakeTriangles } from './stages/index.js';
 import { createPrng, poissonSample } from './prng.js';
 import {
@@ -38,7 +32,6 @@ import {
 	buildTrunkPath,
 	sampleTrunkCenterX,
 	generateCustomBlobs,
-	generateFruitAtSlots,
 	CUSTOM_BLOB_CANOPY_CENTER_X,
 	CUSTOM_BLOB_CANOPY_CENTER_Y,
 	CUSTOM_BLOB_SPREAD_RADIUS,
@@ -520,18 +513,37 @@ function generateTierCanopy(
 // Main entry point
 // ---------------------------------------------------------------------------
 
+interface StageFlags {
+	readonly addStakes: boolean;
+	readonly addFruit: boolean;
+	readonly addFlowers: boolean;
+	readonly addFallingLeaves: boolean;
+}
+
+const DEFAULT_STAGE_FLAGS: StageFlags = {
+	addStakes: false,
+	addFruit: false,
+	addFlowers: false,
+	addFallingLeaves: false,
+};
+
 export function generateTree(config: TreeConfig): TreeGeometry {
 	if (config.shape !== TREE_SHAPES.custom) {
 		const stageResult = applyStageModifiers(config);
 		if (stageResult.kind === 'directGeometry') {
 			return stageResult.geometry;
 		}
-		return generateTreeCore(stageResult.config, stageResult.addStakes, stageResult.addFruit);
+		return generateTreeCore(stageResult.config, {
+			addStakes: stageResult.addStakes,
+			addFruit: stageResult.addFruit,
+			addFlowers: stageResult.addFlowers,
+			addFallingLeaves: stageResult.addFallingLeaves,
+		});
 	}
-	return generateTreeCore(config, false, false);
+	return generateTreeCore(config, DEFAULT_STAGE_FLAGS);
 }
 
-function generateTreeCore(config: TreeConfig, addStakes: boolean, addFruit: boolean): TreeGeometry {
+function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 	const rng = createPrng(config.seed);
 	const shapeDef = getShapeDefinition(config.shape);
 	const isTiered = TIERED_SHAPES.has(config.shape);
@@ -657,31 +669,21 @@ function generateTreeCore(config: TreeConfig, addStakes: boolean, addFruit: bool
 		config.seed,
 	);
 
-	const effectiveFruitType = config.fruitType;
 	const effectiveFruitCount = Math.min(config.fruitCount, FRUIT_COUNT_CAP);
-	let fruitTriangles: Triangle[] = [];
-
-	if (effectiveFruitType !== FRUIT_TYPES.none && effectiveFruitCount > 0) {
-		const fruitSlots = [...anchors.fruitSlots];
-		const fruitRng = createPrng(config.seed + FRUIT_SLOTS_SEED_OFFSET + 2000);
-		fruitTriangles = generateFruitAtSlots(
-			effectiveFruitType,
-			fruitSlots.slice(0, effectiveFruitCount),
-			fruitRng,
-		);
-	}
-
-	const stakeTriangles = addStakes ? generateStakeTriangles(anchors) : [];
-	const fruitSlotsResult = addFruit ? anchors.fruitSlots : [];
+	const stakeTriangles = flags.addStakes ? generateStakeTriangles(anchors) : [];
+	const fruitSlotsResult = flags.addFruit ? anchors.fruitSlots.slice(0, effectiveFruitCount) : [];
+	const flowerSlotsResult = flags.addFlowers ? anchors.fruitSlots : [];
 
 	return {
 		trunkQuads,
 		trunkTriangles: [],
 		branchGroups,
 		canopyBlobs,
-		fruitTriangles,
+		fruitTriangles: [],
 		stakeTriangles,
 		fruitSlots: fruitSlotsResult,
+		flowerSlots: flowerSlotsResult,
+		showFallingLeaves: flags.addFallingLeaves,
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -34,8 +34,6 @@ export {
 
 export { generateBranches } from './shapes/branch_generation.js';
 
-export { generateFruitAtSlots } from './shapes/fruit_geometry.js';
-
 export {
 	getShapeDefinition,
 	generateCustomBlobs,

--- a/src/lib/trees/shapes/flower_geometry.ts
+++ b/src/lib/trees/shapes/flower_geometry.ts
@@ -1,0 +1,35 @@
+import { TREE_SHAPES, type TreeShape } from '../types/config.js';
+import type { Component } from 'svelte';
+import {
+	OakFlowerSvg,
+	BirchFlowerSvg,
+	MapleFlowerSvg,
+	PineFlowerSvg,
+	FirFlowerSvg,
+	WillowFlowerSvg,
+	CypressFlowerSvg,
+	AppleFlowerSvg,
+	CherryFlowerSvg,
+	BushFlowerSvg,
+	BaobabFlowerSvg,
+	AcaciaFlowerSvg,
+} from '../assets/flowers/index.js';
+
+/**
+ * Maps each non-custom tree shape to its flower SVG Svelte component.
+ * Used during the flowering lifecycle stage.
+ */
+export const FLOWER_SVG_COMPONENTS: Record<Exclude<TreeShape, 'custom'>, Component> = {
+	[TREE_SHAPES.oak]: OakFlowerSvg,
+	[TREE_SHAPES.birch]: BirchFlowerSvg,
+	[TREE_SHAPES.maple]: MapleFlowerSvg,
+	[TREE_SHAPES.pine]: PineFlowerSvg,
+	[TREE_SHAPES.fir]: FirFlowerSvg,
+	[TREE_SHAPES.willow]: WillowFlowerSvg,
+	[TREE_SHAPES.cypress]: CypressFlowerSvg,
+	[TREE_SHAPES.apple]: AppleFlowerSvg,
+	[TREE_SHAPES.cherry]: CherryFlowerSvg,
+	[TREE_SHAPES.bush]: BushFlowerSvg,
+	[TREE_SHAPES.baobab]: BaobabFlowerSvg,
+	[TREE_SHAPES.acacia]: AcaciaFlowerSvg,
+};

--- a/src/lib/trees/shapes/fruit_geometry.ts
+++ b/src/lib/trees/shapes/fruit_geometry.ts
@@ -1,43 +1,35 @@
-import type { Point2D, Triangle } from '../types/core.js';
-import { GEOMETRY_GROUPS } from '../types/core.js';
-import { FRUIT_TYPES, FRUIT_SPECS, type FruitType } from '../types/fruit.js';
+import { FRUIT_TYPES, type FruitType } from '../types/fruit.js';
+import type { Component } from 'svelte';
+import {
+	AcornSvg,
+	CatkinBirchSvg,
+	SamaraSvg,
+	PineConeSvg,
+	FirConeSvg,
+	CatkinWillowSvg,
+	SmallConeSvg,
+	AppleSvg,
+	CherryPairSvg,
+	BerrySvg,
+	BaobabFruitSvg,
+	SeedPodSvg,
+} from '../assets/fruits/index.js';
 
 /**
- * Re-export individual shape generators for direct testing.
- * The canonical implementations live in FRUIT_SPECS (types/fruit.ts).
+ * Maps each non-none fruit type to its SVG Svelte component.
+ * The renderer places these at fruit slot positions via `<svelte:component>`.
  */
-export const generateApple = FRUIT_SPECS[FRUIT_TYPES.apple].generateShape;
-export const generateCherry = FRUIT_SPECS[FRUIT_TYPES.cherry].generateShape;
-export const generateFlower = FRUIT_SPECS[FRUIT_TYPES.flower].generateShape;
-
-const DEFAULT_FRUIT_SIZE = 4;
-
-/**
- * Dispatches to the correct shape generator per slot, applies FRUIT_SPECS color,
- * sets group to GEOMETRY_GROUPS.fruit.
- */
-export function generateFruitAtSlots(
-	fruitType: FruitType,
-	slots: readonly Point2D[],
-	rng: () => number,
-): Triangle[] {
-	if (fruitType === FRUIT_TYPES.none || slots.length === 0) {
-		return [];
-	}
-
-	const spec = FRUIT_SPECS[fruitType];
-	const triangles: Triangle[] = [];
-
-	for (const slot of slots) {
-		const shapeTriangles = spec.generateShape(slot.x, slot.y, DEFAULT_FRUIT_SIZE, rng);
-		for (const points of shapeTriangles) {
-			triangles.push({
-				points,
-				color: spec.color,
-				group: GEOMETRY_GROUPS.fruit,
-			});
-		}
-	}
-
-	return triangles;
-}
+export const FRUIT_SVG_COMPONENTS: Record<Exclude<FruitType, 'none'>, Component> = {
+	[FRUIT_TYPES.acorn]: AcornSvg,
+	[FRUIT_TYPES.catkin_birch]: CatkinBirchSvg,
+	[FRUIT_TYPES.samara]: SamaraSvg,
+	[FRUIT_TYPES.pine_cone]: PineConeSvg,
+	[FRUIT_TYPES.fir_cone]: FirConeSvg,
+	[FRUIT_TYPES.catkin_willow]: CatkinWillowSvg,
+	[FRUIT_TYPES.small_cone]: SmallConeSvg,
+	[FRUIT_TYPES.apple]: AppleSvg,
+	[FRUIT_TYPES.cherry_pair]: CherryPairSvg,
+	[FRUIT_TYPES.berry]: BerrySvg,
+	[FRUIT_TYPES.baobab_fruit]: BaobabFruitSvg,
+	[FRUIT_TYPES.seed_pod]: SeedPodSvg,
+};

--- a/src/lib/trees/stages/seed_generator.ts
+++ b/src/lib/trees/stages/seed_generator.ts
@@ -59,6 +59,8 @@ export function generateSeedGeometry(): TreeGeometry {
 		fruitTriangles: [],
 		stakeTriangles: [],
 		fruitSlots: [],
+		flowerSlots: [],
+		showFallingLeaves: false,
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/stages/sprouting_generator.ts
+++ b/src/lib/trees/stages/sprouting_generator.ts
@@ -63,6 +63,8 @@ export function generateSproutingGeometry(): TreeGeometry {
 		fruitTriangles: [],
 		stakeTriangles: [],
 		fruitSlots: [],
+		flowerSlots: [],
+		showFallingLeaves: false,
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/stages/stage_modifiers.ts
+++ b/src/lib/trees/stages/stage_modifiers.ts
@@ -36,6 +36,8 @@ const STAGE_HANDLERS = {
 		}),
 		addStakes: false,
 		addFruit: false,
+		addFlowers: false,
+		addFallingLeaves: false,
 	}),
 
 	[TREE_STAGES.growing]: (_config: TreeConfig): StageResult => ({
@@ -49,8 +51,10 @@ const STAGE_HANDLERS = {
 			polygonsPerBlob: 9,
 			trunkPolygons: 22,
 		}),
-		addStakes: true,
+		addStakes: false,
 		addFruit: false,
+		addFlowers: false,
+		addFallingLeaves: false,
 	}),
 
 	[TREE_STAGES.leafy]: (_config: TreeConfig): StageResult => ({
@@ -58,6 +62,17 @@ const STAGE_HANDLERS = {
 		config: _config,
 		addStakes: false,
 		addFruit: false,
+		addFlowers: false,
+		addFallingLeaves: false,
+	}),
+
+	[TREE_STAGES.flowering]: (_config: TreeConfig): StageResult => ({
+		kind: 'modifiedConfig',
+		config: _config,
+		addStakes: false,
+		addFruit: false,
+		addFlowers: true,
+		addFallingLeaves: false,
 	}),
 
 	[TREE_STAGES.fruiting]: (_config: TreeConfig): StageResult => ({
@@ -65,6 +80,8 @@ const STAGE_HANDLERS = {
 		config: _config,
 		addStakes: false,
 		addFruit: true,
+		addFlowers: false,
+		addFallingLeaves: false,
 	}),
 
 	[TREE_STAGES.autumn]: (_config: TreeConfig): StageResult => ({
@@ -75,6 +92,8 @@ const STAGE_HANDLERS = {
 		}),
 		addStakes: false,
 		addFruit: false,
+		addFlowers: false,
+		addFallingLeaves: true,
 	}),
 
 	[TREE_STAGES.ready]: (_config: TreeConfig): StageResult => ({
@@ -82,6 +101,8 @@ const STAGE_HANDLERS = {
 		config: _config,
 		addStakes: false,
 		addFruit: false,
+		addFlowers: false,
+		addFallingLeaves: false,
 	}),
 
 	[TREE_STAGES.bare]: (_config: TreeConfig): StageResult => ({
@@ -92,6 +113,8 @@ const STAGE_HANDLERS = {
 		}),
 		addStakes: false,
 		addFruit: false,
+		addFlowers: false,
+		addFallingLeaves: false,
 	}),
 
 	[TREE_STAGES.dead]: (_config: TreeConfig): StageResult => ({
@@ -108,6 +131,8 @@ const STAGE_HANDLERS = {
 		}),
 		addStakes: false,
 		addFruit: false,
+		addFlowers: false,
+		addFallingLeaves: false,
 	}),
 
 	[TREE_STAGES.stump]: (): StageResult => ({

--- a/src/lib/trees/stages/stage_types.ts
+++ b/src/lib/trees/stages/stage_types.ts
@@ -6,5 +6,7 @@ export type StageResult =
 			readonly config: TreeConfig;
 			readonly addStakes: boolean;
 			readonly addFruit: boolean;
+			readonly addFlowers: boolean;
+			readonly addFallingLeaves: boolean;
 	  }
 	| { readonly kind: 'directGeometry'; readonly geometry: TreeGeometry };

--- a/src/lib/trees/stages/stages.test.ts
+++ b/src/lib/trees/stages/stages.test.ts
@@ -22,12 +22,12 @@ function hasValidAnchors(geo: TreeGeometry): boolean {
 }
 
 describe('TREE_STAGES', () => {
-	it('has exactly 11 entries', () => {
-		expect(Object.keys(TREE_STAGES)).toHaveLength(11);
+	it('has exactly 12 entries', () => {
+		expect(Object.keys(TREE_STAGES)).toHaveLength(12);
 	});
 
-	it('TREE_STAGE_OPTIONS has 11 options with label/value pairs', () => {
-		expect(TREE_STAGE_OPTIONS).toHaveLength(11);
+	it('TREE_STAGE_OPTIONS has 12 options with label/value pairs', () => {
+		expect(TREE_STAGE_OPTIONS).toHaveLength(12);
 		for (const option of TREE_STAGE_OPTIONS) {
 			expect(typeof option.value).toBe('string');
 			expect(typeof option.label).toBe('string');
@@ -54,6 +54,8 @@ describe('stage generation — every stage produces valid TreeGeometry', () => {
 			expect(Array.isArray(geo.canopyBlobs)).toBe(true);
 			expect(Array.isArray(geo.stakeTriangles)).toBe(true);
 			expect(Array.isArray(geo.fruitSlots)).toBe(true);
+			expect(Array.isArray(geo.flowerSlots)).toBe(true);
+			expect(typeof geo.showFallingLeaves).toBe('boolean');
 		});
 	}
 });
@@ -112,16 +114,9 @@ describe('sapling stage', () => {
 });
 
 describe('growing stage', () => {
-	it('includes stake triangles', () => {
+	it('has no stakes', () => {
 		const geo = generateTree(makeConfig({ stage: TREE_STAGES.growing }));
-		expect(geo.stakeTriangles.length).toBeGreaterThan(0);
-	});
-
-	it('stake triangles have group=stake', () => {
-		const geo = generateTree(makeConfig({ stage: TREE_STAGES.growing }));
-		for (const tri of geo.stakeTriangles) {
-			expect(tri.group).toBe('stake');
-		}
+		expect(geo.stakeTriangles).toHaveLength(0);
 	});
 });
 
@@ -135,14 +130,38 @@ describe('leafy stage', () => {
 	});
 });
 
+describe('flowering stage', () => {
+	it('populates flowerSlots with at least 1 point', () => {
+		const geo = generateTree(makeConfig({ stage: TREE_STAGES.flowering }));
+		expect(geo.flowerSlots.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('flowerSlots contain valid Point2D', () => {
+		const geo = generateTree(makeConfig({ stage: TREE_STAGES.flowering }));
+		for (const slot of geo.flowerSlots) {
+			expect(typeof slot.x).toBe('number');
+			expect(typeof slot.y).toBe('number');
+		}
+	});
+
+	it('has empty fruitSlots (not yet fruiting)', () => {
+		const geo = generateTree(makeConfig({ stage: TREE_STAGES.flowering }));
+		expect(geo.fruitSlots).toHaveLength(0);
+	});
+});
+
 describe('fruiting stage', () => {
 	it('populates fruitSlots with at least 1 point', () => {
-		const geo = generateTree(makeConfig({ stage: TREE_STAGES.fruiting }));
+		const geo = generateTree(
+			makeConfig({ stage: TREE_STAGES.fruiting, fruitType: 'apple', fruitCount: 5 }),
+		);
 		expect(geo.fruitSlots.length).toBeGreaterThanOrEqual(1);
 	});
 
 	it('fruitSlots contain valid Point2D', () => {
-		const geo = generateTree(makeConfig({ stage: TREE_STAGES.fruiting }));
+		const geo = generateTree(
+			makeConfig({ stage: TREE_STAGES.fruiting, fruitType: 'apple', fruitCount: 5 }),
+		);
 		for (const slot of geo.fruitSlots) {
 			expect(typeof slot.x).toBe('number');
 			expect(typeof slot.y).toBe('number');
@@ -166,6 +185,34 @@ describe('autumn stage', () => {
 		// Autumn and leafy should have largely different color sets
 		expect(overlap.length).toBeLessThan(autumnSet.size);
 	});
+
+	it('has showFallingLeaves true', () => {
+		const geo = generateTree(makeConfig({ stage: TREE_STAGES.autumn }));
+		expect(geo.showFallingLeaves).toBe(true);
+	});
+});
+
+describe('showFallingLeaves — only autumn', () => {
+	const allStages = Object.values(TREE_STAGES) as TreeStage[];
+	const nonAutumnStages = allStages.filter((s) => s !== TREE_STAGES.autumn);
+
+	for (const stage of nonAutumnStages) {
+		it(`${stage}: showFallingLeaves is false`, () => {
+			const geo = generateTree(makeConfig({ stage }));
+			expect(geo.showFallingLeaves).toBe(false);
+		});
+	}
+});
+
+describe('flowerSlots array present on all stages', () => {
+	const allStages = Object.values(TREE_STAGES) as TreeStage[];
+
+	for (const stage of allStages) {
+		it(`${stage}: has flowerSlots array`, () => {
+			const geo = generateTree(makeConfig({ stage }));
+			expect(Array.isArray(geo.flowerSlots)).toBe(true);
+		});
+	}
 });
 
 describe('ready stage', () => {

--- a/src/lib/trees/stages/stump_generator.ts
+++ b/src/lib/trees/stages/stump_generator.ts
@@ -70,6 +70,8 @@ export function generateStumpGeometry(): TreeGeometry {
 		fruitTriangles: [],
 		stakeTriangles: [],
 		fruitSlots: [],
+		flowerSlots: [],
+		showFallingLeaves: false,
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/tree_config.context.svelte.ts
+++ b/src/lib/trees/tree_config.context.svelte.ts
@@ -1,4 +1,11 @@
-import { DEFAULT_TREE_CONFIG, TREE_SHAPES, type CustomBlob, type TreeConfig } from './types.js';
+import {
+	DEFAULT_TREE_CONFIG,
+	TREE_SHAPES,
+	FRUIT_TYPES,
+	type CustomBlob,
+	type TreeConfig,
+	type FruitType,
+} from './types.js';
 
 /** Strip readonly from all properties so `bind:value` can write through the deep proxy. */
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
@@ -36,6 +43,11 @@ class TreeConfigState {
 		const migrated = { ...DEFAULT_TREE_CONFIG, ...config };
 		if (legacy.branchCount !== undefined && !('branchesLevel1Range' in config)) {
 			migrated.branchesLevel1Range = [legacy.branchCount, legacy.branchCount];
+		}
+		// Migrate removed fruit types from old configs
+		const validFruitTypes = new Set<string>(Object.values(FRUIT_TYPES));
+		if (!validFruitTypes.has(migrated.fruitType)) {
+			migrated.fruitType = FRUIT_TYPES.none as FruitType;
 		}
 		this.current = migrated;
 		this.customBlobs = config.customBlobs ?? [];

--- a/src/lib/trees/types.test.ts
+++ b/src/lib/trees/types.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
 	DEFAULT_TREE_CONFIG,
 	SHAPE_DEFAULTS,
+	SHAPE_FRUIT_MAP,
 	TREE_SHAPES,
 	TREE_SHAPE_OPTIONS,
 	type TreeShape,
@@ -82,8 +83,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkHue: 25,
 			trunkSaturation: 50,
 			trunkLightness: 25,
-			fruitType: 'none',
-			fruitCount: 0,
+			fruitType: 'acorn',
+			fruitCount: 3,
 		});
 	});
 
@@ -107,8 +108,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkHue: 20,
 			trunkSaturation: 45,
 			trunkLightness: 20,
-			fruitType: 'none',
-			fruitCount: 0,
+			fruitType: 'pine_cone',
+			fruitCount: 3,
 		});
 	});
 
@@ -132,8 +133,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkHue: 40,
 			trunkSaturation: 8,
 			trunkLightness: 82,
-			fruitType: 'none',
-			fruitCount: 0,
+			fruitType: 'catkin_birch',
+			fruitCount: 3,
 		});
 	});
 
@@ -157,8 +158,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkHue: 22,
 			trunkSaturation: 50,
 			trunkLightness: 28,
-			fruitType: 'none',
-			fruitCount: 0,
+			fruitType: 'fir_cone',
+			fruitCount: 3,
 		});
 	});
 
@@ -182,8 +183,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkHue: 30,
 			trunkSaturation: 20,
 			trunkLightness: 35,
-			fruitType: 'none',
-			fruitCount: 0,
+			fruitType: 'samara',
+			fruitCount: 3,
 		});
 	});
 
@@ -207,8 +208,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			trunkHue: 25,
 			trunkSaturation: 40,
 			trunkLightness: 22,
-			fruitType: 'none',
-			fruitCount: 0,
+			fruitType: 'catkin_willow',
+			fruitCount: 3,
 		});
 	});
 
@@ -235,6 +236,8 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 		expect(SHAPE_DEFAULTS.cypress.blobCount).toBe(2);
 		expect(SHAPE_DEFAULTS.cypress.branchDepth).toBe(0);
 		expect(SHAPE_DEFAULTS.cypress.canopyLightColor).toBe('#2d5e3a');
+		expect(SHAPE_DEFAULTS.cypress.fruitType).toBe('small_cone');
+		expect(SHAPE_DEFAULTS.cypress.fruitCount).toBe(3);
 	});
 
 	it('has apple defaults (compact round, short trunk, apple fruit)', () => {
@@ -244,12 +247,12 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 		expect(SHAPE_DEFAULTS.apple.fruitCount).toBe(3);
 	});
 
-	it('has cherry defaults (wide spread, pink canopy, cherry fruit)', () => {
+	it('has cherry defaults (wide spread, pink canopy, cherry_pair fruit)', () => {
 		expect(SHAPE_DEFAULTS.cherry.blobCount).toBe(4);
 		expect(SHAPE_DEFAULTS.cherry.branchDepth).toBe(2);
 		expect(SHAPE_DEFAULTS.cherry.canopyLightColor).toBe('#ffb7c5');
 		expect(SHAPE_DEFAULTS.cherry.canopyDarkColor).toBe('#c4586a');
-		expect(SHAPE_DEFAULTS.cherry.fruitType).toBe('cherry');
+		expect(SHAPE_DEFAULTS.cherry.fruitType).toBe('cherry_pair');
 		expect(SHAPE_DEFAULTS.cherry.fruitCount).toBe(4);
 	});
 
@@ -275,5 +278,26 @@ describe('DEFAULT_TREE_CONFIG canopy color defaults (REQ-P-30/31)', () => {
 	it('uses oak canopyLightColor and canopyDarkColor from §2.6', () => {
 		expect(DEFAULT_TREE_CONFIG.canopyLightColor).toBe('#a8d84e');
 		expect(DEFAULT_TREE_CONFIG.canopyDarkColor).toBe('#1a472a');
+	});
+});
+
+describe('SHAPE_FRUIT_MAP', () => {
+	it('has 12 entries (one per non-custom shape)', () => {
+		expect(Object.keys(SHAPE_FRUIT_MAP)).toHaveLength(12);
+	});
+
+	it('maps each shape to its expected fruit type', () => {
+		expect(SHAPE_FRUIT_MAP.oak).toBe('acorn');
+		expect(SHAPE_FRUIT_MAP.birch).toBe('catkin_birch');
+		expect(SHAPE_FRUIT_MAP.maple).toBe('samara');
+		expect(SHAPE_FRUIT_MAP.pine).toBe('pine_cone');
+		expect(SHAPE_FRUIT_MAP.fir).toBe('fir_cone');
+		expect(SHAPE_FRUIT_MAP.willow).toBe('catkin_willow');
+		expect(SHAPE_FRUIT_MAP.cypress).toBe('small_cone');
+		expect(SHAPE_FRUIT_MAP.apple).toBe('apple');
+		expect(SHAPE_FRUIT_MAP.cherry).toBe('cherry_pair');
+		expect(SHAPE_FRUIT_MAP.bush).toBe('berry');
+		expect(SHAPE_FRUIT_MAP.baobab).toBe('baobab_fruit');
+		expect(SHAPE_FRUIT_MAP.acacia).toBe('seed_pod');
 	});
 });

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -26,7 +26,7 @@ export {
 	isTreeStage,
 } from './types/config.js';
 
-export { FRUIT_TYPES, type FruitType, FRUIT_TYPE_OPTIONS, FRUIT_SPECS } from './types/fruit.js';
+export { FRUIT_TYPES, type FruitType, FRUIT_TYPE_OPTIONS, SHAPE_FRUIT_MAP } from './types/fruit.js';
 
 export {
 	CUSTOM_BLOB_BOUNDARY_KINDS,

--- a/src/lib/trees/types/config.ts
+++ b/src/lib/trees/types/config.ts
@@ -1,5 +1,5 @@
 import type { CustomBlob } from './custom.js';
-import { FRUIT_TYPES, type FruitType } from './fruit.js';
+import { FRUIT_TYPES, SHAPE_FRUIT_MAP, type FruitType } from './fruit.js';
 
 export const TREE_STAGES = {
 	seed: 'seed',
@@ -7,6 +7,7 @@ export const TREE_STAGES = {
 	sapling: 'sapling',
 	growing: 'growing',
 	leafy: 'leafy',
+	flowering: 'flowering',
 	fruiting: 'fruiting',
 	autumn: 'autumn',
 	ready: 'ready',
@@ -23,6 +24,7 @@ export const TREE_STAGE_OPTIONS: readonly { value: TreeStage; label: string }[] 
 	{ value: TREE_STAGES.sapling, label: 'Sapling' },
 	{ value: TREE_STAGES.growing, label: 'Growing' },
 	{ value: TREE_STAGES.leafy, label: 'Leafy' },
+	{ value: TREE_STAGES.flowering, label: 'Flowering' },
 	{ value: TREE_STAGES.fruiting, label: 'Fruiting' },
 	{ value: TREE_STAGES.autumn, label: 'Autumn' },
 	{ value: TREE_STAGES.ready, label: 'Ready' },
@@ -181,8 +183,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 25,
 		trunkSaturation: 50,
 		trunkLightness: 25,
-		fruitType: FRUIT_TYPES.none,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.oak,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.pine]: {
 		blobCount: 5,
@@ -203,8 +205,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 20,
 		trunkSaturation: 45,
 		trunkLightness: 20,
-		fruitType: FRUIT_TYPES.none,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.pine,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.birch]: {
 		blobCount: 6,
@@ -225,8 +227,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 40,
 		trunkSaturation: 8,
 		trunkLightness: 82,
-		fruitType: FRUIT_TYPES.none,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.birch,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.fir]: {
 		blobCount: 6,
@@ -247,8 +249,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 22,
 		trunkSaturation: 50,
 		trunkLightness: 28,
-		fruitType: FRUIT_TYPES.none,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.fir,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.maple]: {
 		blobCount: 5,
@@ -269,8 +271,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 30,
 		trunkSaturation: 20,
 		trunkLightness: 35,
-		fruitType: FRUIT_TYPES.none,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.maple,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.willow]: {
 		blobCount: 6,
@@ -291,8 +293,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 25,
 		trunkSaturation: 40,
 		trunkLightness: 22,
-		fruitType: FRUIT_TYPES.none,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.willow,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.cypress]: {
 		blobCount: 2,
@@ -313,8 +315,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 25,
 		trunkSaturation: 50,
 		trunkLightness: 25,
-		fruitType: FRUIT_TYPES.flower,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.cypress,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.apple]: {
 		blobCount: 2,
@@ -335,7 +337,7 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 25,
 		trunkSaturation: 50,
 		trunkLightness: 30,
-		fruitType: FRUIT_TYPES.apple,
+		fruitType: SHAPE_FRUIT_MAP.apple,
 		fruitCount: 3,
 	},
 	[TREE_SHAPES.cherry]: {
@@ -357,7 +359,7 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 20,
 		trunkSaturation: 40,
 		trunkLightness: 25,
-		fruitType: FRUIT_TYPES.cherry,
+		fruitType: SHAPE_FRUIT_MAP.cherry,
 		fruitCount: 4,
 	},
 	[TREE_SHAPES.bush]: {
@@ -379,8 +381,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 25,
 		trunkSaturation: 50,
 		trunkLightness: 25,
-		fruitType: FRUIT_TYPES.flower,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.bush,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.baobab]: {
 		blobCount: 3,
@@ -401,8 +403,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 30,
 		trunkSaturation: 15,
 		trunkLightness: 45,
-		fruitType: FRUIT_TYPES.flower,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.baobab,
+		fruitCount: 3,
 	},
 	[TREE_SHAPES.acacia]: {
 		blobCount: 3,
@@ -423,8 +425,8 @@ export const SHAPE_DEFAULTS = {
 		trunkHue: 25,
 		trunkSaturation: 35,
 		trunkLightness: 28,
-		fruitType: FRUIT_TYPES.flower,
-		fruitCount: 0,
+		fruitType: SHAPE_FRUIT_MAP.acacia,
+		fruitCount: 3,
 	},
 } as const satisfies Record<
 	Exclude<TreeShape, 'custom'>,

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -3,6 +3,7 @@ export const GEOMETRY_GROUPS = {
 	trunk: 'trunk',
 	branch: 'branch',
 	fruit: 'fruit',
+	flower: 'flower',
 	stake: 'stake',
 } as const;
 
@@ -69,6 +70,10 @@ export interface TreeGeometry {
 	readonly fruitTriangles: readonly Triangle[];
 	readonly stakeTriangles: readonly Triangle[];
 	readonly fruitSlots: readonly Point2D[];
+	/** Slots where flower SVGs should be rendered (flowering stage). */
+	readonly flowerSlots: readonly Point2D[];
+	/** Whether to show falling leaf particles (autumn stage). */
+	readonly showFallingLeaves: boolean;
 	readonly anchors: TreeAnchors;
 	readonly viewBox: { readonly width: number; readonly height: number };
 }

--- a/src/lib/trees/types/fruit.ts
+++ b/src/lib/trees/types/fruit.ts
@@ -1,136 +1,54 @@
-import type { Point2D } from './core.js';
+import type { TreeShape } from './config.js';
 
 export const FRUIT_TYPES = {
 	none: 'none',
+	acorn: 'acorn',
+	catkin_birch: 'catkin_birch',
+	samara: 'samara',
+	pine_cone: 'pine_cone',
+	fir_cone: 'fir_cone',
+	catkin_willow: 'catkin_willow',
+	small_cone: 'small_cone',
 	apple: 'apple',
-	cherry: 'cherry',
-	flower: 'flower',
+	cherry_pair: 'cherry_pair',
+	berry: 'berry',
+	baobab_fruit: 'baobab_fruit',
+	seed_pod: 'seed_pod',
 } as const;
 
 export type FruitType = (typeof FRUIT_TYPES)[keyof typeof FRUIT_TYPES];
 
 export const FRUIT_TYPE_OPTIONS: readonly { value: FruitType; label: string }[] = [
 	{ value: FRUIT_TYPES.none, label: 'None' },
+	{ value: FRUIT_TYPES.acorn, label: 'Acorn' },
+	{ value: FRUIT_TYPES.catkin_birch, label: 'Catkin (Birch)' },
+	{ value: FRUIT_TYPES.samara, label: 'Samara' },
+	{ value: FRUIT_TYPES.pine_cone, label: 'Pine Cone' },
+	{ value: FRUIT_TYPES.fir_cone, label: 'Fir Cone' },
+	{ value: FRUIT_TYPES.catkin_willow, label: 'Catkin (Willow)' },
+	{ value: FRUIT_TYPES.small_cone, label: 'Small Cone' },
 	{ value: FRUIT_TYPES.apple, label: 'Apple' },
-	{ value: FRUIT_TYPES.cherry, label: 'Cherry' },
-	{ value: FRUIT_TYPES.flower, label: 'Flower' },
+	{ value: FRUIT_TYPES.cherry_pair, label: 'Cherry Pair' },
+	{ value: FRUIT_TYPES.berry, label: 'Berry' },
+	{ value: FRUIT_TYPES.baobab_fruit, label: 'Baobab Fruit' },
+	{ value: FRUIT_TYPES.seed_pod, label: 'Seed Pod' },
 ] as const;
 
-interface FruitSpec {
-	readonly color: string;
-	readonly generateShape: (
-		cx: number,
-		cy: number,
-		size: number,
-		rng: () => number,
-	) => [Point2D, Point2D, Point2D][];
-}
-
-function generateAppleShape(
-	cx: number,
-	cy: number,
-	size: number,
-	rng: () => number,
-): [Point2D, Point2D, Point2D][] {
-	const triangleCount = 5 + (rng() < 0.5 ? 1 : 0);
-	const triangles: [Point2D, Point2D, Point2D][] = [];
-	const angleStep = (Math.PI * 2) / triangleCount;
-
-	for (let i = 0; i < triangleCount; i++) {
-		const angle1 = i * angleStep;
-		const angle2 = (i + 1) * angleStep;
-		const r1 = size * (0.8 + rng() * 0.4);
-		const r2 = size * (0.8 + rng() * 0.4);
-		triangles.push([
-			{ x: cx, y: cy },
-			{ x: cx + Math.cos(angle1) * r1, y: cy + Math.sin(angle1) * r1 },
-			{ x: cx + Math.cos(angle2) * r2, y: cy + Math.sin(angle2) * r2 },
-		]);
-	}
-
-	return triangles;
-}
-
-function generateCherryShape(
-	cx: number,
-	cy: number,
-	size: number,
-	rng: () => number,
-): [Point2D, Point2D, Point2D][] {
-	const triangles: [Point2D, Point2D, Point2D][] = [];
-	const offset = size * 1.2;
-
-	for (const side of [-1, 1]) {
-		const ccx = cx + side * offset;
-		const ccy = cy + size * 0.3;
-		const cherryTriCount = 3 + (rng() < 0.5 ? 1 : 0);
-		const angleStep = (Math.PI * 2) / cherryTriCount;
-
-		for (let i = 0; i < cherryTriCount; i++) {
-			const angle1 = i * angleStep;
-			const angle2 = (i + 1) * angleStep;
-			const r1 = size * (0.6 + rng() * 0.3);
-			const r2 = size * (0.6 + rng() * 0.3);
-			triangles.push([
-				{ x: ccx, y: ccy },
-				{ x: ccx + Math.cos(angle1) * r1, y: ccy + Math.sin(angle1) * r1 },
-				{ x: ccx + Math.cos(angle2) * r2, y: ccy + Math.sin(angle2) * r2 },
-			]);
-		}
-
-		const stemWidth = size * 0.15;
-		triangles.push([
-			{ x: ccx, y: ccy - size * 0.5 },
-			{ x: cx + stemWidth, y: cy - size * 0.8 },
-			{ x: cx - stemWidth, y: cy - size * 0.8 },
-		]);
-	}
-
-	return triangles;
-}
-
-function generateFlowerShape(
-	cx: number,
-	cy: number,
-	size: number,
-	rng: () => number,
-): [Point2D, Point2D, Point2D][] {
-	const triangles: [Point2D, Point2D, Point2D][] = [];
-	const jitter = () => rng() * size * 0.2 - size * 0.1;
-	const petalLength = size * 0.9;
-	const petalWidth = size * 0.4;
-
-	for (let i = 0; i < 4; i++) {
-		const angle = (i * Math.PI) / 2;
-		const tipX = cx + Math.cos(angle) * petalLength + jitter();
-		const tipY = cy + Math.sin(angle) * petalLength + jitter();
-		const perpAngle = angle + Math.PI / 2;
-		const baseX1 = cx + Math.cos(perpAngle) * petalWidth;
-		const baseY1 = cy + Math.sin(perpAngle) * petalWidth;
-		const baseX2 = cx - Math.cos(perpAngle) * petalWidth;
-		const baseY2 = cy - Math.sin(perpAngle) * petalWidth;
-
-		triangles.push([
-			{ x: tipX, y: tipY },
-			{ x: baseX1, y: baseY1 },
-			{ x: baseX2, y: baseY2 },
-		]);
-	}
-
-	return triangles;
-}
-
-export const FRUIT_SPECS: Record<Exclude<FruitType, 'none'>, FruitSpec> = {
-	[FRUIT_TYPES.apple]: {
-		color: '#e53e3e',
-		generateShape: generateAppleShape,
-	},
-	[FRUIT_TYPES.cherry]: {
-		color: '#9b2c2c',
-		generateShape: generateCherryShape,
-	},
-	[FRUIT_TYPES.flower]: {
-		color: '#ed64a6',
-		generateShape: generateFlowerShape,
-	},
-};
+/**
+ * Maps each non-custom tree shape to its locked default fruit type.
+ * Only `custom` allows free selection from the full fruit dropdown.
+ */
+export const SHAPE_FRUIT_MAP = {
+	oak: FRUIT_TYPES.acorn,
+	birch: FRUIT_TYPES.catkin_birch,
+	maple: FRUIT_TYPES.samara,
+	pine: FRUIT_TYPES.pine_cone,
+	fir: FRUIT_TYPES.fir_cone,
+	willow: FRUIT_TYPES.catkin_willow,
+	cypress: FRUIT_TYPES.small_cone,
+	apple: FRUIT_TYPES.apple,
+	cherry: FRUIT_TYPES.cherry_pair,
+	bush: FRUIT_TYPES.berry,
+	baobab: FRUIT_TYPES.baobab_fruit,
+	acacia: FRUIT_TYPES.seed_pod,
+} as const satisfies Record<Exclude<TreeShape, 'custom'>, FruitType>;

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -68,6 +68,7 @@
 			fruitType: treeConfig.current.fruitType,
 		}),
 	);
+	const fruitTypeDisabled = $derived(isParamDisabled(treeConfig.current.shape, 'fruitType', {}));
 	const level1Disabled = $derived(
 		isParamDisabled(treeConfig.current.shape, 'branchesLevel1Range', {
 			branchDepth: treeConfig.current.branchDepth,
@@ -331,6 +332,7 @@
 							options={FRUIT_TYPE_OPTIONS}
 							value={treeConfig.current.fruitType}
 							onValueChange={onFruitTypeChange}
+							disabled={fruitTypeDisabled}
 						/>
 						<LabeledSlider
 							label="Fruit Count"

--- a/src/routes/showcase/+page.svelte
+++ b/src/routes/showcase/+page.svelte
@@ -7,6 +7,7 @@
 		TREE_SHAPES,
 		TREE_STAGES,
 		TREE_STAGE_OPTIONS,
+		SHAPE_FRUIT_MAP,
 		isTreeStage,
 		type TreeConfig,
 		type TreeShape,
@@ -19,7 +20,15 @@
 	);
 
 	const stageConfigs: ReadonlyMap<TreeStage, TreeConfig> = new Map(
-		allStages.map((stage) => [stage, { ...DEFAULT_TREE_CONFIG, stage }]),
+		allStages.map((stage) => [
+			stage,
+			{
+				...DEFAULT_TREE_CONFIG,
+				fruitType: SHAPE_FRUIT_MAP.oak,
+				fruitCount: 3,
+				stage,
+			},
+		]),
 	);
 
 	const shapeConfigs: ReadonlyMap<Exclude<TreeShape, 'custom'>, TreeConfig> = new Map(
@@ -70,7 +79,7 @@
 
 		<h2 class="text-xl font-semibold">All Stages</h2>
 
-		<div class="grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-11">
+		<div class="grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-12">
 			{#each allStages as stage (stage)}
 				<div class="flex flex-col items-center gap-2">
 					<div class="w-full rounded-lg border border-border bg-muted/20 p-2">


### PR DESCRIPTION
## Description
- Replace procedural triangle-fan fruits with 12 SVG assets (acorn, catkin, samara, pine cone, fir cone, apple, cherry pair, berry, baobab fruit, seed pod, small cone, catkin willow)
- Add 12 tree-specific flower SVG assets for flowering lifecycle stage
- Add `flowering` stage between leafy and fruiting (12 stages total)
- Remove `flower` from FRUIT_TYPES — flowers are now exclusively a lifecycle stage overlay
- Add `SHAPE_FRUIT_MAP`: each non-custom shape has a locked default fruit type
- Lock fruit type dropdown for non-custom shapes in editor UI
- Add falling leaf CSS particles for autumn stage (~8 leaves, orange/red/brown)
- Remove stakes from growing stage
- Add `flowerSlots` and `showFallingLeaves` fields to `TreeGeometry`
- Migrate legacy fruit types (`flower`, `cherry`) in saved config loader
- Update showcase grid to 12-column layout for all stages

## Resolves
Closes #64

## Testing
- [x] All 12 fruit types render as SVG assets at fruit slot positions
- [x] Selecting non-custom shape auto-sets and locks fruit dropdown
- [x] Custom shape shows full fruit type dropdown
- [x] Flowering stage shows tree-specific flowers at fruit slot positions
- [x] `flower` removed from FRUIT_TYPES enum and dropdown
- [x] 12-stage lifecycle enum, showcase shows all 12 stages
- [x] Flowering appears between leafy and fruiting in showcase
- [x] No stakes in growing stage
- [x] Autumn stage shows falling leaf particles
- [x] 2105 unit tests pass
- [x] check:all (format + lint + typecheck + stylelint + knip) green