### PR TITLE
#87 feat(scene): priority-based equidistant layout

### DIFF
--- a/src/lib/scene/scene_config.ts
+++ b/src/lib/scene/scene_config.ts
@@ -23,6 +23,7 @@ export interface SceneConfig {
 	readonly treeCount: number;
 	readonly depthSpread: number;
 	readonly baseSeed: number;
+	readonly trees?: readonly SceneTreeInput[];
 }
 
 export const SCENE_DEFAULTS: SceneConfig = {
@@ -38,13 +39,35 @@ export const SCENE_LIMITS = {
 	depthSpreadMax: 100,
 } as const;
 
+/** Maximum number of trees in the front row before overflow to back. */
+export const FRONT_ROW_CAPACITY = 10;
+
+/** Minimum scale for back-row trees. */
+export const BACK_SCALE_MIN = 0.65;
+
+/** Maximum scale for back-row trees. */
+export const BACK_SCALE_MAX = 0.8;
+
+/** Minimum back-row depth when depthSpread is 0. */
+export const BACK_DEPTH_FALLBACK = 15;
+
+/** Input descriptor for a tree in the scene, before layout. */
+export interface SceneTreeInput {
+	readonly id?: string;
+	/** 0 = background (always back row), 1 = foreground (front row preferred). Defaults to 1. */
+	readonly priority?: 0 | 1;
+	/** ID of another tree this one must be placed behind (y >= blocker's y). */
+	readonly blockedBy?: string;
+}
+
 /** A positioned tree in the scene, ready for rendering. */
 export interface SceneTreePlacement {
+	readonly id?: string;
 	readonly shape: SceneTreeShape;
 	readonly seed: number;
 	/** Horizontal position as percentage [0, 100]. */
 	readonly x: number;
-	/** Depth position — higher y = closer to viewer (front). */
+	/** Depth position — 0 = front (baseline), higher y = further from viewer (back). */
 	readonly y: number;
 	/** Scale factor derived from depth: 1.0 at front, ~0.65 at back. */
 	readonly scale: number;

--- a/src/lib/scene/scene_layout.test.ts
+++ b/src/lib/scene/scene_layout.test.ts
@@ -1,96 +1,286 @@
 import { describe, expect, it } from 'vitest';
 import { generateSceneLayout } from './scene_layout.js';
 import type { SceneConfig } from './scene_config.js';
+import { BACK_SCALE_MIN, BACK_SCALE_MAX, BACK_DEPTH_FALLBACK } from './scene_config.js';
 
-const BASE_CONFIG: SceneConfig = { treeCount: 10, depthSpread: 50, baseSeed: 42 };
+const BASE_CONFIG: SceneConfig = { treeCount: 3, depthSpread: 0, baseSeed: 42 };
 
 describe('generateSceneLayout', () => {
-	it('returns same output for same config (deterministic)', () => {
-		const a = generateSceneLayout(BASE_CONFIG);
-		const b = generateSceneLayout(BASE_CONFIG);
-		expect(a).toEqual(b);
-	});
-
-	it.each([3, 10, 50, 100])('returns exactly %i trees when treeCount=%i', (count) => {
-		const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: count });
-		expect(result).toHaveLength(count);
-	});
-
-	it('assigns only non-custom shapes', () => {
-		const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 30 });
-		for (const tree of result) {
-			expect(tree.shape).not.toBe('custom');
-		}
-	});
-
-	it('produces unique seeds for each tree', () => {
-		const result = generateSceneLayout(BASE_CONFIG);
-		const seeds = result.map((t) => t.seed);
-		expect(new Set(seeds).size).toBe(seeds.length);
-	});
-
-	it('keeps x positions within [0, 100]', () => {
-		const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 50 });
-		for (const tree of result) {
-			expect(tree.x).toBeGreaterThanOrEqual(0);
-			expect(tree.x).toBeLessThanOrEqual(100);
-		}
-	});
-
-	it('sorts output ascending by y (back-to-front for painter algorithm)', () => {
-		const result = generateSceneLayout(BASE_CONFIG);
-		for (let i = 1; i < result.length; i++) {
-			expect(result[i].y).toBeGreaterThanOrEqual(result[i - 1].y);
-		}
-	});
-
-	describe('depthSpread=0 (flat)', () => {
-		const flat = generateSceneLayout({ ...BASE_CONFIG, depthSpread: 0 });
-
-		it('gives all trees the same y', () => {
-			const ys = new Set(flat.map((t) => t.y));
-			expect(ys.size).toBe(1);
+	describe('Group 1: Front row basics (<=10 trees)', () => {
+		it('treeCount=0 returns empty array', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 0 });
+			expect(result).toEqual([]);
 		});
 
-		it('gives all trees scale 1.0', () => {
-			for (const tree of flat) {
+		it('treeCount=3 produces 3 placements at y=0, scale=1.0, x equidistant at 25/50/75', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 3 });
+			expect(result).toHaveLength(3);
+			for (const tree of result) {
+				expect(tree.y).toBe(0);
 				expect(tree.scale).toBeCloseTo(1.0, 5);
+			}
+			const xs = result.map((t) => t.x).sort((a, b) => a - b);
+			expect(xs[0]).toBeCloseTo(25, 5);
+			expect(xs[1]).toBeCloseTo(50, 5);
+			expect(xs[2]).toBeCloseTo(75, 5);
+		});
+
+		it('treeCount=1 produces x=50, y=0, scale=1.0', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 1 });
+			expect(result).toHaveLength(1);
+			expect(result[0].x).toBeCloseTo(50, 5);
+			expect(result[0].y).toBe(0);
+			expect(result[0].scale).toBeCloseTo(1.0, 5);
+		});
+
+		it('treeCount=10 produces all y=0, scale=1.0, equidistant x', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 10 });
+			expect(result).toHaveLength(10);
+			const xs = result.map((t) => t.x).sort((a, b) => a - b);
+			for (let i = 0; i < 10; i++) {
+				expect(result[i].y).toBe(0);
+				expect(result[i].scale).toBeCloseTo(1.0, 5);
+			}
+			for (let i = 0; i < 10; i++) {
+				const expectedX = ((i + 1) * 100) / 11;
+				expect(xs[i]).toBeCloseTo(expectedX, 5);
+			}
+		});
+
+		it('assigns only non-custom shapes', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 10 });
+			for (const tree of result) {
+				expect(tree.shape).not.toBe('custom');
+			}
+		});
+
+		it('produces unique seeds per tree', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 10 });
+			const seeds = result.map((t) => t.seed);
+			expect(new Set(seeds).size).toBe(seeds.length);
+		});
+	});
+
+	describe('Group 2: Back row overflow (>10 trees)', () => {
+		it('treeCount=11 produces 10 front (y=0, scale=1.0) + 1 back (y>0, scale in [0.65, 0.8])', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 11 });
+			expect(result).toHaveLength(11);
+			const front = result.filter((t) => t.y === 0);
+			const back = result.filter((t) => t.y > 0);
+			expect(front).toHaveLength(10);
+			expect(back).toHaveLength(1);
+			for (const t of front) {
+				expect(t.scale).toBeCloseTo(1.0, 5);
+			}
+			for (const t of back) {
+				expect(t.scale).toBeGreaterThanOrEqual(BACK_SCALE_MIN);
+				expect(t.scale).toBeLessThanOrEqual(BACK_SCALE_MAX);
+			}
+		});
+
+		it('treeCount=15 produces 10 front + 5 back', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 15 });
+			const front = result.filter((t) => t.y === 0);
+			const back = result.filter((t) => t.y > 0);
+			expect(front).toHaveLength(10);
+			expect(back).toHaveLength(5);
+		});
+
+		it('back row x positions within [0, 100]', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 20 });
+			const back = result.filter((t) => t.y > 0);
+			for (const t of back) {
+				expect(t.x).toBeGreaterThanOrEqual(0);
+				expect(t.x).toBeLessThanOrEqual(100);
+			}
+		});
+
+		it('back row y values within effective depth range', () => {
+			const depthSpread = 0;
+			const effectiveDepth = Math.max(depthSpread, BACK_DEPTH_FALLBACK);
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 15, depthSpread: 0 });
+			const back = result.filter((t) => t.y > 0);
+			for (const t of back) {
+				expect(t.y).toBeGreaterThanOrEqual(effectiveDepth * 0.3);
+				expect(t.y).toBeLessThanOrEqual(effectiveDepth);
+			}
+		});
+
+		it('back row respects depthSpread when larger than fallback', () => {
+			const depthSpread = 50;
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 15, depthSpread });
+			const back = result.filter((t) => t.y > 0);
+			for (const t of back) {
+				expect(t.y).toBeGreaterThanOrEqual(depthSpread * 0.3);
+				expect(t.y).toBeLessThanOrEqual(depthSpread);
 			}
 		});
 	});
 
-	describe('depthSpread=100 (full depth)', () => {
-		const deep = generateSceneLayout({
-			...BASE_CONFIG,
-			treeCount: 50,
-			depthSpread: 100,
+	describe('Group 3: Priority field', () => {
+		it('priority=0 forces tree to back row even when front has capacity', () => {
+			const config: SceneConfig = {
+				...BASE_CONFIG,
+				treeCount: 5,
+				trees: [
+					{ priority: 0 },
+					{ priority: 1 },
+					{ priority: 1 },
+					{ priority: 1 },
+					{ priority: 1 },
+				],
+			};
+			const result = generateSceneLayout(config);
+			const front = result.filter((t) => t.y === 0);
+			const back = result.filter((t) => t.y > 0);
+			expect(front).toHaveLength(4);
+			expect(back).toHaveLength(1);
 		});
 
-		it('has back trees scaled down toward 0.65', () => {
-			const minScale = Math.min(...deep.map((t) => t.scale));
-			expect(minScale).toBeGreaterThanOrEqual(0.64);
-			expect(minScale).toBeLessThanOrEqual(0.75);
+		it('priority=1 or undefined defaults to front row', () => {
+			const config: SceneConfig = {
+				...BASE_CONFIG,
+				treeCount: 3,
+				trees: [{ priority: 1 }, {}, { priority: 1 }],
+			};
+			const result = generateSceneLayout(config);
+			for (const t of result) {
+				expect(t.y).toBe(0);
+				expect(t.scale).toBeCloseTo(1.0, 5);
+			}
 		});
 
-		it('has front trees scaled near 1.0', () => {
-			const maxScale = Math.max(...deep.map((t) => t.scale));
-			expect(maxScale).toBeGreaterThanOrEqual(0.95);
-			expect(maxScale).toBeLessThanOrEqual(1.0);
-		});
-
-		it('scales correlate with y — higher y means larger scale', () => {
-			// Compare first (back) and last (front) after sort
-			const back = deep[0];
-			const front = deep[deep.length - 1];
-			expect(front.scale).toBeGreaterThan(back.scale);
+		it('mixed: 8 trees with 3 having priority=0 produces 5 front, 3 back', () => {
+			const config: SceneConfig = {
+				...BASE_CONFIG,
+				treeCount: 8,
+				trees: [
+					{ priority: 0 },
+					{ priority: 1 },
+					{ priority: 0 },
+					{ priority: 1 },
+					{ priority: 1 },
+					{ priority: 0 },
+					{ priority: 1 },
+					{ priority: 1 },
+				],
+			};
+			const result = generateSceneLayout(config);
+			const front = result.filter((t) => t.y === 0);
+			const back = result.filter((t) => t.y > 0);
+			expect(front).toHaveLength(5);
+			expect(back).toHaveLength(3);
 		});
 	});
 
-	it('produces different layouts for different seeds', () => {
-		const a = generateSceneLayout({ ...BASE_CONFIG, baseSeed: 1 });
-		const b = generateSceneLayout({ ...BASE_CONFIG, baseSeed: 2 });
-		const aXs = a.map((t) => t.x);
-		const bXs = b.map((t) => t.x);
-		expect(aXs).not.toEqual(bXs);
+	describe('Group 4: blockedBy field', () => {
+		it('tree with blockedBy has y >= blocker y', () => {
+			const config: SceneConfig = {
+				...BASE_CONFIG,
+				treeCount: 3,
+				depthSpread: 50,
+				trees: [
+					{ id: 'blocker', priority: 0 },
+					{ id: 'blocked', priority: 0, blockedBy: 'blocker' },
+					{ priority: 1 },
+				],
+			};
+			const result = generateSceneLayout(config);
+			const blocker = result.find((t) => t.id === 'blocker');
+			const blocked = result.find((t) => t.id === 'blocked');
+			expect(blocker).toBeDefined();
+			expect(blocked).toBeDefined();
+			expect(blocked!.y).toBeGreaterThanOrEqual(blocker!.y);
+		});
+
+		it('nonexistent blockedBy ID is ignored, tree positioned normally', () => {
+			const config: SceneConfig = {
+				...BASE_CONFIG,
+				treeCount: 2,
+				trees: [{ id: 'a', blockedBy: 'nonexistent' }, { id: 'b' }],
+			};
+			const result = generateSceneLayout(config);
+			expect(result).toHaveLength(2);
+			// No crash, both placed
+			for (const t of result) {
+				expect(t.x).toBeGreaterThanOrEqual(0);
+				expect(t.x).toBeLessThanOrEqual(100);
+			}
+		});
+
+		it('circular blockedBy does not cause infinite loop, both trees still placed', () => {
+			const config: SceneConfig = {
+				...BASE_CONFIG,
+				treeCount: 2,
+				depthSpread: 50,
+				trees: [
+					{ id: 'a', priority: 0, blockedBy: 'b' },
+					{ id: 'b', priority: 0, blockedBy: 'a' },
+				],
+			};
+			const result = generateSceneLayout(config);
+			expect(result).toHaveLength(2);
+			expect(result.find((t) => t.id === 'a')).toBeDefined();
+			expect(result.find((t) => t.id === 'b')).toBeDefined();
+		});
+	});
+
+	describe('Group 5: Determinism & sorting', () => {
+		it('same config + seed produces identical output', () => {
+			const config: SceneConfig = { ...BASE_CONFIG, treeCount: 15, depthSpread: 50 };
+			const a = generateSceneLayout(config);
+			const b = generateSceneLayout(config);
+			expect(a).toEqual(b);
+		});
+
+		it('different seeds produce different layouts', () => {
+			const a = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 15,
+				depthSpread: 50,
+				baseSeed: 1,
+			});
+			const b = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 15,
+				depthSpread: 50,
+				baseSeed: 2,
+			});
+			const aPositions = a.map((t) => ({ x: t.x, y: t.y }));
+			const bPositions = b.map((t) => ({ x: t.x, y: t.y }));
+			expect(aPositions).not.toEqual(bPositions);
+		});
+
+		it('output sorted descending by y (back-to-front for painter algorithm)', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 20, depthSpread: 50 });
+			for (let i = 1; i < result.length; i++) {
+				expect(result[i].y).toBeLessThanOrEqual(result[i - 1].y);
+			}
+		});
+	});
+
+	describe('Group 6: Backward compatibility', () => {
+		it('config without trees field still works, all front row', () => {
+			const config: SceneConfig = { treeCount: 5, depthSpread: 0, baseSeed: 42 };
+			const result = generateSceneLayout(config);
+			expect(result).toHaveLength(5);
+			for (const t of result) {
+				expect(t.y).toBe(0);
+				expect(t.scale).toBeCloseTo(1.0, 5);
+			}
+		});
+	});
+
+	describe('Group 7: ID passthrough', () => {
+		it('when trees have id, corresponding placement has id', () => {
+			const config: SceneConfig = {
+				...BASE_CONFIG,
+				treeCount: 3,
+				trees: [{ id: 'tree-a' }, { id: 'tree-b' }, { id: 'tree-c' }],
+			};
+			const result = generateSceneLayout(config);
+			const ids = result.map((t) => t.id).sort((a, b) => (a ?? '').localeCompare(b ?? ''));
+			expect(ids).toEqual(['tree-a', 'tree-b', 'tree-c']);
+		});
 	});
 });

--- a/src/lib/scene/scene_layout.ts
+++ b/src/lib/scene/scene_layout.ts
@@ -1,51 +1,179 @@
-import { createPrng } from '$lib/trees/prng.js';
-import { SCENE_SHAPES, type SceneConfig, type SceneTreePlacement } from './scene_config.js';
-
-/** Minimum scale for the farthest-back trees. */
-const BACK_SCALE = 0.65;
+import { createPrng, randomInRange } from '$lib/trees/prng.js';
+import {
+	SCENE_SHAPES,
+	FRONT_ROW_CAPACITY,
+	BACK_SCALE_MIN,
+	BACK_SCALE_MAX,
+	BACK_DEPTH_FALLBACK,
+	type SceneConfig,
+	type SceneTreeInput,
+	type SceneTreePlacement,
+} from './scene_config.js';
 
 /**
  * Generate deterministic scene tree placements from a config.
  *
- * Returns an array sorted ascending by y (back-to-front) for painter's
- * algorithm rendering — DOM/SVG order matches visual depth.
+ * Trees are partitioned into front row (equidistant at y=0, scale=1) and
+ * back row (semi-random positions/scale). Priority and blockedBy fields
+ * control placement. Output sorted descending by y (back-to-front) for
+ * painter's algorithm — back trees first in DOM, front trees last.
  */
 export function generateSceneLayout(config: SceneConfig): SceneTreePlacement[] {
 	const { treeCount, depthSpread, baseSeed } = config;
+	if (treeCount === 0) {
+		return [];
+	}
+
 	const rng = createPrng(baseSeed);
 
-	const placements: SceneTreePlacement[] = [];
+	// Build input descriptors — use config.trees if provided, else default foreground
+	const inputs: SceneTreeInput[] = Array.from(
+		{ length: treeCount },
+		(_, i) => config.trees?.[i] ?? {},
+	);
 
-	for (let i = 0; i < treeCount; i++) {
+	// Assign shapes and seeds upfront
+	const shapeSeeds = inputs.map((_, i) => {
 		const shape = SCENE_SHAPES[Math.floor(rng() * SCENE_SHAPES.length)];
 		const seed = baseSeed + i * 1000 + Math.floor(rng() * 999);
-		const x = rng() * 100;
-		const y = depthSpread === 0 ? 0 : rng() * depthSpread;
+		return { shape, seed };
+	});
 
-		placements.push({ shape, seed, x, y, scale: 0 }); // scale computed after
-	}
+	// Partition into front and back indices
+	const frontIndices: number[] = [];
+	const backIndices: number[] = [];
 
-	// Derive scale from y relative to depth range
-	if (depthSpread === 0) {
-		// Flat — all trees at front, full scale
-		for (let i = 0; i < placements.length; i++) {
-			placements[i] = { ...placements[i], scale: 1 };
-		}
-	} else {
-		const maxY = Math.max(...placements.map((p) => p.y));
-		const minY = Math.min(...placements.map((p) => p.y));
-		const range = maxY - minY;
-
-		for (let i = 0; i < placements.length; i++) {
-			// normalizedDepth 0 = back (min y), 1 = front (max y)
-			const normalizedDepth = range === 0 ? 1 : (placements[i].y - minY) / range;
-			const scale = BACK_SCALE + normalizedDepth * (1 - BACK_SCALE);
-			placements[i] = { ...placements[i], scale };
+	for (let i = 0; i < inputs.length; i++) {
+		const input = inputs[i];
+		if (input.priority === 0) {
+			backIndices.push(i);
+		} else if (frontIndices.length < FRONT_ROW_CAPACITY) {
+			frontIndices.push(i);
+		} else {
+			backIndices.push(i);
 		}
 	}
 
-	// Sort ascending by y — back trees first in DOM = painted behind front trees
-	placements.sort((a, b) => a.y - b.y);
+	const effectiveDepth = Math.max(depthSpread, BACK_DEPTH_FALLBACK);
 
-	return placements;
+	const buildPlacement = (
+		idx: number,
+		x: number,
+		y: number,
+		scale: number,
+	): SceneTreePlacement => ({
+		id: inputs[idx].id,
+		shape: shapeSeeds[idx].shape,
+		seed: shapeSeeds[idx].seed,
+		x,
+		y,
+		scale,
+	});
+
+	// Position front row: equidistant, y=0, scale=1.0
+	const frontCount = frontIndices.length;
+	const placements = new Map<number, SceneTreePlacement>();
+
+	for (let slot = 0; slot < frontCount; slot++) {
+		const idx = frontIndices[slot];
+		const x = ((slot + 1) * 100) / (frontCount + 1);
+		placements.set(idx, buildPlacement(idx, x, 0, 1.0));
+	}
+
+	// Position back row: semi-random within depth range
+	for (const idx of backIndices) {
+		const x = randomInRange(rng, 5, 95);
+		const y = randomInRange(rng, effectiveDepth * 0.3, effectiveDepth);
+		const scale = randomInRange(rng, BACK_SCALE_MIN, BACK_SCALE_MAX);
+		placements.set(idx, buildPlacement(idx, x, y, scale));
+	}
+
+	// Enforce blockedBy constraints (blocked tree must have y >= blocker's y)
+	enforceBlockedBy(inputs, placements);
+
+	// Collect, sort descending by y (back-to-front for painter's algorithm)
+	// Higher y = further back → first in DOM → painted behind front trees
+	const result = Array.from(placements.values());
+	result.sort((a, b) => b.y - a.y);
+	return result;
+}
+
+/**
+ * Enforce blockedBy: if tree A has blockedBy "X", ensure A.y >= X.y.
+ * Uses fixpoint iteration to handle transitive chains (A→B→C).
+ * Detects cycles and skips them. Ignores nonexistent IDs.
+ */
+function enforceBlockedBy(
+	inputs: SceneTreeInput[],
+	placements: Map<number, SceneTreePlacement>,
+): void {
+	// Build id-to-index map
+	const idToIndex = new Map<string, number>();
+	for (let i = 0; i < inputs.length; i++) {
+		const id = inputs[i].id;
+		if (id !== undefined) {
+			idToIndex.set(id, i);
+		}
+	}
+
+	// Fixpoint: iterate until no changes (handles transitive chains)
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (let i = 0; i < inputs.length; i++) {
+			const blockedById = inputs[i].blockedBy;
+			if (blockedById === undefined) {
+				continue;
+			}
+
+			const blockerIndex = idToIndex.get(blockedById);
+			if (blockerIndex === undefined) {
+				continue;
+			}
+
+			if (hasCycle(inputs, idToIndex, i)) {
+				continue;
+			}
+
+			const blockerPlacement = placements.get(blockerIndex);
+			const currentPlacement = placements.get(i);
+			if (!blockerPlacement || !currentPlacement) {
+				continue;
+			}
+
+			if (currentPlacement.y < blockerPlacement.y) {
+				placements.set(i, { ...currentPlacement, y: blockerPlacement.y });
+				changed = true;
+			}
+		}
+	}
+}
+
+/** Check if following the blockedBy chain from startIndex leads back to itself. */
+function hasCycle(
+	inputs: SceneTreeInput[],
+	idToIndex: Map<string, number>,
+	startIndex: number,
+): boolean {
+	const visited = new Set<number>();
+	visited.add(startIndex);
+
+	let currentIndex = startIndex;
+	while (true) {
+		const blockedById = inputs[currentIndex].blockedBy;
+		if (blockedById === undefined) {
+			return false;
+		}
+
+		const nextIndex = idToIndex.get(blockedById);
+		if (nextIndex === undefined) {
+			return false;
+		}
+
+		if (visited.has(nextIndex)) {
+			return true;
+		}
+		visited.add(nextIndex);
+		currentIndex = nextIndex;
+	}
 }


### PR DESCRIPTION
## Description
- Rewrites `generateSceneLayout()` from random positioning to priority-based layout
- Front row (up to 10 trees): equidistant spacing at y=0, scale=1.0
- Back row (overflow): semi-random placement, reduced scale (0.65–0.8x), elevated y-offset
- Adds optional `priority` (0=background, 1=foreground) and `blockedBy` fields for explicit row/depth control
- Cycle-safe fixpoint `blockedBy` enforcement for transitive chains
- Descending y-sort for correct painter's algorithm (back-to-front DOM order)

## Resolves
Closes #87

## Testing
- [x] 22 new tests across 7 groups: front row basics, back row overflow, priority field, blockedBy, determinism, backward compat, ID passthrough
- [x] All 2150 tests pass
- [x] `check:all` clean (format + lint + typecheck + stylelint + knip)