### PR TITLE
#83 fix(animation): sway delay, hierarchical branches, falling leaves

### DIFF
--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -8,11 +8,13 @@
 		type TreeConfig,
 		type TreeAnchors,
 		type TreeShape,
+		type BranchGeometry,
 	} from '$lib/trees/types.js';
 	import {
 		computeAnimationDelay,
 		computeBranchDuration,
 		computeBranchDelay,
+		computeCanopyBottomY,
 	} from '$lib/trees/animation.js';
 	import TreeTool from '$lib/trees/TreeTool.svelte';
 	import {
@@ -23,6 +25,7 @@
 	import { FRUIT_SVG_COMPONENTS } from '$lib/trees/shapes/fruit_geometry.js';
 	import { FLOWER_SVG_COMPONENTS } from '$lib/trees/shapes/flower_geometry.js';
 	import { createPrng, randomInRange } from '$lib/trees/prng.js';
+	import { SvelteMap } from 'svelte/reactivity';
 
 	interface Props {
 		config?: TreeConfig;
@@ -73,6 +76,25 @@
 		geometry.branchGroups.map((_, i) => computeBranchDelay(config.seed, i)),
 	);
 
+	const rootBranches = $derived(
+		geometry.branchGroups
+			.map((group, index) => ({ group, index }))
+			.filter(({ group }) => group.parentIndex === null),
+	);
+
+	const childBranchesByParent = $derived.by(() => {
+		const map = new SvelteMap<number, { group: BranchGeometry; index: number }[]>();
+		for (let i = 0; i < geometry.branchGroups.length; i++) {
+			const group = geometry.branchGroups[i]!;
+			if (group.parentIndex !== null) {
+				const children = map.get(group.parentIndex) ?? [];
+				children.push({ group, index: i });
+				map.set(group.parentIndex, children);
+			}
+		}
+		return map;
+	});
+
 	const fruitComponent = $derived(
 		config.fruitType !== FRUIT_TYPES.none ? FRUIT_SVG_COMPONENTS[config.fruitType] : null,
 	);
@@ -102,7 +124,7 @@
 		const bounds = geometry.anchors;
 		const minX = bounds.crownCenter.x - 30;
 		const maxX = bounds.crownCenter.x + 30;
-		const startY = bounds.crownTop.y;
+		const startY = computeCanopyBottomY(geometry.canopyBlobs);
 		const colors = ['#E8A028', '#C47020', '#8B2010', '#A05020', '#D08030'];
 		for (let i = 0; i < count; i++) {
 			leaves.push({
@@ -160,38 +182,45 @@
 			</g>
 		{/if}
 
+		{#snippet branchGroupSnippet(branchGroup: BranchGeometry, branchIndex: number)}
+			<g
+				class="branch-group"
+				class:animate-branch-sway={animateBranches}
+				style="--branch-duration: {branchDurations[
+					branchIndex
+				]}s; --branch-delay: {branchDelays[branchIndex]}s; --branch-origin-x: {branchGroup
+					.origin.x}px; --branch-origin-y: {branchGroup.origin.y}px;"
+			>
+				{#each branchGroup.quads as quad (quad)}
+					<polygon
+						points="{quad.points[0].x},{quad.points[0].y} {quad.points[1].x},{quad
+							.points[1].y} {quad.points[2].x},{quad.points[2].y} {quad.points[3]
+							.x},{quad.points[3].y}"
+						fill={quad.color}
+						stroke={quad.color}
+						stroke-width="0.5"
+					/>
+				{/each}
+				{#each branchGroup.junctionFills as fill (fill)}
+					<polygon
+						points="{fill.points[0].x},{fill.points[0].y} {fill.points[1].x},{fill
+							.points[1].y} {fill.points[2].x},{fill.points[2].y} {fill.points[3]
+							.x},{fill.points[3].y}"
+						fill={fill.color}
+						stroke={fill.color}
+						stroke-width="0.5"
+					/>
+				{/each}
+				{#each childBranchesByParent.get(branchIndex) ?? [] as { group: child, index: childIndex } (childIndex)}
+					{@render branchGroupSnippet(child, childIndex)}
+				{/each}
+			</g>
+		{/snippet}
+
 		{#if showBranches}
 			<g class="branches">
-				{#each geometry.branchGroups as group, groupIndex (group)}
-					<g
-						class="branch-group"
-						class:animate-branch-sway={animateBranches}
-						style="--branch-duration: {branchDurations[
-							groupIndex
-						]}s; --branch-delay: {branchDelays[groupIndex]}s; --branch-origin-x: {group
-							.origin.x}px; --branch-origin-y: {group.origin.y}px;"
-					>
-						{#each group.quads as quad (quad)}
-							<polygon
-								points="{quad.points[0].x},{quad.points[0].y} {quad.points[1]
-									.x},{quad.points[1].y} {quad.points[2].x},{quad.points[2]
-									.y} {quad.points[3].x},{quad.points[3].y}"
-								fill={quad.color}
-								stroke={quad.color}
-								stroke-width="0.5"
-							/>
-						{/each}
-						{#each group.junctionFills as fill (fill)}
-							<polygon
-								points="{fill.points[0].x},{fill.points[0].y} {fill.points[1]
-									.x},{fill.points[1].y} {fill.points[2].x},{fill.points[2]
-									.y} {fill.points[3].x},{fill.points[3].y}"
-								fill={fill.color}
-								stroke={fill.color}
-								stroke-width="0.5"
-							/>
-						{/each}
-					</g>
+				{#each rootBranches as { group, index: groupIndex } (groupIndex)}
+					{@render branchGroupSnippet(group, groupIndex)}
 				{/each}
 			</g>
 		{/if}

--- a/src/lib/trees/animation.test.ts
+++ b/src/lib/trees/animation.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { computeAnimationDelay, computeBranchDuration, computeBranchDelay } from './animation.js';
+import {
+	computeAnimationDelay,
+	computeBranchDuration,
+	computeBranchDelay,
+	computeCanopyBottomY,
+} from './animation.js';
+import type { BlobGeometry } from './types/core.js';
 
 describe('Animation helpers', () => {
 	describe('computeAnimationDelay', () => {
-		it('returns a value in [0, 3]', () => {
+		it('returns a value in [0, 0.5]', () => {
 			const delay = computeAnimationDelay(42);
 			expect(delay).toBeGreaterThanOrEqual(0);
-			expect(delay).toBeLessThanOrEqual(3);
+			expect(delay).toBeLessThanOrEqual(0.5);
 		});
 
 		it('is deterministic (same seed same result)', () => {
@@ -51,6 +57,48 @@ describe('Animation helpers', () => {
 
 		it('different branch indices produce different values', () => {
 			expect(computeBranchDelay(42, 0)).not.toBe(computeBranchDelay(42, 1));
+		});
+	});
+
+	describe('computeCanopyBottomY', () => {
+		it('returns the max Y from all blob triangle points', () => {
+			const blobs: BlobGeometry[] = [
+				{
+					triangles: [
+						{
+							points: [
+								{ x: 0, y: 10 },
+								{ x: 5, y: 20 },
+								{ x: 10, y: 15 },
+							],
+							color: '#000',
+							group: 'canopy',
+						},
+					],
+					center: { x: 5, y: 15 },
+					depth: 0,
+				},
+				{
+					triangles: [
+						{
+							points: [
+								{ x: 0, y: 5 },
+								{ x: 5, y: 30 },
+								{ x: 10, y: 25 },
+							],
+							color: '#000',
+							group: 'canopy',
+						},
+					],
+					center: { x: 5, y: 20 },
+					depth: 0,
+				},
+			];
+			expect(computeCanopyBottomY(blobs)).toBe(30);
+		});
+
+		it('returns 0 for empty blobs', () => {
+			expect(computeCanopyBottomY([])).toBe(0);
 		});
 	});
 });

--- a/src/lib/trees/animation.ts
+++ b/src/lib/trees/animation.ts
@@ -1,9 +1,10 @@
 import { createPrng, randomInRange } from './prng.js';
+import type { BlobGeometry } from './types/core.js';
 
 /** Deterministic animation delay for per-tree canopy sway phase offset. */
 export function computeAnimationDelay(seed: number): number {
 	const rng = createPrng(seed);
-	return randomInRange(rng, 0, 3);
+	return randomInRange(rng, 0, 0.5);
 }
 
 /** Deterministic branch sway duration that varies per branch. */
@@ -16,4 +17,19 @@ export function computeBranchDuration(seed: number, branchIndex: number): number
 export function computeBranchDelay(seed: number, branchIndex: number): number {
 	const rng = createPrng(seed + branchIndex * 2000);
 	return randomInRange(rng, 0, 2);
+}
+
+/** Returns the maximum Y value across all triangle points in canopy blobs (bottom edge). */
+export function computeCanopyBottomY(canopyBlobs: readonly BlobGeometry[]): number {
+	let maxY = -Infinity;
+	for (const blob of canopyBlobs) {
+		for (const tri of blob.triangles) {
+			for (const p of tri.points) {
+				if (p.y > maxY) {
+					maxY = p.y;
+				}
+			}
+		}
+	}
+	return maxY === -Infinity ? 0 : maxY;
 }

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -1896,7 +1896,7 @@ describe('VQ-3: branchDepth config', () => {
 		// while sub-sub-branches use SUB_BRANCH_WIDTH_MIN (3.5) at scale 0.5 = 1.75.
 		// At least one branch should be thinner than the trunk-origin minimum.
 		const trunkMinWidthAtScale1 = 7; // TRUNK_BRANCH_WIDTH_START_MIN
-		const allWidths = branches.map((b) => b.widthStart);
+		const allWidths = branches.map((b) => b.segment.widthStart);
 		const minOverallWidth = Math.min(...allWidths);
 		expect(minOverallWidth).toBeLessThan(trunkMinWidthAtScale1);
 	});
@@ -1909,6 +1909,97 @@ describe('VQ-3: branchDepth config', () => {
 		for (let i = 0; i < geo1.branchGroups.length; i++) {
 			expect(geo1.branchGroups[i]!.origin).toEqual(geo2.branchGroups[i]!.origin);
 			expect(geo1.branchGroups[i]!.quads).toEqual(geo2.branchGroups[i]!.quads);
+		}
+	});
+});
+
+// ============================================================================
+// #83: Hierarchical branch nesting — parentIndex on BranchGeometry
+// ============================================================================
+
+describe('#83: hierarchical branch parentIndex', () => {
+	it('BranchGeometry includes parentIndex property', () => {
+		const config = makeConfig({
+			shape: TREE_SHAPES.oak,
+			branchDepth: 2,
+			branchesLevel1Range: [3, 5],
+			branchesLevel2Range: [1, 2],
+			seed: 42,
+		});
+		const geometry = generateTree(config);
+		for (const group of geometry.branchGroups) {
+			expect(group).toHaveProperty('parentIndex');
+		}
+	});
+
+	it('depth-2 branches have non-null parentIndex', () => {
+		const config = makeConfig({
+			shape: TREE_SHAPES.oak,
+			branchDepth: 2,
+			branchesLevel1Range: [3, 5],
+			branchesLevel2Range: [1, 2],
+			seed: 42,
+		});
+		const geometry = generateTree(config);
+		const hasParent = geometry.branchGroups.some((g) => g.parentIndex !== null);
+		expect(hasParent).toBe(true);
+	});
+
+	it('depth-2 branches reference valid parent indices with correct depth', () => {
+		const config = makeConfig({
+			shape: TREE_SHAPES.oak,
+			branchDepth: 2,
+			branchesLevel1Range: [3, 5],
+			branchesLevel2Range: [1, 2],
+			seed: 42,
+		});
+		const geometry = generateTree(config);
+		for (const group of geometry.branchGroups) {
+			if (group.parentIndex !== null) {
+				expect(group.parentIndex).toBeGreaterThanOrEqual(0);
+				expect(group.parentIndex).toBeLessThan(geometry.branchGroups.length);
+				expect(geometry.branchGroups[group.parentIndex]!.depth).toBe(group.depth - 1);
+			}
+		}
+	});
+
+	it('depth-1 branches have parentIndex null', () => {
+		const config = makeConfig({
+			shape: TREE_SHAPES.oak,
+			branchDepth: 2,
+			branchesLevel1Range: [3, 5],
+			branchesLevel2Range: [1, 2],
+			seed: 42,
+		});
+		const geometry = generateTree(config);
+		for (const group of geometry.branchGroups) {
+			if (group.depth === 1) {
+				expect(group.parentIndex).toBeNull();
+			}
+		}
+	});
+
+	it('generateBranches returns GeneratedBranch[] with depth and parentIndex', () => {
+		const blobs: Blob[] = [{ cx: 100, cy: 100, rx: 60, ry: 60, boundary: 'circle' }];
+		const trunkJunctions = [
+			{ x: 100, y: 260 },
+			{ x: 100, y: 80 },
+		];
+		const config = makeConfig({
+			branchesLevel1Range: [3, 3],
+			branchesLevel2Range: [1, 2],
+			branchDepth: 2,
+			seed: 42,
+		});
+		const rng = createPrng(42 + 7777);
+		const branches = generateBranches(rng, 80, 260, 5, config, trunkJunctions, blobs);
+		expect(branches.length).toBeGreaterThan(0);
+		for (const b of branches) {
+			expect(b).toHaveProperty('segment');
+			expect(b).toHaveProperty('depth');
+			expect(b).toHaveProperty('parentIndex');
+			expect(b.segment).toHaveProperty('x1');
+			expect(b.segment).toHaveProperty('y1');
 		}
 	});
 });

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -38,6 +38,7 @@ import {
 	TRUNK_ENTRY_MIN_PX,
 	type Blob,
 	type BranchSegment,
+	type GeneratedBranch,
 } from './shapes.js';
 import { BOUNDARIES, BOUNDARY_KINDS, smoothAcuteBoundaryAngles } from './boundaries.js';
 import { computeCanopyColor, computeTwoToneColors, isLeftSideLight } from './lighting.js';
@@ -262,6 +263,7 @@ function generateBranchQuadGroup(
 	branch: BranchSegment,
 	config: TreeConfig,
 	depth: number,
+	parentIndex: number | null = null,
 ): BranchGeometry {
 	const { lightColor, darkColor } = computeTwoToneColors(config);
 
@@ -269,7 +271,13 @@ function generateBranchQuadGroup(
 	const dirY = branch.y2 - branch.y1;
 	const length = Math.sqrt(dirX * dirX + dirY * dirY);
 	if (length === 0) {
-		return { quads: [], junctionFills: [], origin: { x: branch.x1, y: branch.y1 }, depth };
+		return {
+			quads: [],
+			junctionFills: [],
+			origin: { x: branch.x1, y: branch.y1 },
+			depth,
+			parentIndex,
+		};
 	}
 
 	// Unit direction and perpendicular
@@ -320,14 +328,17 @@ function generateBranchQuadGroup(
 		junctionFills: [],
 		origin: { x: branch.x1, y: branch.y1 },
 		depth,
+		parentIndex,
 	};
 }
 
 function generateAllBranchQuads(
-	branches: readonly BranchSegment[],
+	branches: readonly GeneratedBranch[],
 	config: TreeConfig,
 ): BranchGeometry[] {
-	return branches.map((branch) => generateBranchQuadGroup(branch, config, 1));
+	return branches.map((branch) =>
+		generateBranchQuadGroup(branch.segment, config, branch.depth, branch.parentIndex),
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -630,7 +641,7 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 	const trunkTop = trunkJunctions[trunkJunctions.length - 1]!.y;
 
 	// Branch generation: all shapes (including maple) use the generic system (BR-13)
-	let branches: BranchSegment[];
+	let branches: GeneratedBranch[];
 	if (isTiered) {
 		branches = [];
 	} else {
@@ -645,7 +656,17 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 		);
 	}
 
-	const extraBranches = isTiered ? [] : validateNoFloatingBlobs(blobs, branches);
+	const extraSegments = isTiered
+		? []
+		: validateNoFloatingBlobs(
+				blobs,
+				branches.map((b) => b.segment),
+			);
+	const extraBranches: GeneratedBranch[] = extraSegments.map((seg) => ({
+		segment: seg,
+		depth: 1,
+		parentIndex: null,
+	}));
 	const allBranches = [...branches, ...extraBranches];
 
 	// Generate trunk quads (BR-1: stacked trapezoids with centerline)
@@ -662,7 +683,7 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 	const anchors = computeAnchors(
 		trunkJunctions,
 		canopyBounds,
-		allBranches,
+		allBranches.map((b) => b.segment),
 		canopyBlobs,
 		blobs,
 		tiers,

--- a/src/lib/trees/oak_prd_generator.ts
+++ b/src/lib/trees/oak_prd_generator.ts
@@ -50,6 +50,7 @@ function scaleBranchGeometry(branch: BranchGeometry): BranchGeometry {
 		junctionFills: branch.junctionFills.map(scaleQuad),
 		origin: scalePoint(branch.origin),
 		depth: branch.depth,
+		parentIndex: branch.parentIndex,
 	};
 }
 

--- a/src/lib/trees/shapes.test.ts
+++ b/src/lib/trees/shapes.test.ts
@@ -450,7 +450,7 @@ describe('generateBranches — visibility & crossing invariants', () => {
 		);
 		expect(branches.length).toBeGreaterThan(0);
 		for (const b of branches) {
-			const visible = computeVisibleBranchLength(b, blobs, []);
+			const visible = computeVisibleBranchLength(b.segment, blobs, []);
 			expect(visible).toBeGreaterThanOrEqual(5);
 		}
 	});
@@ -497,12 +497,12 @@ describe('generateBranches — visibility & crossing invariants', () => {
 			// A branch either stays on one side of the trunk axis or ends on the
 			// axis. Use the midpoint as the reference side (trunk-origin branches
 			// have startX === centerX so the start alone cannot tell us).
-			const midX = (b.x1 + b.x2) / 2;
-			const midY = (b.y1 + b.y2) / 2;
+			const midX = (b.segment.x1 + b.segment.x2) / 2;
+			const midY = (b.segment.y1 + b.segment.y2) / 2;
 			const centerAtMid = sampleTrunkCenterX(trunkJunctions, midY);
-			const centerAtEnd = sampleTrunkCenterX(trunkJunctions, b.y2);
+			const centerAtEnd = sampleTrunkCenterX(trunkJunctions, b.segment.y2);
 			const midSide = Math.sign(midX - centerAtMid);
-			const endSide = Math.sign(b.x2 - centerAtEnd);
+			const endSide = Math.sign(b.segment.x2 - centerAtEnd);
 			if (midSide !== 0) {
 				expect(endSide === 0 || endSide === midSide).toBe(true);
 			} else {
@@ -580,8 +580,8 @@ describe('generateBranches — visibility & crossing invariants', () => {
 			longInputs.blobs,
 		);
 		const branchLen = (b: BranchSegment): number => Math.hypot(b.x2 - b.x1, b.y2 - b.y1);
-		const maxShort = Math.max(...shortBranches.map(branchLen));
-		const maxLong = Math.max(...longBranches.map(branchLen));
+		const maxShort = Math.max(...shortBranches.map((b) => branchLen(b.segment)));
+		const maxLong = Math.max(...longBranches.map((b) => branchLen(b.segment)));
 		expect(maxLong).toBeGreaterThan(maxShort * 1.2);
 	});
 

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -32,7 +32,7 @@ export {
 	resolveBranchLengthRange,
 } from './shapes/geometry.js';
 
-export { generateBranches } from './shapes/branch_generation.js';
+export { generateBranches, type GeneratedBranch } from './shapes/branch_generation.js';
 
 export {
 	getShapeDefinition,

--- a/src/lib/trees/shapes/branch_generation.ts
+++ b/src/lib/trees/shapes/branch_generation.ts
@@ -40,10 +40,10 @@ const TRUNK_BRANCH_BASE_MIN = 40;
 const TRUNK_BRANCH_BASE_MAX = 80;
 
 // ---------------------------------------------------------------------------
-// Internal types
+// Public enriched branch type
 // ---------------------------------------------------------------------------
 
-interface InternalBranch {
+export interface GeneratedBranch {
 	readonly segment: BranchSegment;
 	readonly depth: number;
 	readonly parentIndex: number | null;
@@ -156,7 +156,7 @@ function sampleBranchCountForLevel(rng: () => number, config: TreeConfig, depth:
  */
 function overlapsAnySameDepth(
 	candidate: BranchSegment,
-	branches: readonly InternalBranch[],
+	branches: readonly GeneratedBranch[],
 	depth: number,
 	excludeParentSegment?: BranchSegment,
 ): boolean {
@@ -178,7 +178,7 @@ function overlapsAnySameDepth(
 // Branch generation — trunk-origin (depth 1)
 // ---------------------------------------------------------------------------
 
-function generateTrunkBranches(ctx: BranchContext, branches: InternalBranch[]): void {
+function generateTrunkBranches(ctx: BranchContext, branches: GeneratedBranch[]): void {
 	const { rng, config, trunkJunctions, blobs, trunkTop, trunkAxisAngle } = ctx;
 	const trunkHeight = ctx.trunkBottom - trunkTop;
 	const count = sampleBranchCountForLevel(rng, config, 1);
@@ -276,7 +276,7 @@ function generateTrunkBranches(ctx: BranchContext, branches: InternalBranch[]): 
 
 function generateSubBranches(
 	ctx: BranchContext,
-	branches: InternalBranch[],
+	branches: GeneratedBranch[],
 	parentDepth: number,
 ): void {
 	const { rng, config, blobs } = ctx;
@@ -392,7 +392,7 @@ export function generateBranches(
 	config: TreeConfig,
 	trunkJunctions: readonly Point2D[],
 	blobs: readonly Blob[],
-): BranchSegment[] {
+): GeneratedBranch[] {
 	const branchDepth = config.branchDepth;
 	if (branchDepth <= 0) {
 		return [];
@@ -422,7 +422,7 @@ export function generateBranches(
 		branchThicknessScale,
 	};
 
-	const branches: InternalBranch[] = [];
+	const branches: GeneratedBranch[] = [];
 
 	// Depth 1: trunk-origin branches
 	generateTrunkBranches(ctx, branches);
@@ -460,5 +460,5 @@ export function generateBranches(
 		});
 	}
 
-	return branches.map((b) => b.segment);
+	return branches;
 }

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -59,6 +59,7 @@ export interface BranchGeometry {
 	readonly junctionFills: readonly Quad[];
 	readonly origin: Point2D;
 	readonly depth: number;
+	readonly parentIndex: number | null;
 }
 
 export interface TreeGeometry {

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -5,19 +5,25 @@ test('homepage loads', async ({ page }) => {
 	expect(response?.status()).toBe(200);
 });
 
-/** Helper: select a fruit type from the Growables card dropdown. */
-async function selectFruitType(page: Page, fruitName: string) {
-	// Scope to the Growables card via data-slot, then find the select trigger inside it.
-	const growablesCard = page
-		.getByText('Growables')
-		.locator('xpath=ancestor::*[@data-slot="card"]');
-	const fruitTypeTrigger = growablesCard.locator('[data-slot="select-trigger"]');
-	await fruitTypeTrigger.click();
+/** Helper: select a value from a LabeledSelect dropdown identified by its label text. */
+async function selectDropdownOption(page: Page, labelText: string, optionName: string) {
+	const card = page.getByText(labelText).locator('xpath=ancestor::*[contains(@class,"grid")]');
+	const trigger = card.locator('[data-slot="select-trigger"]');
+	await trigger.click();
 	await page.waitForTimeout(300);
 
-	// The listbox is portalled to the body root; use getByRole to find the option.
-	await page.getByRole('option', { name: fruitName, exact: true }).click();
+	await page.getByRole('option', { name: optionName, exact: true }).click();
 	await page.waitForTimeout(300);
+}
+
+/** Helper: switch tree shape to Custom so fruit type dropdown is unlocked. */
+async function switchToCustomShape(page: Page) {
+	await selectDropdownOption(page, 'Tree Type', 'Custom');
+}
+
+/** Helper: select a fruit type from the Growables card dropdown. */
+async function selectFruitType(page: Page, fruitName: string) {
+	await selectDropdownOption(page, 'Fruit Type', fruitName);
 }
 
 test.describe('Growables card', () => {
@@ -35,6 +41,11 @@ test.describe('Growables card', () => {
 		await page.goto('/editor');
 		await page.waitForLoadState('networkidle');
 
+		// Fruit type dropdown is locked for non-custom shapes; switch to Custom first.
+		await switchToCustomShape(page);
+		// Custom inherits the previous shape's fruit type — reset to None.
+		await selectFruitType(page, 'None');
+
 		// Fruit count slider (shadcn) — auto-generated ID from label "Fruit Count"
 		const fruitCountSlider = page.locator('#slider-fruit-count');
 		await expect(fruitCountSlider).toHaveAttribute('data-disabled', '');
@@ -49,6 +60,7 @@ test.describe('Growables card', () => {
 		await page.goto('/editor');
 		await page.waitForLoadState('networkidle');
 
+		await switchToCustomShape(page);
 		await selectFruitType(page, 'Apple');
 
 		// Set fruit count via keyboard on the shadcn slider
@@ -71,6 +83,7 @@ test.describe('Growables card', () => {
 		await page.goto('/editor');
 		await page.waitForLoadState('networkidle');
 
+		await switchToCustomShape(page);
 		await selectFruitType(page, 'Apple');
 
 		// Increase fruit count via keyboard


### PR DESCRIPTION
## Description
- Reduce canopy sway initial delay from 0-3s to 0-0.5s so animation starts promptly
- Nest child branches (L2+) inside parent `<g>` elements hierarchically so they inherit parent rotation during sway animation — uses recursive `{#snippet}` for arbitrary depth support
- Move falling leaf particle spawn from canopy top (`crownTop.y`) to canopy bottom boundary (max Y across all canopy blob triangles)
- Tool animation toggle verified working — no code changes needed

## Resolves
Closes #83

## Testing
- [x] Unit: `computeAnimationDelay` returns [0, 0.5] range (updated existing test)
- [x] Unit: `computeCanopyBottomY` returns max Y from blob triangles (2 new tests)
- [x] Unit: `BranchGeometry.parentIndex` exists and is correct (5 new tests)
- [x] Unit: `generateBranches` returns `GeneratedBranch[]` with depth/parentIndex (updated existing tests)
- [x] All 2150 unit tests pass
- [x] `check:all` passes (format + lint + typecheck + stylelint + knip)