### PR TITLE
#86 fix(rendering): SVG accessories & fruit fixes (watering can, woodpecker, fruit 2x)

### DIFF
--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -28,6 +28,8 @@
 	import { createPrng, randomInRange } from '$lib/trees/prng.js';
 	import { SvelteMap } from 'svelte/reactivity';
 
+	const FRUIT_RENDER_SCALE = 2;
+
 	interface Props {
 		config?: TreeConfig;
 		showCanopy?: boolean;
@@ -325,7 +327,7 @@
 			{@const FruitSvg = fruitComponent}
 			<g class="fruit">
 				{#each geometry.fruitSlots as slot (slot)}
-					<g transform="translate({slot.x},{slot.y})">
+					<g transform="translate({slot.x},{slot.y}) scale({FRUIT_RENDER_SCALE})">
 						<FruitSvg />
 					</g>
 				{/each}

--- a/src/lib/trees/assets/tools/WateringCanSvg.svelte
+++ b/src/lib/trees/assets/tools/WateringCanSvg.svelte
@@ -2,8 +2,9 @@
 	Watering Can placeholder SVG — recognizable metal can with spout.
 	Flat design: dark charcoal grey metal body.
 	Snap point: spout tip at local (16, -8).
+	Static -20° tilt around spout tip for "as if pouring" resting pose.
 -->
-<g>
+<g transform="rotate(-20, 16, -8)">
 	<!-- Body (main container) -->
 	<path d="M-10,-4 L10,-4 L12,10 L-12,10 Z" fill="#5A6A7A" />
 	<!-- Body highlight -->

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -1605,6 +1605,29 @@ describe('Fruit generation (SVG-based)', () => {
 		const geo = generateTree(makeConfig());
 		expect(geo.fruitSlots).toHaveLength(0);
 	});
+
+	it('fruit slots are far enough from canopy edge for 2x rendering', () => {
+		const geo = generateTree(
+			makeConfig({ stage: 'fruiting', fruitType: 'apple', fruitCount: 7, seed: 42 }),
+		);
+		// Canopy is blob-shaped so bounding-box margins understate interior clearance.
+		// Still, every slot must have at least 3px margin from the bounding box —
+		// this catches the worst edge-clipping cases from an overly loose inset factor.
+		const allCanopyVertices = geo.canopyBlobs.flatMap((b) =>
+			b.triangles.flatMap((t) => t.points),
+		);
+		const minX = Math.min(...allCanopyVertices.map((p) => p.x));
+		const maxX = Math.max(...allCanopyVertices.map((p) => p.x));
+		const minY = Math.min(...allCanopyVertices.map((p) => p.y));
+		const maxY = Math.max(...allCanopyVertices.map((p) => p.y));
+		const minimumBoundingBoxMargin = 3;
+		for (const slot of geo.fruitSlots) {
+			expect(slot.x).toBeGreaterThanOrEqual(minX + minimumBoundingBoxMargin);
+			expect(slot.x).toBeLessThanOrEqual(maxX - minimumBoundingBoxMargin);
+			expect(slot.y).toBeGreaterThanOrEqual(minY + minimumBoundingBoxMargin);
+			expect(slot.y).toBeLessThanOrEqual(maxY - minimumBoundingBoxMargin);
+		}
+	});
 });
 
 // ============================================================================

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -120,7 +120,8 @@ function isTriangleInsideRegion(
 const ROOTS_DEPTH_PX = 15;
 const FRUIT_SLOTS_SEED_OFFSET = 54321;
 const FRUIT_COUNT_CAP = 7;
-const FRUIT_CONTAINMENT_INSET_FACTOR = 0.85;
+/** Calibrated for 2× fruit render scale (FRUIT_RENDER_SCALE in LowPolyTree.svelte). */
+const FRUIT_CONTAINMENT_INSET_FACTOR = 0.7;
 
 function buildCanopyContainmentTest(
 	blobs: readonly Blob[],

--- a/src/lib/trees/tools/tool_definitions.test.ts
+++ b/src/lib/trees/tools/tool_definitions.test.ts
@@ -64,6 +64,6 @@ describe('TOOL_DEFINITIONS', () => {
 	});
 
 	it('woodpecker has correct snapOffset', () => {
-		expect(TOOL_DEFINITIONS.woodpecker.snapOffset).toEqual({ x: 0, y: 10 });
+		expect(TOOL_DEFINITIONS.woodpecker.snapOffset).toEqual({ x: 6, y: 10 });
 	});
 });

--- a/src/lib/trees/tools/tool_definitions.ts
+++ b/src/lib/trees/tools/tool_definitions.ts
@@ -44,6 +44,6 @@ export const TOOL_DEFINITIONS = {
 	[TOOL_TYPES.woodpecker]: {
 		svgComponent: WoodpeckerSvg,
 		anchorTarget: 'trunkMiddle',
-		snapOffset: { x: 0, y: 10 },
+		snapOffset: { x: 6, y: 10 },
 	},
 } as const satisfies Record<ToolType, ToolDefinition>;


### PR DESCRIPTION
## Description
- Watering can: static -20° tilt rotation around spout tip for "as if pouring" resting pose
- Woodpecker: snapOffset.x 0→6 to position body flush against trunk center
- Fruit: 2x render scale via `FRUIT_RENDER_SCALE` constant in `LowPolyTree.svelte`
- Fruit containment inset 0.85→0.70, calibrated for 2x fruit size to prevent canopy edge clipping

## Resolves
Closes #86

## Testing
- [x] Unit tests: 2273 passing (woodpecker offset assertion updated, fruit boundary clearance test added)
- [x] Static checks: `check:all` clean (prettier, oxlint, stylelint, knip, svelte-check, eslint)
- [x] Watering can snap offset unchanged (rotation pivots around spout tip)