### PR TITLE
#105 feat(engine): real branchSegments + branchCrookedness (multi-junction branches)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -788,20 +788,20 @@ Trunk color UI includes preset swatch buttons that set all three HSL sliders at 
 
 - [ ] **REQ-EV2-TZ-03** Updated SHAPE_DEFAULTS for `trunkSegments`:
 
-                                                                                    | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
-                                                                                    |---------|---------|--------|-------------|---------------------------|
-                                                                                    | oak     | 5       | 3      | 5           | 1 + 4                     |
-                                                                                    | maple   | 3       | 5      | 7           | 2 + 5                     |
-                                                                                    | willow  | 5       | 5      | 7           | 2 + 5                     |
-                                                                                    | cherry  | 3       | 4      | 6           | 1 + 5                     |
-                                                                                    | birch   | 3       | 2      | 4           | 1 + 3                     |
-                                                                                    | apple   | 3       | 2      | 3           | 1 + 2                     |
-                                                                                    | baobab  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                    | acacia  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                    | pine    | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                    | fir     | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                    | cypress | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                    | bush    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                          | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
+                                                                                          |---------|---------|--------|-------------|---------------------------|
+                                                                                          | oak     | 5       | 3      | 5           | 1 + 4                     |
+                                                                                          | maple   | 3       | 5      | 7           | 2 + 5                     |
+                                                                                          | willow  | 5       | 5      | 7           | 2 + 5                     |
+                                                                                          | cherry  | 3       | 4      | 6           | 1 + 5                     |
+                                                                                          | birch   | 3       | 2      | 4           | 1 + 3                     |
+                                                                                          | apple   | 3       | 2      | 3           | 1 + 2                     |
+                                                                                          | baobab  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                          | acacia  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                          | pine    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                          | fir     | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                          | cypress | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                          | bush    | 3       | 0      | 3           | unchanged (no branches)    |
 
 ### 13.6 Bottom-Up Sequential Generation
 
@@ -1040,16 +1040,16 @@ Phase 1 must deliver these interfaces for Phase 2 to consume:
 
 - [x] **REQ-EV2-SS-02** Shape-specific identity preserved via style parameters:
 
-                                                                                    | Shape   | Key Characteristics                                                 |
-                                                                                    |---------|---------------------------------------------------------------------|
-                                                                                    | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
-                                                                                    | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
-                                                                                    | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
-                                                                                    | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
-                                                                                    | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
-                                                                                    | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
-                                                                                    | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
-                                                                                    | apple   | Compact round canopy. Minimal branching. Large single blob.         |
+                                                                                          | Shape   | Key Characteristics                                                 |
+                                                                                          |---------|---------------------------------------------------------------------|
+                                                                                          | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
+                                                                                          | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
+                                                                                          | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
+                                                                                          | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
+                                                                                          | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
+                                                                                          | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
+                                                                                          | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
+                                                                                          | apple   | Compact round canopy. Minimal branching. Large single blob.         |
 
 - [x] **REQ-EV2-SS-03** Some branch tips will naturally not have blobs — those that fall outside
       the canopy envelope. This is acceptable and realistic (bare branch poking out of canopy).

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -3056,3 +3056,114 @@ describe('REQ-EV2-BC: Branch-Driven Canopy', () => {
 		}
 	});
 });
+
+// ============================================================================
+// Issue #105: multi-junction branch quads
+// ============================================================================
+
+describe('Issue #105: multi-junction branch rendering', () => {
+	it('branchSegments=3 produces more quads per branch than branchSegments=1', () => {
+		const config1 = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 1,
+			branchCrookedness: 50,
+			branchDepth: 1,
+			seed: 42,
+			trunkStripCount: 3,
+		});
+		const config3 = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 3,
+			branchCrookedness: 50,
+			branchDepth: 1,
+			seed: 42,
+			trunkStripCount: 3,
+		});
+		const geo1 = generateTree(config1);
+		const geo3 = generateTree(config3);
+		// With 3 segments and 3 strips, each L1 branch should produce 3×3=9 quads
+		// vs 1×3=3 quads with 1 segment. Total branch quads should be ~3× more.
+		const quads1 = allBranchQuads(geo1).length;
+		const quads3 = allBranchQuads(geo3).length;
+		expect(quads3).toBeGreaterThan(quads1);
+	});
+
+	it('branchSegments=3 branch quads share junction vertices (no gaps)', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 3,
+			branchCrookedness: 50,
+			branchDepth: 1,
+			seed: 42,
+			trunkStripCount: 3,
+		});
+		const geo = generateTree(config);
+		// For each branch group, check that consecutive junction quads share edge points
+		for (const group of geo.branchGroups) {
+			if (group.depth >= 3) {
+				continue; // L3 uses single quad
+			}
+			const stripCount = config.trunkStripCount;
+			const segmentCount = group.quads.length / stripCount;
+			if (segmentCount <= 1) {
+				continue;
+			}
+			// Quads are ordered: [seg0_strip0, seg0_strip1, ..., seg1_strip0, ...]
+			for (let seg = 0; seg < segmentCount - 1; seg++) {
+				for (let strip = 0; strip < stripCount; strip++) {
+					const currentQuad = group.quads[seg * stripCount + strip]!;
+					const nextQuad = group.quads[(seg + 1) * stripCount + strip]!;
+					// Current quad's "top" edge (points[0] and [1]) should match
+					// next quad's "bottom" edge (points[2] and [3])
+					// In our layout: quad.points = [topLeft, topRight, bottomRight, bottomLeft]
+					// for segment i: top = junction[i+1], bottom = junction[i]
+					// So current quad top should equal next quad bottom
+					expect(currentQuad.points[0]!.x).toBeCloseTo(nextQuad.points[3]!.x, 6);
+					expect(currentQuad.points[0]!.y).toBeCloseTo(nextQuad.points[3]!.y, 6);
+					expect(currentQuad.points[1]!.x).toBeCloseTo(nextQuad.points[2]!.x, 6);
+					expect(currentQuad.points[1]!.y).toBeCloseTo(nextQuad.points[2]!.y, 6);
+				}
+			}
+		}
+	});
+
+	it('branchTips anchors use the last junction position (crooked tip)', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 3,
+			branchCrookedness: 80,
+			branchDepth: 1,
+			seed: 42,
+		});
+		const geo = generateTree(config);
+		// branchTips should equal the tip positions from branchGroups
+		// Each branch group has an origin; the tip is the last segment endpoint
+		expect(geo.anchors.branchTips.length).toBeGreaterThan(0);
+		// All branch tips should be finite numbers
+		for (const tip of geo.anchors.branchTips) {
+			expect(Number.isFinite(tip.x)).toBe(true);
+			expect(Number.isFinite(tip.y)).toBe(true);
+		}
+	});
+
+	it('branchSegments=1 branchCrookedness=0 produces identical output to defaults', () => {
+		// Backwards compatibility: branchSegments=1 means single straight segment
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 1,
+			branchCrookedness: 0,
+			branchDepth: 1,
+			seed: 42,
+		});
+		const geo = generateTree(config);
+		expect(geo.branchGroups.length).toBeGreaterThan(0);
+		for (const group of geo.branchGroups) {
+			expect(group.quads.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -490,6 +490,7 @@ const BACK_BRANCH_LIGHTNESS_OFFSET = -3;
 
 function generateBranchQuadGroup(
 	branch: BranchSegment,
+	path: readonly Point2D[],
 	config: TreeConfig,
 	depth: number,
 	parentIndex: number | null = null,
@@ -510,9 +511,6 @@ function generateBranchQuadGroup(
 		};
 	}
 
-	const perpX = -dirY / length;
-	const perpY = dirX / length;
-
 	// Per-branch PRNG seeded from position to ensure determinism
 	const branchRng = createPrng(
 		config.seed +
@@ -528,6 +526,8 @@ function generateBranchQuadGroup(
 
 	// REQ-EV2-B-02: L3+ uses single plain quad (no strip system)
 	if (depth >= 3) {
+		const perpX = -dirY / length;
+		const perpY = dirX / length;
 		const halfStart = branch.widthStart / 2;
 		const halfEnd = branch.widthEnd / 2;
 		const colors = computeStripColors({
@@ -568,73 +568,110 @@ function generateBranchQuadGroup(
 	const stripCount = config.trunkStripCount;
 	const twistAttenuation = TWIST_ATTENUATION_BY_DEPTH[depth] ?? 0;
 	const effectiveTwist = config.trunkTwist * twistAttenuation;
+	const junctionCount = path.length;
 
-	// Compute strip ratios for branch (2 junctions: start + end)
+	// Compute strip ratios for all junctions (reuses trunk strip ratio model)
 	const branchStripRatios = computeJunctionStripRatios(
 		config.seed + Math.round(branch.x1 * 100) + Math.round(branch.y1 * 100),
-		2,
+		junctionCount,
 		stripCount,
 		effectiveTwist,
 	);
 
-	const stripColors = computeStripColors({
-		segmentDirectionX: dirX,
-		segmentDirectionY: dirY,
-		lightAngle: config.lightAngle,
-		trunkHue: config.trunkHue,
-		trunkSaturation: config.trunkSaturation,
-		trunkLightness: config.trunkLightness,
-		centerPerturbationX: centerPerturbX,
-		centerPerturbationY: centerPerturbY,
-		stripCount,
-		lightnessOffset: branchLightnessOffset,
-	});
+	// Compute bisector perpendicular directions at each junction
+	const bisectors = computeJunctionBisectors(path);
 
-	// Compute edge points at start and end using strip ratios
-	function computeEdgePoints(cx: number, cy: number, half: number, ratios: number[]): Point2D[] {
-		const points: Point2D[] = [];
-		points.push({ x: cx + perpX * half, y: cy + perpY * half });
-		let accRatio = 0;
-		for (let s = 0; s < stripCount - 1; s++) {
-			accRatio += ratios[s]!;
-			const offset = half - accRatio * half * 2;
-			points.push({ x: cx + perpX * offset, y: cy + perpY * offset });
-		}
-		points.push({ x: cx - perpX * half, y: cy - perpY * half });
-		return points;
+	// Compute widths at each junction (linear taper from widthStart to widthEnd)
+	const junctionWidths: number[] = [];
+	for (let j = 0; j < junctionCount; j++) {
+		const t = junctionCount > 1 ? j / (junctionCount - 1) : 0;
+		junctionWidths.push(branch.widthStart + t * (branch.widthEnd - branch.widthStart));
 	}
 
-	const halfStart = branch.widthStart / 2;
-	const halfEnd = branch.widthEnd / 2;
-	const startPoints = computeEdgePoints(branch.x1, branch.y1, halfStart, branchStripRatios[0]!);
-	const endPoints = computeEdgePoints(branch.x2, branch.y2, halfEnd, branchStripRatios[1]!);
+	// Compute shared junction edge points (same model as trunk — REQ-EV2-J-02)
+	const junctionEdgePoints = computeJunctionEdgePoints(
+		path,
+		bisectors,
+		junctionWidths,
+		branchStripRatios,
+		stripCount,
+	);
 
 	const quads: Quad[] = [];
-	for (let s = 0; s < stripCount; s++) {
-		quads.push({
-			points: [startPoints[s]!, startPoints[s + 1]!, endPoints[s + 1]!, endPoints[s]!],
-			color: stripColors[s]!,
-			group: GEOMETRY_GROUPS.branch,
+
+	// Build quads between adjacent junctions, iterating like trunk
+	for (let i = 0; i < junctionCount - 1; i++) {
+		const bottomPoints = junctionEdgePoints[i]!;
+		const topPoints = junctionEdgePoints[i + 1]!;
+
+		const segDirX = path[i + 1]!.x - path[i]!.x;
+		const segDirY = path[i + 1]!.y - path[i]!.y;
+
+		// Per-segment strip colors (consistent lighting per segment)
+		const stripColors = computeStripColors({
+			segmentDirectionX: segDirX,
+			segmentDirectionY: segDirY,
+			lightAngle: config.lightAngle,
+			trunkHue: config.trunkHue,
+			trunkSaturation: config.trunkSaturation,
+			trunkLightness: config.trunkLightness,
+			centerPerturbationX: centerPerturbX,
+			centerPerturbationY: centerPerturbY,
+			stripCount,
+			lightnessOffset: branchLightnessOffset,
 		});
+
+		for (let s = 0; s < stripCount; s++) {
+			quads.push({
+				points: [topPoints[s]!, topPoints[s + 1]!, bottomPoints[s + 1]!, bottomPoints[s]!],
+				color: stripColors[s]!,
+				group: GEOMETRY_GROUPS.branch,
+			});
+		}
 	}
 
-	// REQ-EV2-F-02: junction collar quad at fork point
-	// The collar bridges between the trunk edge and branch start, colored with the
-	// outermost strip color from the branch side (peel-off continuity).
+	// REQ-EV2-F-02: junction collar quad at fork point (base junction only)
 	const junctionFills: Quad[] = [];
-	const collarLength = Math.min(3, length * 0.15);
+	const firstSegDirX = path[1]!.x - path[0]!.x;
+	const firstSegDirY = path[1]!.y - path[0]!.y;
+	const firstSegLen = Math.sqrt(firstSegDirX * firstSegDirX + firstSegDirY * firstSegDirY);
+	const collarLength = Math.min(3, firstSegLen * 0.15);
 	if (collarLength > 0.5) {
-		const collarColor = stripColors[0]!;
-		// Collar extends from branch origin slightly along the branch direction
-		const collarEndX = branch.x1 + (dirX / length) * collarLength;
-		const collarEndY = branch.y1 + (dirY / length) * collarLength;
+		const baseBisector = bisectors[0]!;
+		const halfStart = junctionWidths[0]! / 2;
+		const collarColor = computeStripColors({
+			segmentDirectionX: firstSegDirX,
+			segmentDirectionY: firstSegDirY,
+			lightAngle: config.lightAngle,
+			trunkHue: config.trunkHue,
+			trunkSaturation: config.trunkSaturation,
+			trunkLightness: config.trunkLightness,
+			centerPerturbationX: centerPerturbX,
+			centerPerturbationY: centerPerturbY,
+			stripCount,
+			lightnessOffset: branchLightnessOffset,
+		})[0]!;
+		const collarEndX = path[0]!.x + (firstSegDirX / firstSegLen) * collarLength;
+		const collarEndY = path[0]!.y + (firstSegDirY / firstSegLen) * collarLength;
 		const collarHalfEnd = halfStart * 0.85;
 		junctionFills.push({
 			points: [
-				{ x: branch.x1 + perpX * halfStart * 1.1, y: branch.y1 + perpY * halfStart * 1.1 },
-				{ x: branch.x1 - perpX * halfStart * 1.1, y: branch.y1 - perpY * halfStart * 1.1 },
-				{ x: collarEndX - perpX * collarHalfEnd, y: collarEndY - perpY * collarHalfEnd },
-				{ x: collarEndX + perpX * collarHalfEnd, y: collarEndY + perpY * collarHalfEnd },
+				{
+					x: path[0]!.x + baseBisector.perpX * halfStart * 1.1,
+					y: path[0]!.y + baseBisector.perpY * halfStart * 1.1,
+				},
+				{
+					x: path[0]!.x - baseBisector.perpX * halfStart * 1.1,
+					y: path[0]!.y - baseBisector.perpY * halfStart * 1.1,
+				},
+				{
+					x: collarEndX - baseBisector.perpX * collarHalfEnd,
+					y: collarEndY - baseBisector.perpY * collarHalfEnd,
+				},
+				{
+					x: collarEndX + baseBisector.perpX * collarHalfEnd,
+					y: collarEndY + baseBisector.perpY * collarHalfEnd,
+				},
 			],
 			color: collarColor,
 			group: GEOMETRY_GROUPS.branch,
@@ -659,6 +696,7 @@ function generateAllBranchQuads(
 	return branches.map((branch, i) =>
 		generateBranchQuadGroup(
 			branch.segment,
+			branch.path,
 			config,
 			branch.depth,
 			branch.parentIndex,
@@ -1051,6 +1089,10 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 			);
 	const extraBranches: GeneratedBranch[] = extraSegments.map((seg) => ({
 		segment: seg,
+		path: [
+			{ x: seg.x1, y: seg.y1 },
+			{ x: seg.x2, y: seg.y2 },
+		],
 		depth: 1,
 		parentIndex: null,
 	}));
@@ -1079,6 +1121,10 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 				widthStart: 3 * (config.branchThickness / 100),
 				widthEnd: 1,
 			},
+			path: [
+				{ x: topJunction.x, y: topJunction.y },
+				{ x: targetX, y: targetY },
+			],
 			depth: 1,
 			parentIndex: null,
 		});

--- a/src/lib/trees/shapes.test.ts
+++ b/src/lib/trees/shapes.test.ts
@@ -14,6 +14,9 @@ import {
 	computeZoneSplit,
 	generateCustomBlobs,
 	growCustomBlobs,
+	buildBranchPath,
+	computeEffectiveBranchSegments,
+	samplePointAlongPath,
 	CUSTOM_BLOB_CANOPY_CENTER_X,
 	CUSTOM_BLOB_CANOPY_CENTER_Y,
 	CUSTOM_BLOB_SPREAD_RADIUS,
@@ -771,6 +774,249 @@ describe('generateBranches — visibility & crossing invariants', () => {
 });
 
 // ============================================================================
+// Issue #105: multi-junction branch path integration
+// ============================================================================
+
+describe('generateBranches — multi-junction paths (issue #105)', () => {
+	it('branchSegments=3 L1 branches have path.length === 4', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 3,
+			branchCrookedness: 50,
+			branchDepth: 1,
+			seed: 42,
+			trunkSegments: 5,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const { branches } = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		expect(branches.length).toBeGreaterThan(0);
+		for (const b of branches) {
+			expect(b.path).toHaveLength(4); // 3 segments + 1
+		}
+	});
+
+	it('branchSegments=3 L2 branches have path.length === 3', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchesLevel2Range: [2, 3],
+			branchSegments: 3,
+			branchCrookedness: 50,
+			branchDepth: 2,
+			seed: 42,
+			trunkSegments: 5,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const { branches } = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		const l2Branches = branches.filter((b) => b.depth === 2);
+		expect(l2Branches.length).toBeGreaterThan(0);
+		for (const b of l2Branches) {
+			expect(b.path).toHaveLength(3); // max(3-1,1)=2 segments + 1
+		}
+	});
+
+	it('branchSegments=3 L3 branches have path.length === 2 (always straight)', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchesLevel2Range: [2, 2],
+			branchesLevel3Range: [1, 2],
+			branchSegments: 3,
+			branchCrookedness: 50,
+			branchDepth: 3,
+			seed: 42,
+			trunkSegments: 5,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const { branches } = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		const l3Branches = branches.filter((b) => b.depth === 3);
+		if (l3Branches.length > 0) {
+			for (const b of l3Branches) {
+				expect(b.path).toHaveLength(2); // 1 segment + 1
+			}
+		}
+	});
+
+	it('branchSegments=1 produces path.length === 2 (backwards compatible)', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 1,
+			branchCrookedness: 50,
+			branchDepth: 1,
+			seed: 42,
+			trunkSegments: 5,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const { branches } = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		expect(branches.length).toBeGreaterThan(0);
+		for (const b of branches) {
+			expect(b.path).toHaveLength(2);
+		}
+	});
+
+	it('branchCrookedness=0 produces collinear path junctions', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 3,
+			branchCrookedness: 0,
+			branchDepth: 1,
+			seed: 42,
+			trunkSegments: 5,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const { branches } = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		expect(branches.length).toBeGreaterThan(0);
+		for (const b of branches) {
+			const first = b.path[0]!;
+			const last = b.path[b.path.length - 1]!;
+			const dx = last.x - first.x;
+			const dy = last.y - first.y;
+			const len = Math.sqrt(dx * dx + dy * dy);
+			for (const junction of b.path) {
+				const cross =
+					Math.abs((junction.x - first.x) * dy - (junction.y - first.y) * dx) / len;
+				expect(cross).toBeLessThan(1e-6);
+			}
+		}
+	});
+
+	it('path[0] matches segment start, path[last] matches segment end', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchSegments: 3,
+			branchCrookedness: 50,
+			branchDepth: 1,
+			seed: 42,
+			trunkSegments: 5,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const { branches } = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		for (const b of branches) {
+			expect(b.path[0]!.x).toBeCloseTo(b.segment.x1, 6);
+			expect(b.path[0]!.y).toBeCloseTo(b.segment.y1, 6);
+			expect(b.path[b.path.length - 1]!.x).toBeCloseTo(b.segment.x2, 6);
+			expect(b.path[b.path.length - 1]!.y).toBeCloseTo(b.segment.y2, 6);
+		}
+	});
+
+	it('L2 origin lies on parent crooked path (distance < 1px)', () => {
+		const config = makeConfig({
+			shape: 'oak',
+			branchesLevel1Range: [3, 3],
+			branchesLevel2Range: [2, 3],
+			branchSegments: 3,
+			branchCrookedness: 50,
+			branchDepth: 2,
+			seed: 42,
+			trunkSegments: 5,
+		});
+		const { rng, trunkTop, trunkBottom, trunkTopWidth, trunkJunctions, blobs } =
+			setupOakBranchInputs(config);
+		const { branches } = generateBranches(
+			rng,
+			trunkTop,
+			trunkBottom,
+			trunkTopWidth,
+			config,
+			trunkJunctions,
+			blobs,
+		);
+		const l2Branches = branches.filter((b) => b.depth === 2);
+		expect(l2Branches.length).toBeGreaterThan(0);
+		for (const child of l2Branches) {
+			const parent = branches[child.parentIndex!]!;
+			// Compute min distance from child origin to any sub-segment of parent path
+			let minDist = Infinity;
+			for (let s = 0; s < parent.path.length - 1; s++) {
+				const ax = parent.path[s]!.x;
+				const ay = parent.path[s]!.y;
+				const bx = parent.path[s + 1]!.x;
+				const by = parent.path[s + 1]!.y;
+				const dx = bx - ax;
+				const dy = by - ay;
+				const lenSq = dx * dx + dy * dy;
+				const t =
+					lenSq > 0
+						? Math.max(
+								0,
+								Math.min(
+									1,
+									((child.segment.x1 - ax) * dx + (child.segment.y1 - ay) * dy) /
+										lenSq,
+								),
+							)
+						: 0;
+				const projX = ax + t * dx;
+				const projY = ay + t * dy;
+				const dist = Math.sqrt(
+					(child.segment.x1 - projX) ** 2 + (child.segment.y1 - projY) ** 2,
+				);
+				minDist = Math.min(minDist, dist);
+			}
+			expect(minDist).toBeLessThan(1);
+		}
+	});
+});
+
+// ============================================================================
 // REQ-C-18: oak non-primary blobs distributed radially (full 360°)
 // ============================================================================
 
@@ -1347,5 +1593,179 @@ describe('B7: willow redesign', () => {
 		const willowMeanCy = willowBlobs.reduce((s, b) => s + b.cy, 0) / willowBlobs.length;
 		const oakMeanCy = oakBlobs.reduce((s, b) => s + b.cy, 0) / oakBlobs.length;
 		expect(willowMeanCy).toBeGreaterThan(oakMeanCy);
+	});
+});
+
+// ============================================================================
+// Issue #105: buildBranchPath — multi-junction crooked branch paths
+// ============================================================================
+
+describe('buildBranchPath', () => {
+	it('segments=1 returns 2-point path (straight)', () => {
+		const path = buildBranchPath(createPrng(42), 100, 200, 150, 150, 1, 50, 'alternating');
+		expect(path).toHaveLength(2);
+		expect(path[0]).toEqual({ x: 100, y: 200 });
+	});
+
+	it('segments=3 returns 4 junctions', () => {
+		const path = buildBranchPath(createPrng(42), 100, 200, 200, 100, 3, 50, 'alternating');
+		expect(path).toHaveLength(4);
+	});
+
+	it('crookedness=0 produces collinear junctions at any segment count', () => {
+		const path = buildBranchPath(createPrng(42), 100, 200, 200, 100, 3, 0, 'alternating');
+		expect(path).toHaveLength(4);
+		// All junctions should lie on the line from start to end
+		const dx = 200 - 100;
+		const dy = 100 - 200;
+		for (const junction of path) {
+			// Cross product of (junction - start) × (end - start) should be ~0
+			const cross = (junction.x - 100) * dy - (junction.y - 200) * dx;
+			expect(Math.abs(cross)).toBeLessThan(1e-6);
+		}
+	});
+
+	it('crookedness=50 produces non-collinear junctions with segments>1', () => {
+		const path = buildBranchPath(createPrng(42), 100, 200, 200, 100, 3, 50, 'alternating');
+		// At least one internal junction should deviate from the straight line
+		const dx = 200 - 100;
+		const dy = 100 - 200;
+		const len = Math.sqrt(dx * dx + dy * dy);
+		let maxDeviation = 0;
+		for (let i = 1; i < path.length - 1; i++) {
+			const cross = Math.abs((path[i]!.x - 100) * dy - (path[i]!.y - 200) * dx) / len;
+			maxDeviation = Math.max(maxDeviation, cross);
+		}
+		expect(maxDeviation).toBeGreaterThan(0.1);
+	});
+
+	it('first junction is always at start point', () => {
+		const path = buildBranchPath(createPrng(42), 50, 80, 200, 30, 3, 70, 'random');
+		expect(path[0]).toEqual({ x: 50, y: 80 });
+	});
+
+	it('same seed + config produces identical paths', () => {
+		const p1 = buildBranchPath(createPrng(42), 100, 200, 200, 100, 3, 50, 'alternating');
+		const p2 = buildBranchPath(createPrng(42), 100, 200, 200, 100, 3, 50, 'alternating');
+		expect(p1).toEqual(p2);
+	});
+
+	it('segments clamped to [1, 5]', () => {
+		const p0 = buildBranchPath(createPrng(42), 0, 0, 100, 0, 0, 50, 'alternating');
+		expect(p0).toHaveLength(2);
+		const p9 = buildBranchPath(createPrng(42), 0, 0, 100, 0, 9, 50, 'alternating');
+		expect(p9).toHaveLength(6);
+	});
+
+	it('works for horizontal branches', () => {
+		const path = buildBranchPath(createPrng(42), 100, 150, 200, 150, 3, 50, 'alternating');
+		expect(path).toHaveLength(4);
+		expect(path[0]).toEqual({ x: 100, y: 150 });
+	});
+
+	it('works for vertical branches', () => {
+		const path = buildBranchPath(createPrng(42), 100, 200, 100, 100, 3, 50, 'alternating');
+		expect(path).toHaveLength(4);
+		expect(path[0]).toEqual({ x: 100, y: 200 });
+	});
+
+	it('zero-length branch returns 2 identical junctions', () => {
+		const path = buildBranchPath(createPrng(42), 100, 200, 100, 200, 3, 50, 'alternating');
+		expect(path).toHaveLength(2);
+		expect(path[0]).toEqual(path[1]);
+	});
+});
+
+// ============================================================================
+// Issue #105: computeEffectiveBranchSegments — per-depth reduction
+// ============================================================================
+
+describe('computeEffectiveBranchSegments', () => {
+	it('L1 (depth 1) returns config value', () => {
+		expect(computeEffectiveBranchSegments(3, 1)).toBe(3);
+	});
+
+	it('L2 (depth 2) returns max(config - 1, 1)', () => {
+		expect(computeEffectiveBranchSegments(3, 2)).toBe(2);
+		expect(computeEffectiveBranchSegments(1, 2)).toBe(1);
+	});
+
+	it('L3 (depth 3) always returns 1', () => {
+		expect(computeEffectiveBranchSegments(3, 3)).toBe(1);
+		expect(computeEffectiveBranchSegments(5, 3)).toBe(1);
+	});
+
+	it('depth > 3 always returns 1', () => {
+		expect(computeEffectiveBranchSegments(3, 4)).toBe(1);
+	});
+});
+
+// ============================================================================
+// Issue #105: samplePointAlongPath — piecewise linear sampling
+// ============================================================================
+
+describe('samplePointAlongPath', () => {
+	it('t=0 returns first junction', () => {
+		const path = [
+			{ x: 0, y: 0 },
+			{ x: 100, y: 0 },
+		];
+		const p = samplePointAlongPath(path, 0);
+		expect(p.x).toBeCloseTo(0, 10);
+		expect(p.y).toBeCloseTo(0, 10);
+	});
+
+	it('t=1 returns last junction', () => {
+		const path = [
+			{ x: 0, y: 0 },
+			{ x: 100, y: 0 },
+		];
+		const p = samplePointAlongPath(path, 1);
+		expect(p.x).toBeCloseTo(100, 10);
+		expect(p.y).toBeCloseTo(0, 10);
+	});
+
+	it('t=0.5 on 2-point path returns midpoint', () => {
+		const path = [
+			{ x: 0, y: 0 },
+			{ x: 100, y: 0 },
+		];
+		const p = samplePointAlongPath(path, 0.5);
+		expect(p.x).toBeCloseTo(50, 10);
+		expect(p.y).toBeCloseTo(0, 10);
+	});
+
+	it('correctly interpolates multi-segment path', () => {
+		// 3-segment path: (0,0)→(100,0)→(100,100)→(200,100), each segment length=100
+		// Total length = 300, t=0.5 → distance 150 → midpoint of second segment → (100,50)
+		const path = [
+			{ x: 0, y: 0 },
+			{ x: 100, y: 0 },
+			{ x: 100, y: 100 },
+			{ x: 200, y: 100 },
+		];
+		const p = samplePointAlongPath(path, 0.5);
+		expect(p.x).toBeCloseTo(100, 6);
+		expect(p.y).toBeCloseTo(50, 6);
+	});
+
+	it('clamps t < 0 to first junction', () => {
+		const path = [
+			{ x: 10, y: 20 },
+			{ x: 110, y: 20 },
+		];
+		const p = samplePointAlongPath(path, -0.5);
+		expect(p.x).toBeCloseTo(10, 10);
+		expect(p.y).toBeCloseTo(20, 10);
+	});
+
+	it('clamps t > 1 to last junction', () => {
+		const path = [
+			{ x: 10, y: 20 },
+			{ x: 110, y: 20 },
+		];
+		const p = samplePointAlongPath(path, 1.5);
+		expect(p.x).toBeCloseTo(110, 10);
+		expect(p.y).toBeCloseTo(20, 10);
 	});
 });

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -36,6 +36,9 @@ export {
 
 export {
 	generateBranches,
+	buildBranchPath,
+	computeEffectiveBranchSegments,
+	samplePointAlongPath,
 	type GeneratedBranch,
 	type ForkReduction,
 } from './shapes/branch_generation.js';

--- a/src/lib/trees/shapes/branch_generation.ts
+++ b/src/lib/trees/shapes/branch_generation.ts
@@ -1,5 +1,5 @@
-import type { TreeConfig, Point2D } from '../types.js';
-import { VIEWBOX_WIDTH } from '../types.js';
+import type { TreeConfig, Point2D, CrookednessMode } from '../types.js';
+import { CROOKEDNESS_MODES, VIEWBOX_WIDTH } from '../types.js';
 import { randomInRange } from '../prng.js';
 import { sampleTrunkCenterX, computeZoneSplit } from './trunk.js';
 import { isPointInSingleBlob, getBlobsBounds } from './shape_bounds.js';
@@ -9,6 +9,189 @@ import {
 	resolveBranchLengthRange,
 } from './geometry.js';
 import type { Blob, BranchSegment } from './shape_types.js';
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function lerp(a: number, b: number, t: number): number {
+	return a + (b - a) * t;
+}
+
+// ---------------------------------------------------------------------------
+// Branch path building (issue #105 — multi-junction branches)
+// ---------------------------------------------------------------------------
+
+/** Maximum absolute angle from branch axis (degrees) to prevent self-intersection. */
+const MAX_BRANCH_ABSOLUTE_ANGLE_DEG = 85;
+
+/**
+ * Compute effective branch segments per depth (REQ-EV2-B-04):
+ * L1 = config, L2 = max(config-1, 1), L3+ = 1.
+ */
+export function computeEffectiveBranchSegments(configSegments: number, depth: number): number {
+	if (depth >= 3) {
+		return 1;
+	}
+	if (depth === 2) {
+		return Math.max(configSegments - 1, 1);
+	}
+	return configSegments;
+}
+
+/**
+ * Build a crooked polyline path for a branch. Analogous to trunk's
+ * `buildCrookedPath` but works in the branch's local coordinate frame
+ * (arbitrary direction, not just vertical).
+ *
+ * Uses the same jitter model as the trunk: cumulative angle from branch
+ * axis, per-junction jitter reduction, segment length variation, and
+ * alternating/random mode.
+ */
+export function buildBranchPath(
+	rng: () => number,
+	startX: number,
+	startY: number,
+	endX: number,
+	endY: number,
+	segments: number,
+	crookedness: number,
+	crookednessMode: CrookednessMode,
+): Point2D[] {
+	const segmentCount = Math.max(1, Math.min(5, Math.round(segments)));
+	const clampedCrookedness = Math.max(0, Math.min(100, crookedness));
+
+	const totalDx = endX - startX;
+	const totalDy = endY - startY;
+	const totalLength = Math.sqrt(totalDx * totalDx + totalDy * totalDy);
+
+	if (totalLength === 0) {
+		return [
+			{ x: startX, y: startY },
+			{ x: endX, y: endY },
+		];
+	}
+
+	// Unit vectors along branch axis and perpendicular
+	const axisX = totalDx / totalLength;
+	const axisY = totalDy / totalLength;
+	const perpX = -axisY;
+	const perpY = axisX;
+
+	const baseSegmentLen = totalLength / segmentCount;
+
+	// Segment length variation: only when crookedness > 0 (same as trunk)
+	let segmentMultipliers: number[] | null = null;
+	let normalizeScale = 1;
+	if (clampedCrookedness > 0) {
+		segmentMultipliers = [];
+		let multiplierSum = 0;
+		for (let i = 0; i < segmentCount; i++) {
+			const mult = 0.7 + rng() * 0.6; // 0.7-1.3 range (+/-30%)
+			segmentMultipliers.push(mult);
+			multiplierSum += mult;
+		}
+		normalizeScale = segmentCount / multiplierSum;
+	}
+
+	const junctions: Point2D[] = [{ x: startX, y: startY }];
+
+	const maxJitterDeg = lerp(0, 90, clampedCrookedness / 100);
+	const maxAbsoluteRad = (MAX_BRANCH_ABSOLUTE_ANGLE_DEG * Math.PI) / 180;
+
+	let currentAngleRad = 0; // Angle relative to branch axis
+	let alternatingSign = clampedCrookedness > 0 ? (rng() < 0.5 ? -1 : 1) : 1;
+	let cumulativeAxisLen = 0;
+	let cumulativePerpOffset = 0;
+
+	for (let i = 1; i <= segmentCount; i++) {
+		const segmentLen =
+			segmentMultipliers !== null
+				? baseSegmentLen * segmentMultipliers[i - 1]! * normalizeScale
+				: baseSegmentLen;
+
+		if (i > 1 && clampedCrookedness > 0) {
+			// Per-junction jitter reduction: up to 50% of max
+			const jitterReduction = 0.5 + rng() * 0.5; // 0.5-1.0 multiplier
+			const effectiveMaxJitter = maxJitterDeg * jitterReduction;
+
+			let jitterSign: number;
+			if (crookednessMode === CROOKEDNESS_MODES.alternating) {
+				alternatingSign *= -1;
+				jitterSign = alternatingSign;
+			} else {
+				jitterSign = rng() < 0.5 ? -1 : 1;
+			}
+
+			const jitterDeg =
+				randomInRange(rng, effectiveMaxJitter * 0.3, effectiveMaxJitter) * jitterSign;
+			currentAngleRad += (jitterDeg * Math.PI) / 180;
+			currentAngleRad = Math.max(-maxAbsoluteRad, Math.min(maxAbsoluteRad, currentAngleRad));
+		}
+
+		cumulativeAxisLen += segmentLen;
+		cumulativePerpOffset += segmentLen * Math.tan(currentAngleRad);
+
+		junctions.push({
+			x: startX + axisX * cumulativeAxisLen + perpX * cumulativePerpOffset,
+			y: startY + axisY * cumulativeAxisLen + perpY * cumulativePerpOffset,
+		});
+	}
+
+	return junctions;
+}
+
+/**
+ * Sample a point along a polyline path at parametric position t ∈ [0,1].
+ * Piecewise-linear interpolation: t=0 → first junction, t=1 → last junction.
+ */
+export function samplePointAlongPath(path: readonly Point2D[], t: number): Point2D {
+	if (path.length < 2) {
+		return path[0]!;
+	}
+
+	// Fast-path exact endpoints to avoid float-accumulation drift
+	if (t <= 0) {
+		return path[0]!;
+	}
+	if (t >= 1) {
+		return path[path.length - 1]!;
+	}
+
+	const clampedT = t;
+
+	// Compute cumulative segment lengths
+	let totalLength = 0;
+	const segmentLengths: number[] = [];
+	for (let i = 0; i < path.length - 1; i++) {
+		const dx = path[i + 1]!.x - path[i]!.x;
+		const dy = path[i + 1]!.y - path[i]!.y;
+		const len = Math.sqrt(dx * dx + dy * dy);
+		segmentLengths.push(len);
+		totalLength += len;
+	}
+
+	if (totalLength === 0) {
+		return path[0]!;
+	}
+
+	const targetDistance = clampedT * totalLength;
+	let accumulated = 0;
+
+	for (let i = 0; i < segmentLengths.length; i++) {
+		const segLen = segmentLengths[i]!;
+		if (accumulated + segLen >= targetDistance || i === segmentLengths.length - 1) {
+			const localT = segLen > 0 ? (targetDistance - accumulated) / segLen : 0;
+			return {
+				x: path[i]!.x + localT * (path[i + 1]!.x - path[i]!.x),
+				y: path[i]!.y + localT * (path[i + 1]!.y - path[i]!.y),
+			};
+		}
+		accumulated += segLen;
+	}
+
+	return path[path.length - 1]!;
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -43,6 +226,8 @@ const TRUNK_BRANCH_BASE_MAX = VIEWBOX_WIDTH * 0.4;
 
 export interface GeneratedBranch {
 	readonly segment: BranchSegment;
+	/** Ordered junction list: path[0] = branch origin, path[last] = tip. */
+	readonly path: readonly Point2D[];
 	readonly depth: number;
 	readonly parentIndex: number | null;
 }
@@ -353,7 +538,24 @@ function generateTrunkBranches(ctx: BranchContext, branches: GeneratedBranch[]):
 		}
 
 		if (accepted !== null) {
-			branches.push({ segment: accepted, depth: 1, parentIndex: null });
+			const effectiveSegments = computeEffectiveBranchSegments(config.branchSegments, 1);
+			const path = buildBranchPath(
+				rng,
+				accepted.x1,
+				accepted.y1,
+				accepted.x2,
+				accepted.y2,
+				effectiveSegments,
+				config.branchCrookedness,
+				config.crookednessMode,
+			);
+			const tip = path[path.length - 1]!;
+			const segmentWithCrookedTip: BranchSegment = {
+				...accepted,
+				x2: tip.x,
+				y2: tip.y,
+			};
+			branches.push({ segment: segmentWithCrookedTip, path, depth: 1, parentIndex: null });
 		}
 	}
 }
@@ -386,16 +588,25 @@ function generateSubBranches(
 			return;
 		}
 
-		const parent = branches[parentIndex]!.segment;
+		const parentBranch = branches[parentIndex]!;
+		const parent = parentBranch.segment;
+		const parentPath = parentBranch.path;
 		const childCount = sampleBranchCountForLevel(rng, config, targetDepth);
 		if (childCount <= 0) {
 			continue;
 		}
 
 		// BR-5: Children originate from upper 50-100% of parent length
+		// Compute parent length from the crooked path (piecewise sum)
+		let parentLength = 0;
+		for (let s = 0; s < parentPath.length - 1; s++) {
+			const dx = parentPath[s + 1]!.x - parentPath[s]!.x;
+			const dy = parentPath[s + 1]!.y - parentPath[s]!.y;
+			parentLength += Math.sqrt(dx * dx + dy * dy);
+		}
+		// Overall parent direction (start to tip) for angle divergence
 		const parentDirX = parent.x2 - parent.x1;
 		const parentDirY = parent.y2 - parent.y1;
-		const parentLength = Math.sqrt(parentDirX * parentDirX + parentDirY * parentDirY);
 		const parentAngle = Math.atan2(parentDirY, parentDirX);
 
 		for (let c = 0; c < childCount; c++) {
@@ -406,10 +617,11 @@ function generateSubBranches(
 			let accepted: BranchSegment | null = null;
 
 			for (let attempt = 0; attempt < BRANCH_RETRY_ATTEMPTS; attempt++) {
-				// Origin along upper 50-100% of parent
+				// Origin along upper 50-100% of parent — sample the crooked path
 				const originT = randomInRange(rng, 0.5, 1.0);
-				const originX = parent.x1 + parentDirX * originT;
-				const originY = parent.y1 + parentDirY * originT;
+				const origin = samplePointAlongPath(parentPath, originT);
+				const originX = origin.x;
+				const originY = origin.y;
 
 				// Rule K: child length 20-80% of parent
 				const lengthRatio = randomInRange(
@@ -472,7 +684,32 @@ function generateSubBranches(
 			}
 
 			if (accepted !== null) {
-				branches.push({ segment: accepted, depth: targetDepth, parentIndex });
+				const effectiveSegments = computeEffectiveBranchSegments(
+					config.branchSegments,
+					targetDepth,
+				);
+				const childPath = buildBranchPath(
+					rng,
+					accepted.x1,
+					accepted.y1,
+					accepted.x2,
+					accepted.y2,
+					effectiveSegments,
+					config.branchCrookedness,
+					config.crookednessMode,
+				);
+				const tip = childPath[childPath.length - 1]!;
+				const segmentWithCrookedTip: BranchSegment = {
+					...accepted,
+					x2: tip.x,
+					y2: tip.y,
+				};
+				branches.push({
+					segment: segmentWithCrookedTip,
+					path: childPath,
+					depth: targetDepth,
+					parentIndex,
+				});
 			}
 		}
 	}
@@ -558,15 +795,21 @@ export function generateBranches(
 		const originY = trunkTop + trunkHeight * branchT;
 		const originX = sampleTrunkCenterX(trunkJunctions, originY);
 
+		const fallbackSegment: BranchSegment = {
+			x1: originX,
+			y1: originY,
+			x2: blob.cx,
+			y2: blob.cy,
+			widthStart: randomInRange(rng, 5.25, 8.75) * branchThicknessScale,
+			widthEnd: randomInRange(rng, 1.75, 3.5) * branchThicknessScale,
+		};
+		// Fallback branches are straight (no crookedness) — emergency connectors
 		branches.push({
-			segment: {
-				x1: originX,
-				y1: originY,
-				x2: blob.cx,
-				y2: blob.cy,
-				widthStart: randomInRange(rng, 5.25, 8.75) * branchThicknessScale,
-				widthEnd: randomInRange(rng, 1.75, 3.5) * branchThicknessScale,
-			},
+			segment: fallbackSegment,
+			path: [
+				{ x: originX, y: originY },
+				{ x: blob.cx, y: blob.cy },
+			],
 			depth: 1,
 			parentIndex: null,
 		});


### PR DESCRIPTION
## Description
- Bring branches to parity with trunk multi-junction model: `buildBranchPath` builds crooked polylines in branch-local coordinate frame
- `computeEffectiveBranchSegments` implements REQ-EV2-B-04: L1=config, L2=max(config-1,1), L3=1
- `samplePointAlongPath` for piecewise-linear L2 origin sampling along parent crooked path
- Rewrote `generateBranchQuadGroup` to iterate junctions using shared edge vertices via `computeJunctionBisectors`/`StripRatios`/`EdgePoints` (same functions as trunk)
- `segment.x2/y2` updated to match crooked tip for all downstream consumers (anchors, canopy clustering, z-order)

## Resolves
Closes #105

## Testing
- [x] `buildBranchPath` unit tests: segments=1/3, crookedness=0/50, collinearity, determinism, edge cases
- [x] `computeEffectiveBranchSegments` unit tests: L1/L2/L3/L4 depth coverage
- [x] `samplePointAlongPath` unit tests: t=0/0.5/1, multi-segment, clamping
- [x] Integration tests: path length per depth, collinearity at crookedness=0, path↔segment consistency, L2 origin on parent path (<1px)
- [x] Quad generation tests: more quads with segments=3, junction vertex sharing
- [x] All 2320 tests pass, `pnpm check:all` clean