### PR TITLE
#101 chore(engine): resolve Phase 2 unresolved items

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -788,20 +788,20 @@ Trunk color UI includes preset swatch buttons that set all three HSL sliders at 
 
 - [ ] **REQ-EV2-TZ-03** Updated SHAPE_DEFAULTS for `trunkSegments`:
 
-          | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
-          |---------|---------|--------|-------------|---------------------------|
-          | oak     | 5       | 3      | 5           | 1 + 4                     |
-          | maple   | 3       | 5      | 7           | 2 + 5                     |
-          | willow  | 5       | 5      | 7           | 2 + 5                     |
-          | cherry  | 3       | 4      | 6           | 1 + 5                     |
-          | birch   | 3       | 2      | 4           | 1 + 3                     |
-          | apple   | 3       | 2      | 3           | 1 + 2                     |
-          | baobab  | 3       | 3      | 5           | 1 + 4                     |
-          | acacia  | 3       | 3      | 5           | 1 + 4                     |
-          | pine    | 3       | 0      | 3           | unchanged (no branches)    |
-          | fir     | 3       | 0      | 3           | unchanged (no branches)    |
-          | cypress | 3       | 0      | 3           | unchanged (no branches)    |
-          | bush    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                  | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
+                                                                  |---------|---------|--------|-------------|---------------------------|
+                                                                  | oak     | 5       | 3      | 5           | 1 + 4                     |
+                                                                  | maple   | 3       | 5      | 7           | 2 + 5                     |
+                                                                  | willow  | 5       | 5      | 7           | 2 + 5                     |
+                                                                  | cherry  | 3       | 4      | 6           | 1 + 5                     |
+                                                                  | birch   | 3       | 2      | 4           | 1 + 3                     |
+                                                                  | apple   | 3       | 2      | 3           | 1 + 2                     |
+                                                                  | baobab  | 3       | 3      | 5           | 1 + 4                     |
+                                                                  | acacia  | 3       | 3      | 5           | 1 + 4                     |
+                                                                  | pine    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                  | fir     | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                  | cypress | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                  | bush    | 3       | 0      | 3           | unchanged (no branches)    |
 
 ### 13.6 Bottom-Up Sequential Generation
 
@@ -937,110 +937,113 @@ Phase 1 must deliver these interfaces for Phase 2 to consume:
 
 ### 14.1 Z-Ordering — Front/Back Branch Placement
 
-- [ ] **REQ-EV2-Z-01** Branches are classified as **front** (in front of trunk) or **back**
+- [x] **REQ-EV2-Z-01** Branches are classified as **front** (in front of trunk) or **back**
       (behind trunk) using light-angle-biased randomness: - Branches on the **lit side** (facing `lightAngle`): 70% chance of front placement. - Branches on the **shadow side**: 30% chance of front placement. - Classification is seeded for determinism.
 
-- [ ] **REQ-EV2-Z-02** Back branches render **before** trunk quads in SVG order and receive a
+- [x] **REQ-EV2-Z-02** Back branches render **before** trunk quads in SVG order and receive a
       **−3 lightness offset** (subtle darkness for depth cue). Front branches render after trunk
       (current behavior, no offset).
 
-- [ ] **REQ-EV2-Z-03** L2 branches inherit their parent L1's front/back status by default, with
+- [x] **REQ-EV2-Z-03** L2 branches inherit their parent L1's front/back status by default, with
       a small seeded chance (~20%) of flipping. The L2→L1 depth relationship mirrors the L1→trunk
       relationship — consistent hierarchy.
 
-- [ ] **REQ-EV2-Z-04** Five z-order render layers for branching shapes (painter's order): 1. Back branches (behind trunk) 2. Trunk quads 3. Front branches (in front of trunk) 4. Back canopy blobs (connected to back branches) 5. Front canopy blobs (connected to front/trunk branches)
+- [x] **REQ-EV2-Z-04** Five z-order render layers for branching shapes (painter's order): 1. Back branches (behind trunk) 2. Trunk quads 3. Front branches (in front of trunk) 4. Back canopy blobs (connected to back branches) 5. Front canopy blobs (connected to front/trunk branches)
       Branchless shapes retain the original 3-layer model (REQ-R-02).
 
-- [ ] **REQ-EV2-Z-05** Each geometry element (`Quad`, `Triangle`, `BranchGeometry`,
+- [x] **REQ-EV2-Z-05** Each container geometry element (`Quad`, `BranchGeometry`,
       `BlobGeometry`) gains a `zOrder` field. The renderer sorts by z-order layer. This replaces
-      the fixed array-based render order.
+      the fixed array-based render order. **`Triangle` is explicitly waived** — triangles always
+      inherit ordering from their parent `BlobGeometry` (whose `zOrder` governs the whole blob),
+      or render in fixed pipeline slots (trunk/fruit/flower/stake). Per-triangle z-order has no
+      consumer in the renderer and would add dead state on every triangle.
 
 ### 14.2 Revised Generation Pipeline
 
-- [ ] **REQ-EV2-P-01** For branching shapes, the generation pipeline is: 1. Build trunk path with two-zone segments (bottom-up, with fork reactions — from Phase 1) 2. Fork L1 branches from trunk at upper-zone junctions (Phase 1) 3. Fork L2 branches from L1 branches using same model (Phase 1) 4. Generate L3 branches (simplified, Phase 1) 5. **Cluster branch tips into blob groups** (new in Phase 2) 6. **Generate canopy blobs around cluster centroids** (new in Phase 2) 7. **Assign z-order to all geometry elements** (new in Phase 2)
+- [x] **REQ-EV2-P-01** For branching shapes, the generation pipeline is: 1. Build trunk path with two-zone segments (bottom-up, with fork reactions — from Phase 1) 2. Fork L1 branches from trunk at upper-zone junctions (Phase 1) 3. Fork L2 branches from L1 branches using same model (Phase 1) 4. Generate L3 branches (simplified, Phase 1) 5. **Cluster branch tips into blob groups** (new in Phase 2) 6. **Generate canopy blobs around cluster centroids** (new in Phase 2) 7. **Assign z-order to all geometry elements** (new in Phase 2)
 
-- [ ] **REQ-EV2-P-02** Branchless shapes (pine, fir, cypress, bush) keep their **current
+- [x] **REQ-EV2-P-02** Branchless shapes (pine, fir, cypress, bush) keep their **current
       generation system entirely**. Tier-based canopy for pine/fir, blob generators for
       bush/cypress. No changes to branchless shape rendering.
 
 ### 14.3 Branch-Driven Canopy Blob Placement
 
-- [ ] **REQ-EV2-BC-01** Given N branch tips (L1 + L2 + optional trunk tip), cluster them into M
+- [x] **REQ-EV2-BC-01** Given N branch tips (L1 + L2 + optional trunk tip), cluster them into M
       groups where M = `blobCount` slider value. Use a clustering algorithm (e.g., k-means or
       similar seeded algorithm). Each blob is centered on its cluster's centroid. - Tips close together share a blob (wide canopy supported by multiple branches). - Tips far apart get individual blobs. - `blobCount` slider meaning shifts from "number of ellipses" to "number of canopy
       clusters" — more intuitive.
 
-- [ ] **REQ-EV2-BC-02** The trunk tip is included as a cluster point. For shapes like oak, the
+- [x] **REQ-EV2-BC-02** The trunk tip is included as a cluster point. For shapes like oak, the
       trunk tip has **higher weight** in the clustering (attracts a blob to itself = central
       crown). For shapes like maple, the trunk tip has low/zero weight (no central blob — maple's
       trunk tip is a fork point, not a canopy anchor).
 
-- [ ] **REQ-EV2-BC-03** **Key visual requirement:** branches must go into the **middle** of their
+- [x] **REQ-EV2-BC-03** **Key visual requirement:** branches must go into the **middle** of their
       blob. This is more important than strict geometric positioning rules. If a branch tip lands
       at the edge of a blob, the blob should shift to center on the tip, not the other way around.
 
-- [ ] **REQ-EV2-BC-04** Weaker branches (higher depth levels) get **smaller blobs**. An L3 branch
+- [x] **REQ-EV2-BC-04** Weaker branches (higher depth levels) get **smaller blobs**. An L3 branch
       tip should never anchor the biggest blob. Blob size correlates with the branch
       level/thickness of its strongest contributing branch tip.
 
 ### 14.4 Blob Sizing
 
-- [ ] **REQ-EV2-BS-01** Blob base radius is determined by two factors combined: - **Cluster size** — more branch tips in a cluster → larger blob radius. - **Branch thickness** — thicker branches (L1) produce larger blobs than thinner (L2, L3).
+- [x] **REQ-EV2-BS-01** Blob base radius is determined by two factors combined: - **Cluster size** — more branch tips in a cluster → larger blob radius. - **Branch thickness** — thicker branches (L1) produce larger blobs than thinner (L2, L3).
       `blobSizeVariance` adds seeded randomness on top.
 
-- [ ] **REQ-EV2-BS-02** `canopySize` slider scales the **canopy envelope** smartly: - Does NOT simply multiply all radii — adapts cluster boundaries so branches remain visible. - Small `canopySize` → tight envelope, fewer tips covered, more bare branches visible
+- [x] **REQ-EV2-BS-02** `canopySize` slider scales the **canopy envelope** smartly: - Does NOT simply multiply all radii — adapts cluster boundaries so branches remain visible. - Small `canopySize` → tight envelope, fewer tips covered, more bare branches visible
       (good for sapling/young tree stages). - Large `canopySize` → wider envelope, more tips covered, lush canopy. - Branches should remain visible at all canopy sizes — the envelope grows to cover tips
       further out, it doesn't inflate blobs to hide nearby branches.
 
 ### 14.5 Canopy Envelope
 
-- [ ] **REQ-EV2-CE-01** Each shape defines a **canopy envelope** — a bounding region where blobs
+- [x] **REQ-EV2-CE-01** Each shape defines a **canopy envelope** — a bounding region where blobs
       should exist. Derived from the spatial patterns of current blob generators (making implicit
       knowledge explicit).
 
-- [ ] **REQ-EV2-CE-02** `canopySize` scales the envelope from its center (grows outward/upward,
+- [x] **REQ-EV2-CE-02** `canopySize` scales the envelope from its center (grows outward/upward,
       not downward into the trunk).
 
-- [ ] **REQ-EV2-CE-03** **Viewport clamp:** the canopy envelope cannot extend within **10 px** of
+- [x] **REQ-EV2-CE-03** **Viewport clamp:** the canopy envelope cannot extend within **10 px** of
       any viewport edge. This prevents canopy overflow regardless of `canopySize` value.
 
-- [ ] **REQ-EV2-CE-04** Branch tips **outside** the envelope: their blob is pulled back to the
+- [x] **REQ-EV2-CE-04** Branch tips **outside** the envelope: their blob is pulled back to the
       envelope edge (smaller blob at boundary). Tips very far outside get no blob — just bare
       branch poking out (looks realistic for some shapes). Tips near the envelope center get
       larger blobs.
 
-- [ ] **REQ-EV2-CE-05** The envelope serves as the "recommended space" for blobs. It adapts to
+- [x] **REQ-EV2-CE-05** The envelope serves as the "recommended space" for blobs. It adapts to
       `canopySize` and viewport, providing a smart boundary that prevents both overflow and
       branch-hiding. This works well with stages like sapling (small canopySize = few small blobs)
       and mature (large canopySize = full coverage).
 
 ### 14.6 Shape Style Parameters
 
-- [ ] **REQ-EV2-SS-01** Each shape definition retains **style parameters** that control how
+- [x] **REQ-EV2-SS-01** Each shape definition retains **style parameters** that control how
       branch-tip-derived blobs look. These replace the absolute blob placement of current
-      generators while preserving each shape's visual identity: - `blobRxRyRatio`: controls blob shape (1.0 = round, 3.0+ = flat like acacia parasol). - `blobVerticalOffset`: shifts blobs relative to tip position (negative for willow droop). - `blobBoundary`: circle or teardrop (for cypress-style). - `blobClusterBehavior`: how aggressively nearby tips merge into shared blobs.
+      generators while preserving each shape's visual identity: - `blobRxRyRatio`: controls blob shape (1.0 = round, 3.0+ = flat like acacia parasol). - `blobVerticalOffset`: shifts blobs relative to tip position (positive = droop downward, since SVG Y increases downward — used by willow). - `blobBoundary`: circle or teardrop (for cypress-style). - `blobClusterBehavior`: how aggressively nearby tips merge into shared blobs.
 
-- [ ] **REQ-EV2-SS-02** Shape-specific identity preserved via style parameters:
+- [x] **REQ-EV2-SS-02** Shape-specific identity preserved via style parameters:
 
-          | Shape   | Key Characteristics                                                 |
-          |---------|---------------------------------------------------------------------|
-          | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
-          | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
-          | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
-          | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
-          | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
-          | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
-          | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
-          | apple   | Compact round canopy. Minimal branching. Large single blob.         |
+                                                                  | Shape   | Key Characteristics                                                 |
+                                                                  |---------|---------------------------------------------------------------------|
+                                                                  | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
+                                                                  | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
+                                                                  | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
+                                                                  | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
+                                                                  | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
+                                                                  | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
+                                                                  | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
+                                                                  | apple   | Compact round canopy. Minimal branching. Large single blob.         |
 
-- [ ] **REQ-EV2-SS-03** Some branch tips will naturally not have blobs — those that fall outside
+- [x] **REQ-EV2-SS-03** Some branch tips will naturally not have blobs — those that fall outside
       the canopy envelope. This is acceptable and realistic (bare branch poking out of canopy).
 
 ### 14.7 Canopy Z-Ordering
 
-- [ ] **REQ-EV2-CZ-01** Each canopy blob inherits z-order from its cluster's branches: - Single-branch cluster: blob gets that branch's front/back status. - Multi-branch cluster with mixed front/back: blob defaults to front. - Trunk-tip blob (e.g., oak center): always front.
+- [x] **REQ-EV2-CZ-01** Each canopy blob inherits z-order from its cluster's branches: - Single-branch cluster: blob gets that branch's front/back status. - Multi-branch cluster with mixed front/back: blob defaults to front. - Trunk-tip blob (e.g., oak center): always front.
 
-- [ ] **REQ-EV2-CZ-02** Back canopy blobs render in layer 4, front canopy blobs in layer 5
+- [x] **REQ-EV2-CZ-02** Back canopy blobs render in layer 4, front canopy blobs in layer 5
       (per REQ-EV2-Z-04). This creates visible depth — some canopy clusters appear behind the
       trunk while others are in front.
 

--- a/src/lib/trees/canopy_clustering.test.ts
+++ b/src/lib/trees/canopy_clustering.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-	clusterBranchTips,
-	computeClusterBlob,
-	type BranchTipInfo,
-	type ShapeStyleParameters,
-} from './canopy_clustering.js';
+import { clusterBranchTips, computeClusterBlob, type BranchTipInfo } from './canopy_clustering.js';
+import type { ShapeStyleParameters } from './shapes/shape_types.js';
 import { computeCanopyEnvelope } from './canopy_envelope.js';
 import { createPrng } from './prng.js';
 

--- a/src/lib/trees/canopy_clustering.ts
+++ b/src/lib/trees/canopy_clustering.ts
@@ -1,9 +1,10 @@
 import type { Point2D } from './types/core.js';
 import type { CanopyEnvelope } from './canopy_envelope.js';
 import { clampToEnvelope, computeEnvelopeScaleFactor } from './canopy_envelope.js';
-import type { Blob } from './shapes/shape_types.js';
+import type { Blob, ShapeStyleParameters } from './shapes/shape_types.js';
 import { BOUNDARY_KINDS } from './boundaries.js';
 import { createPrng } from './prng.js';
+import { classifyCanopyBlobZOrder } from './z_ordering.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -29,19 +30,6 @@ interface BlobCluster {
 	readonly hasTrunkTip: boolean;
 	/** Aggregate z-order for the cluster. */
 	readonly zOrder: 'front' | 'back';
-}
-
-export interface ShapeStyleParameters {
-	/** Blob rx/ry ratio: 1.0 = round, 3.0+ = flat (REQ-EV2-SS-01). */
-	readonly blobRxRyRatio: number;
-	/** Vertical offset from tip position: negative = droop (REQ-EV2-SS-01). */
-	readonly blobVerticalOffset: number;
-	/** Boundary shape: 'circle' or 'teardrop' (REQ-EV2-SS-01). */
-	readonly blobBoundary: 'circle' | 'teardrop';
-	/** How aggressively nearby tips merge: 0 = spread, 1 = tight (REQ-EV2-SS-01). */
-	readonly blobClusterBehavior: number;
-	/** Trunk tip weight in clustering: 0 = ignore, 1 = strong anchor (REQ-EV2-BC-02). */
-	readonly trunkTipWeight: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -230,11 +218,7 @@ export function clusterBranchTips(
 		}
 
 		// Z-order: trunk-tip clusters always front, else majority wins (REQ-EV2-CZ-01)
-		let zOrder: 'front' | 'back' = 'front';
-		if (!hasTrunkTip && zOrders.length > 0) {
-			const allBack = zOrders.every((z) => z === 'back');
-			zOrder = allBack ? 'back' : 'front';
-		}
+		const zOrder = classifyCanopyBlobZOrder(zOrders, hasTrunkTip);
 
 		if (strongestDepth === Infinity) {
 			strongestDepth = 1;

--- a/src/lib/trees/canopy_envelope.test.ts
+++ b/src/lib/trees/canopy_envelope.test.ts
@@ -123,4 +123,14 @@ describe('computeEnvelopeScaleFactor', () => {
 		expect(factor).toBeGreaterThan(0);
 		expect(factor).toBeLessThan(0.3);
 	});
+
+	it('point exactly on envelope edge returns ENVELOPE_EDGE_SCALE (0.3)', () => {
+		// Edge: centerX + radiusX = 150 + 80 = 230 → normalizedDistance = 1.0
+		expect(computeEnvelopeScaleFactor(230, 90, envelope)).toBeCloseTo(0.3);
+	});
+
+	it('point at the cutoff distance (1.3× radiusX) returns 0', () => {
+		// 150 + 80 * 1.3 = 254 → normalizedDistance just above 1.3 → 0
+		expect(computeEnvelopeScaleFactor(254.01, 90, envelope)).toBe(0);
+	});
 });

--- a/src/lib/trees/canopy_envelope.ts
+++ b/src/lib/trees/canopy_envelope.ts
@@ -7,6 +7,21 @@ import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types/config.js';
 /** Minimum distance from canopy envelope to viewport edge (REQ-EV2-CE-03). */
 const VIEWPORT_MARGIN_PX = 10;
 
+/**
+ * Maximum normalised distance (1.0 = on envelope edge) beyond which a tip gets
+ * no blob — returning scale factor 0 (REQ-EV2-CE-04, bare branch).
+ */
+const ENVELOPE_CUTOFF_DISTANCE = 1.3;
+
+/** Scale factor at the envelope edge — blobs shrink from 1.0 at center to this at edge. */
+const ENVELOPE_EDGE_SCALE = 0.3;
+
+/** Range for the inside-envelope linear ramp: 1.0 (center) → ENVELOPE_EDGE_SCALE (edge). */
+const ENVELOPE_INSIDE_LERP_RANGE = 1.0 - ENVELOPE_EDGE_SCALE;
+
+/** Range for the outside-envelope fade: ENVELOPE_EDGE_SCALE → 0 over (cutoff - 1.0). */
+const ENVELOPE_OUTSIDE_FADE_RANGE = ENVELOPE_CUTOFF_DISTANCE - 1.0;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -146,16 +161,16 @@ export function computeEnvelopeScaleFactor(x: number, y: number, envelope: Canop
 	const dy = (y - envelope.centerY) / envelope.radiusY;
 	const normalizedDistance = Math.sqrt(dx * dx + dy * dy);
 
-	if (normalizedDistance > 1.3) {
+	if (normalizedDistance > ENVELOPE_CUTOFF_DISTANCE) {
 		// Very far outside — no blob
 		return 0;
 	}
 
 	if (normalizedDistance > 1.0) {
-		// Outside but close — small blob pulled to edge
-		return 0.3 * (1 - (normalizedDistance - 1.0) / 0.3);
+		// Outside but close — small blob pulled to edge, fading from EDGE_SCALE → 0
+		return ENVELOPE_EDGE_SCALE * (1 - (normalizedDistance - 1.0) / ENVELOPE_OUTSIDE_FADE_RANGE);
 	}
 
-	// Inside: linear interpolation from 1.0 (center) to 0.3 (edge)
-	return 1.0 - normalizedDistance * 0.7;
+	// Inside: linear interpolation from 1.0 (center) to ENVELOPE_EDGE_SCALE (edge)
+	return 1.0 - normalizedDistance * ENVELOPE_INSIDE_LERP_RANGE;
 }

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -283,6 +283,13 @@ describe('REQ-C: Canopy Generation', () => {
 	});
 
 	describe('REQ-C-03b: canopySize effect', () => {
+		const getCanopyWidth = (geo: TreeGeometry) => {
+			const xs = geo.canopyBlobs.flatMap((b) =>
+				b.triangles.flatMap((t) => t.points.map((p) => p.x)),
+			);
+			return Math.max(...xs) - Math.min(...xs);
+		};
+
 		it('canopySize 200 produces larger canopy than 50', () => {
 			// canopySize directly controls blob sizing for branchless shapes; use cypress.
 			const geoLarge = generateTree(
@@ -291,12 +298,33 @@ describe('REQ-C: Canopy Generation', () => {
 			const geoSmall = generateTree(
 				makeConfig({ shape: 'cypress', canopySize: 50, seed: 42 }),
 			);
-			const getCanopyWidth = (geo: TreeGeometry) => {
-				const xs = geo.canopyBlobs.flatMap((b) =>
-					b.triangles.flatMap((t) => t.points.map((p) => p.x)),
-				);
-				return Math.max(...xs) - Math.min(...xs);
-			};
+			expect(getCanopyWidth(geoLarge)).toBeGreaterThan(getCanopyWidth(geoSmall));
+		});
+
+		it('canopySize scales branching-shape canopy via envelope (oak, Phase 2 path)', () => {
+			// Oak exercises the envelope-based scaling path (REQ-EV2-CE-01..05);
+			// cypress does not. This pins that the branching pipeline also responds
+			// to canopySize, not just the branchless pipeline.
+			const geoLarge = generateTree(
+				makeConfig({
+					shape: 'oak',
+					canopySize: 200,
+					seed: 42,
+					blobCount: 4,
+					branchDepth: 2,
+				}),
+			);
+			const geoSmall = generateTree(
+				makeConfig({
+					shape: 'oak',
+					canopySize: 50,
+					seed: 42,
+					blobCount: 4,
+					branchDepth: 2,
+				}),
+			);
+			expect(geoLarge.canopyBlobs.length).toBeGreaterThan(0);
+			expect(geoSmall.canopyBlobs.length).toBeGreaterThan(0);
 			expect(getCanopyWidth(geoLarge)).toBeGreaterThan(getCanopyWidth(geoSmall));
 		});
 	});
@@ -2891,17 +2919,28 @@ describe('REQ-EV2-BC: Branch-Driven Canopy', () => {
 		}
 	});
 
-	it('canopy envelope stays within 10px of viewport edges', () => {
+	it('canopy envelope stays within 10px of viewport edges (REQ-EV2-CE-03)', () => {
 		const geo = generateTree(
 			makeConfig({ shape: 'oak', seed: 42, blobCount: 5, canopySize: 200 }),
 		);
+		// Strict: blob centers are clamped to the envelope (which is itself 10px inset).
+		// Allow a ~2px jitter for centroid-before-clamping edge cases.
+		const centerMargin = 8;
+		for (const blob of geo.canopyBlobs) {
+			expect(blob.center.x).toBeGreaterThanOrEqual(centerMargin);
+			expect(blob.center.x).toBeLessThanOrEqual(300 - centerMargin);
+			expect(blob.center.y).toBeGreaterThanOrEqual(centerMargin);
+			expect(blob.center.y).toBeLessThanOrEqual(300 - centerMargin);
+		}
+		// Vertices can extend by blob.rx/ry around the clamped center — but must stay
+		// within the viewport. This is the meaningful drawable-area check.
 		for (const blob of geo.canopyBlobs) {
 			for (const tri of blob.triangles) {
 				for (const p of tri.points) {
-					expect(p.x).toBeGreaterThanOrEqual(-5); // small tolerance for triangulation
-					expect(p.x).toBeLessThanOrEqual(305);
-					expect(p.y).toBeGreaterThanOrEqual(-5);
-					expect(p.y).toBeLessThanOrEqual(305);
+					expect(p.x).toBeGreaterThanOrEqual(0);
+					expect(p.x).toBeLessThanOrEqual(300);
+					expect(p.y).toBeGreaterThanOrEqual(0);
+					expect(p.y).toBeLessThanOrEqual(300);
 				}
 			}
 		}

--- a/src/lib/trees/shapes/shape_types.ts
+++ b/src/lib/trees/shapes/shape_types.ts
@@ -1,11 +1,22 @@
 import type { BoundaryKind } from '../boundaries.js';
-import type { ShapeStyleParameters } from '../canopy_clustering.js';
 
 // ---------------------------------------------------------------------------
 // Public interfaces
 // ---------------------------------------------------------------------------
 
-export type { ShapeStyleParameters };
+/** Per-shape style knobs that drive branch-driven canopy rendering (REQ-EV2-SS-01). */
+export interface ShapeStyleParameters {
+	/** Blob rx/ry ratio: 1.0 = round, 3.0+ = flat (REQ-EV2-SS-01). */
+	readonly blobRxRyRatio: number;
+	/** Vertical offset from tip position: positive = droop downward (SVG Y increases downward) (REQ-EV2-SS-01). */
+	readonly blobVerticalOffset: number;
+	/** Boundary shape: 'circle' or 'teardrop' (REQ-EV2-SS-01). */
+	readonly blobBoundary: 'circle' | 'teardrop';
+	/** How aggressively nearby tips merge: 0 = spread, 1 = tight (REQ-EV2-SS-01). */
+	readonly blobClusterBehavior: number;
+	/** Trunk tip weight in clustering: 0 = ignore, 1 = strong anchor (REQ-EV2-BC-02). */
+	readonly trunkTipWeight: number;
+}
 
 export interface Blob {
 	cx: number;

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -30,6 +30,14 @@ export interface Point2D {
 	readonly y: number;
 }
 
+/**
+ * Low-level triangle primitive.
+ *
+ * REQ-EV2-Z-05 note: `Triangle` intentionally has no `zOrder` field. Triangles
+ * always inherit ordering from their containing `BlobGeometry` (whose `zOrder`
+ * governs the whole blob) or render in fixed pipeline slots (trunk/fruit/flower/
+ * stake). Per-triangle ordering has no consumer in `LowPolyTree.svelte`.
+ */
 export interface Triangle {
 	readonly points: readonly [Point2D, Point2D, Point2D];
 	readonly color: string;

--- a/src/lib/trees/z_ordering.test.ts
+++ b/src/lib/trees/z_ordering.test.ts
@@ -127,6 +127,11 @@ describe('classifyCanopyBlobZOrder', () => {
 		expect(classifyCanopyBlobZOrder([], true)).toBe('front');
 	});
 
+	it('trunk-tip cluster with mixed branches → always front (spec override)', () => {
+		expect(classifyCanopyBlobZOrder(['back', 'back', 'back'], true)).toBe('front');
+		expect(classifyCanopyBlobZOrder(['back'], true)).toBe('front');
+	});
+
 	it('empty non-trunk cluster → front (fallback)', () => {
 		expect(classifyCanopyBlobZOrder([], false)).toBe('front');
 	});

--- a/src/lib/trees/z_ordering.ts
+++ b/src/lib/trees/z_ordering.ts
@@ -73,17 +73,18 @@ export function classifyChildBranchZOrder(
 // ---------------------------------------------------------------------------
 
 /**
- * Classify a canopy blob based on its cluster's branch z-orders.
+ * Classify a canopy blob based on its cluster's branch z-orders (REQ-EV2-CZ-01).
  *
+ * - Trunk-tip cluster: always front (regardless of branch contents).
  * - Single branch: inherit that branch's status.
- * - Mixed front/back: default to front.
- * - Trunk-tip only (isTrunkTipCluster): always front.
+ * - All-back multi-branch: back.
+ * - Mixed / empty non-trunk: front.
  */
 export function classifyCanopyBlobZOrder(
 	branchZOrders: readonly ('front' | 'back')[],
 	isTrunkTipCluster: boolean,
 ): 'front' | 'back' {
-	if (isTrunkTipCluster && branchZOrders.length === 0) {
+	if (isTrunkTipCluster) {
 		return 'front';
 	}
 


### PR DESCRIPTION
## Description

Resolves 8 cleanup items from PR #100 (Phase 2 canopy-branch coupling):

- **Item 2**: Move `ShapeStyleParameters` type to `shapes/shape_types.ts` — fixes inverted dep arrow where a type file imported from an algorithm file.
- **Item 3**: Extract envelope magic numbers (1.3, 0.3, 0.7) in `canopy_envelope.ts` to named constants (`ENVELOPE_CUTOFF_DISTANCE`, `ENVELOPE_EDGE_SCALE`, `ENVELOPE_INSIDE_LERP_RANGE`); derived `0.7` from `1.0 - ENVELOPE_EDGE_SCALE` for self-consistency. Added boundary regression test.
- **Item 1**: Consolidate z-order logic — `clusterBranchTips` now calls `classifyCanopyBlobZOrder`. Tightened the function so trunk-tip clusters unconditionally return `'front'` (matches REQ-EV2-CZ-01; previously only worked by chance for empty clusters).
- **Item 5**: Tighten REQ-EV2-CE-03 viewport margin test from 15 px slack to ~2 px, plus strict blob-center bound (`[8, 292]`).
- **Item 8**: Add branching-shape canopySize test (oak, canopySize 50 vs 200) exercising the Phase 2 envelope-scaling path. Existing coverage was branchless-only (cypress).
- **Item 6**: Fix inverted `blobVerticalOffset` docstring — "positive = droop downward (SVG Y increases downward)" — in both the type definition and REQUIREMENTS §14.6.
- **Item 4**: Explicitly waive `Triangle.zOrder` in REQ-EV2-Z-05 with JSDoc rationale. Triangles inherit ordering from parent `BlobGeometry` or render in fixed pipeline slots; no renderer consumer exists, so a per-triangle field would add dead state on hundreds of triangles per tree.
- **Item 7**: Check off all 23 §14 Phase 2 requirement boxes implemented by PR #100.

## Resolves

Closes #101

## Testing

- [x] Unit tests: 2276 passing (added 4 new)
- [x] `pnpm run check:all`: 0 warnings, 0 errors
- [x] No behavioral changes beyond the trunk-tip cluster z-order contract fix