### PR TITLE
#106 fix(engine): canopy-size cliff — single canopy system, envelope retune, debug viz

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -49,7 +49,7 @@ All parameters are read-only. Defaults apply when a value is omitted.
 | REQ-P-17 | `blobCloseness`     | `number`                                                     | `50`      | 20 – 80      | 1     | "50 %"                  |
 | REQ-P-18 | `trunkThickness`    | `number`                                                     | `100`     | 25 – 400     | 5     | "100 %"                 |
 | REQ-P-19 | `branchThickness`   | `number`                                                     | `100`     | 25 – 400     | 5     | "100 %"                 |
-| REQ-P-20 | `canopySize`        | `number`                                                     | `100`     | 25 – 400     | 5     | "100 %"                 |
+| REQ-P-20 | `canopySize`        | `number`                                                     | `100`     | 25 – 200     | 5     | "100 %"                 |
 | REQ-P-21 | `trunkHeight`       | `number`                                                     | `100`     | 30 – 150     | 5     | "100 %"                 |
 | REQ-P-22 | `trunkBranchRatio`  | `number`                                                     | `70`      | 40 – 80      | 5     | "70 %"                  |
 
@@ -503,6 +503,8 @@ Trunk color UI includes preset swatch buttons that set all three HSL sliders at 
     - Fir: `branchCount` disabled (always 0)
     - Pine/Fir: `trunkBranchRatio` disabled
     - `trunkCrookedness` disabled when `trunkSegments = 1`
+    - `blobCloseness` disabled for branching shapes (oak, birch, maple, willow, apple, cherry,
+      baobab, acacia) — closeness is moot when blob positions are driven by branch-tip clusters
 
 ### 8.6 Color picker UI
 
@@ -788,20 +790,20 @@ Trunk color UI includes preset swatch buttons that set all three HSL sliders at 
 
 - [ ] **REQ-EV2-TZ-03** Updated SHAPE_DEFAULTS for `trunkSegments`:
 
-                                                                                                    | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
-                                                                                                    |---------|---------|--------|-------------|---------------------------|
-                                                                                                    | oak     | 5       | 3      | 5           | 1 + 4                     |
-                                                                                                    | maple   | 3       | 5      | 7           | 2 + 5                     |
-                                                                                                    | willow  | 5       | 5      | 7           | 2 + 5                     |
-                                                                                                    | cherry  | 3       | 4      | 6           | 1 + 5                     |
-                                                                                                    | birch   | 3       | 2      | 4           | 1 + 3                     |
-                                                                                                    | apple   | 3       | 2      | 3           | 1 + 2                     |
-                                                                                                    | baobab  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                                    | acacia  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                                    | pine    | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                    | fir     | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                    | cypress | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                    | bush    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                    | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
+                                                                                                                    |---------|---------|--------|-------------|---------------------------|
+                                                                                                                    | oak     | 5       | 3      | 5           | 1 + 4                     |
+                                                                                                                    | maple   | 3       | 5      | 7           | 2 + 5                     |
+                                                                                                                    | willow  | 5       | 5      | 7           | 2 + 5                     |
+                                                                                                                    | cherry  | 3       | 4      | 6           | 1 + 5                     |
+                                                                                                                    | birch   | 3       | 2      | 4           | 1 + 3                     |
+                                                                                                                    | apple   | 3       | 2      | 3           | 1 + 2                     |
+                                                                                                                    | baobab  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                                                    | acacia  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                                                    | pine    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                    | fir     | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                    | cypress | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                    | bush    | 3       | 0      | 3           | unchanged (no branches)    |
 
 ### 13.6 Bottom-Up Sequential Generation
 
@@ -1019,8 +1021,9 @@ Phase 1 must deliver these interfaces for Phase 2 to consume:
 - [x] **REQ-EV2-CE-02** `canopySize` scales the envelope from its center (grows outward/upward,
       not downward into the trunk).
 
-- [x] **REQ-EV2-CE-03** **Viewport clamp:** the canopy envelope cannot extend within **10 px** of
-      any viewport edge. This prevents canopy overflow regardless of `canopySize` value.
+- [x] **REQ-EV2-CE-03** ~~**Viewport clamp**~~ Removed (issue #106). The canopy envelope grows
+      freely with `canopySize`. SVG overflow clipping (REQ-R-01) handles viewport bounds.
+      `canopySize` slider capped at 200% to limit overflow.
 
 - [x] **REQ-EV2-CE-04** Branch tips **outside** the envelope: their blob is pulled back to the
       envelope edge (smaller blob at boundary). Tips very far outside get no blob — just bare
@@ -1040,16 +1043,16 @@ Phase 1 must deliver these interfaces for Phase 2 to consume:
 
 - [x] **REQ-EV2-SS-02** Shape-specific identity preserved via style parameters:
 
-                                                                                                    | Shape   | Key Characteristics                                                 |
-                                                                                                    |---------|---------------------------------------------------------------------|
-                                                                                                    | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
-                                                                                                    | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
-                                                                                                    | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
-                                                                                                    | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
-                                                                                                    | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
-                                                                                                    | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
-                                                                                                    | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
-                                                                                                    | apple   | Compact round canopy. Minimal branching. Large single blob.         |
+                                                                                                                    | Shape   | Key Characteristics                                                 |
+                                                                                                                    |---------|---------------------------------------------------------------------|
+                                                                                                                    | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
+                                                                                                                    | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
+                                                                                                                    | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
+                                                                                                                    | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
+                                                                                                                    | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
+                                                                                                                    | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
+                                                                                                                    | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
+                                                                                                                    | apple   | Compact round canopy. Minimal branching. Large single blob.         |
 
 - [x] **REQ-EV2-SS-03** Some branch tips will naturally not have blobs — those that fall outside
       the canopy envelope. This is acceptable and realistic (bare branch poking out of canopy).

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -37,6 +37,7 @@
 		showTrunk?: boolean;
 		showFruit?: boolean;
 		showAnchors?: boolean;
+		showEnvelope?: boolean;
 		animateCanopySway?: boolean;
 		animateBranches?: boolean;
 		animateGrowth?: boolean;
@@ -55,6 +56,7 @@
 		showTrunk = true,
 		showFruit = true,
 		showAnchors = false,
+		showEnvelope = false,
 		animateCanopySway = false,
 		animateBranches = false,
 		animateGrowth = false,
@@ -444,6 +446,22 @@
 						stroke-width="0.5"
 					/>
 				{/each}
+			</g>
+		{/if}
+
+		{#if showEnvelope && geometry.canopyEnvelope}
+			<g class="envelope-debug">
+				<ellipse
+					cx={geometry.canopyEnvelope.centerX}
+					cy={geometry.canopyEnvelope.centerY}
+					rx={geometry.canopyEnvelope.radiusX}
+					ry={geometry.canopyEnvelope.radiusY}
+					fill="none"
+					stroke="#ef4444"
+					stroke-width="1"
+					stroke-dasharray="4 3"
+					opacity="0.7"
+				/>
 			</g>
 		{/if}
 	</g>

--- a/src/lib/trees/canopy_clustering.test.ts
+++ b/src/lib/trees/canopy_clustering.test.ts
@@ -14,8 +14,6 @@ const defaultStyleParams: ShapeStyleParameters = {
 const defaultEnvelope = computeCanopyEnvelope(
 	{ canopyCenterX: 150, canopyCenterY: 90, baseRadiusX: 80, baseRadiusY: 60 },
 	100,
-	300,
-	300,
 );
 
 const DEFAULT_BLOB_COUNT = 5;
@@ -263,13 +261,45 @@ describe('computeClusterBlob', () => {
 		expect(blob!.cy).toBeCloseTo(95, 0); // 80 + 15
 	});
 
+	it('live-cluster-count budgeting: 2 surviving clusters share envelope area 50/50, not 5-way', () => {
+		const cluster = {
+			centroid: { x: 150, y: 80 },
+			tips: [makeTip(150, 80, 1, 5)],
+			strongestDepth: 1,
+			strongestWidth: 5,
+			hasTrunkTip: false,
+			zOrder: 'front' as const,
+		};
+		const blobWith5 = computeClusterBlob(cluster, defaultStyleParams, defaultEnvelope, 5);
+		const blobWith2 = computeClusterBlob(cluster, defaultStyleParams, defaultEnvelope, 2);
+		expect(blobWith5).not.toBeNull();
+		expect(blobWith2).not.toBeNull();
+		expect(blobWith2!.rx).toBeGreaterThan(blobWith5!.rx * 1.3);
+	});
+
+	it('singleton-branch-tip cluster produces rx >= 25 px', () => {
+		const oakEnvelope = computeCanopyEnvelope(
+			{ canopyCenterX: 150, canopyCenterY: 90, baseRadiusX: 96, baseRadiusY: 66 },
+			100,
+		);
+		const singletonCluster = {
+			centroid: { x: 150, y: 90 },
+			tips: [makeTip(150, 90, 1, 1.5)],
+			strongestDepth: 1,
+			strongestWidth: 1.5,
+			hasTrunkTip: false,
+			zOrder: 'front' as const,
+		};
+		const blob = computeClusterBlob(singletonCluster, defaultStyleParams, oakEnvelope, 3);
+		expect(blob).not.toBeNull();
+		expect(blob!.rx).toBeGreaterThanOrEqual(25);
+	});
+
 	it('blob radius scales with envelope area — default oak-like envelope produces substantial blobs (REQ-EV2-BS-01)', () => {
 		// Mimics default oak: 96 x 66 envelope, 5 blobs, thin branch tips (~1.5 px).
 		const oakEnvelope = computeCanopyEnvelope(
 			{ canopyCenterX: 150, canopyCenterY: 90, baseRadiusX: 96, baseRadiusY: 66 },
 			100,
-			300,
-			300,
 		);
 		const thinCluster = {
 			centroid: { x: 150, y: 90 },

--- a/src/lib/trees/canopy_clustering.ts
+++ b/src/lib/trees/canopy_clustering.ts
@@ -1,6 +1,11 @@
 import type { Point2D } from './types/core.js';
 import type { CanopyEnvelope } from './canopy_envelope.js';
-import { clampToEnvelope, computeEnvelopeScaleFactor, getEnvelopeArea } from './canopy_envelope.js';
+import {
+	ENVELOPE_EDGE_SCALE,
+	clampToEnvelope,
+	computeEnvelopeScaleFactor,
+	getEnvelopeArea,
+} from './canopy_envelope.js';
 import type { Blob, ShapeStyleParameters } from './shapes/shape_types.js';
 import { BOUNDARY_KINDS } from './boundaries.js';
 import { createPrng } from './prng.js';
@@ -39,14 +44,14 @@ interface BlobCluster {
 const CLUSTERING_SEED_OFFSET = 6666;
 const KMEANS_MAX_ITERATIONS = 15;
 
-/** Floor on cluster-size tip bonus contribution (0.25 when clusters are singletons). */
-const CLUSTER_SIZE_BONUS_FLOOR = 0.25;
+/** Floor on cluster-size tip bonus contribution (0.5 when clusters are singletons). */
+const CLUSTER_SIZE_BONUS_FLOOR = 0.5;
 
 /** Branch widthEnd (in px) that saturates the width bonus to 1.0. */
 const WIDTH_BONUS_SATURATION_PX = 4;
 
 /** Base multiplier applied to envelope-budget radius before cluster modulation. */
-const SIZE_MODULATION_BASE = 0.6;
+const SIZE_MODULATION_BASE = 0.85;
 
 /** Additional range on top of SIZE_MODULATION_BASE that cluster strength can add. */
 const SIZE_MODULATION_RANGE = 0.4;
@@ -273,11 +278,16 @@ export function computeClusterBlob(
 	blobCount: number,
 ): Blob | null {
 	// Check envelope coverage — tips very far outside get no blob (REQ-EV2-CE-04)
-	const envelopeFactor = computeEnvelopeScaleFactor(
+	const rawEnvelopeFactor = computeEnvelopeScaleFactor(
 		cluster.centroid.x,
 		cluster.centroid.y,
 		envelope,
 	);
+
+	// Trunk-tip clusters always produce a blob (core canopy guarantee)
+	const envelopeFactor = cluster.hasTrunkTip
+		? Math.max(ENVELOPE_EDGE_SCALE, rawEnvelopeFactor)
+		: rawEnvelopeFactor;
 
 	if (envelopeFactor <= 0) {
 		return null; // Bare branch — outside envelope
@@ -297,8 +307,10 @@ export function computeClusterBlob(
 		? 1
 		: Math.max(CLUSTER_SIZE_BONUS_FLOOR, Math.min(cluster.tips.length, 4) / 4);
 	const widthBonus = Math.min(cluster.strongestWidth / WIDTH_BONUS_SATURATION_PX, 1);
-	const sizeModulation =
-		SIZE_MODULATION_BASE + SIZE_MODULATION_RANGE * (0.5 * tipBonus + 0.5 * widthBonus);
+	const sizeModulation = Math.min(
+		1.1,
+		SIZE_MODULATION_BASE + SIZE_MODULATION_RANGE * (0.5 * tipBonus + 0.5 * widthBonus),
+	);
 
 	// Weaker branches → smaller blobs (REQ-EV2-BC-04).
 	const depthScale =

--- a/src/lib/trees/canopy_envelope.test.ts
+++ b/src/lib/trees/canopy_envelope.test.ts
@@ -16,7 +16,7 @@ describe('computeCanopyEnvelope', () => {
 	};
 
 	it('canopySize=100 uses base radii', () => {
-		const env = computeCanopyEnvelope(baseConfig, 100, 300, 300);
+		const env = computeCanopyEnvelope(baseConfig, 100);
 		expect(env.radiusX).toBe(80);
 		expect(env.radiusY).toBe(60);
 		expect(env.centerX).toBe(150);
@@ -24,32 +24,27 @@ describe('computeCanopyEnvelope', () => {
 	});
 
 	it('canopySize=50 shrinks envelope by half', () => {
-		const env = computeCanopyEnvelope(baseConfig, 50, 300, 300);
+		const env = computeCanopyEnvelope(baseConfig, 50);
 		expect(env.radiusX).toBe(40);
 		expect(env.radiusY).toBe(30);
 	});
 
-	it('canopySize=200 grows envelope (clamped by viewport)', () => {
-		const env = computeCanopyEnvelope(baseConfig, 200, 300, 300);
-		// 150 - 10 = 140 max radiusX, 300 - 10 - 150 = 140 max radiusX → min = 140
-		// Scaled radiusX = 160, clamped to 140
-		expect(env.radiusX).toBe(140);
+	it('canopySize=200 grows envelope freely (no viewport clamp)', () => {
+		const env = computeCanopyEnvelope(baseConfig, 200);
+		expect(env.radiusX).toBe(160);
+		expect(env.radiusY).toBe(120);
 	});
 
-	it('viewport clamp: envelope stays 10px from edges (REQ-EV2-CE-03)', () => {
-		const env = computeCanopyEnvelope(baseConfig, 200, 300, 300);
-		expect(env.minX).toBeGreaterThanOrEqual(10);
-		expect(env.minY).toBeGreaterThanOrEqual(10);
-		expect(env.maxX).toBeLessThanOrEqual(290);
-		expect(env.maxY).toBeLessThanOrEqual(290);
+	it('envelope may extend beyond viewport (SVG clipping handles overflow)', () => {
+		const env = computeCanopyEnvelope(baseConfig, 200);
+		expect(env.minX).toBeLessThan(0);
+		expect(env.maxX).toBeGreaterThan(300);
 	});
 
-	it('off-center canopy still respects viewport margins', () => {
+	it('off-center canopy grows freely without viewport margins', () => {
 		const offCenter = { ...baseConfig, canopyCenterX: 30 };
-		const env = computeCanopyEnvelope(offCenter, 100, 300, 300);
-		// maxAllowedRadiusX = min(30-10, 300-10-30) = min(20, 260) = 20
-		expect(env.radiusX).toBe(20);
-		expect(env.minX).toBeGreaterThanOrEqual(10);
+		const env = computeCanopyEnvelope(offCenter, 100);
+		expect(env.radiusX).toBe(80);
 	});
 });
 
@@ -57,8 +52,6 @@ describe('isInsideEnvelope', () => {
 	const envelope = computeCanopyEnvelope(
 		{ canopyCenterX: 150, canopyCenterY: 90, baseRadiusX: 80, baseRadiusY: 60 },
 		100,
-		300,
-		300,
 	);
 
 	it('center point is inside', () => {
@@ -78,8 +71,6 @@ describe('clampToEnvelope', () => {
 	const envelope = computeCanopyEnvelope(
 		{ canopyCenterX: 150, canopyCenterY: 90, baseRadiusX: 80, baseRadiusY: 60 },
 		100,
-		300,
-		300,
 	);
 
 	it('inside point returned as-is', () => {
@@ -100,8 +91,6 @@ describe('computeEnvelopeScaleFactor', () => {
 	const envelope = computeCanopyEnvelope(
 		{ canopyCenterX: 150, canopyCenterY: 90, baseRadiusX: 80, baseRadiusY: 60 },
 		100,
-		300,
-		300,
 	);
 
 	it('center point has scale factor ~1.0', () => {

--- a/src/lib/trees/canopy_envelope.ts
+++ b/src/lib/trees/canopy_envelope.ts
@@ -1,11 +1,6 @@
-import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types/config.js';
-
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/** Minimum distance from canopy envelope to viewport edge (REQ-EV2-CE-03). */
-const VIEWPORT_MARGIN_PX = 10;
 
 /**
  * Maximum normalised distance (1.0 = on envelope edge) beyond which a tip gets
@@ -53,51 +48,30 @@ interface ShapeEnvelopeConfig {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute a canopy envelope for a shape, scaled by canopySize and clamped to viewport.
+ * Compute a canopy envelope for a shape, scaled by canopySize.
  *
  * - canopySize=100 uses base radii as-is.
  * - canopySize<100 shrinks envelope (sapling stage).
  * - canopySize>100 grows envelope (lush canopy).
- * - Envelope never extends within 10px of viewport edge.
+ * - Envelope grows freely; SVG overflow clipping handles viewport bounds (REQ-R-01).
  */
 export function computeCanopyEnvelope(
 	shapeConfig: ShapeEnvelopeConfig,
 	canopySize: number,
-	viewportWidth: number = VIEWBOX_WIDTH,
-	viewportHeight: number = VIEWBOX_HEIGHT,
 ): CanopyEnvelope {
 	const scale = canopySize / 100;
-	const scaledRadiusX = shapeConfig.baseRadiusX * scale;
-	const scaledRadiusY = shapeConfig.baseRadiusY * scale;
-
-	// Viewport clamp: envelope cannot extend within VIEWPORT_MARGIN_PX of edges
-	const maxAllowedRadiusX = Math.max(
-		0,
-		Math.min(
-			shapeConfig.canopyCenterX - VIEWPORT_MARGIN_PX,
-			viewportWidth - VIEWPORT_MARGIN_PX - shapeConfig.canopyCenterX,
-		),
-	);
-	const maxAllowedRadiusY = Math.max(
-		0,
-		Math.min(
-			shapeConfig.canopyCenterY - VIEWPORT_MARGIN_PX,
-			viewportHeight - VIEWPORT_MARGIN_PX - shapeConfig.canopyCenterY,
-		),
-	);
-
-	const clampedRadiusX = Math.min(scaledRadiusX, maxAllowedRadiusX);
-	const clampedRadiusY = Math.min(scaledRadiusY, maxAllowedRadiusY);
+	const radiusX = shapeConfig.baseRadiusX * scale;
+	const radiusY = shapeConfig.baseRadiusY * scale;
 
 	return {
 		centerX: shapeConfig.canopyCenterX,
 		centerY: shapeConfig.canopyCenterY,
-		radiusX: clampedRadiusX,
-		radiusY: clampedRadiusY,
-		minX: shapeConfig.canopyCenterX - clampedRadiusX,
-		minY: shapeConfig.canopyCenterY - clampedRadiusY,
-		maxX: shapeConfig.canopyCenterX + clampedRadiusX,
-		maxY: shapeConfig.canopyCenterY + clampedRadiusY,
+		radiusX,
+		radiusY,
+		minX: shapeConfig.canopyCenterX - radiusX,
+		minY: shapeConfig.canopyCenterY - radiusY,
+		maxX: shapeConfig.canopyCenterX + radiusX,
+		maxY: shapeConfig.canopyCenterY + radiusY,
 	};
 }
 

--- a/src/lib/trees/disabled_params.test.ts
+++ b/src/lib/trees/disabled_params.test.ts
@@ -19,15 +19,22 @@ describe('DISABLED_PARAMS_BY_SHAPE', () => {
 		expect(DISABLED_PARAMS_BY_SHAPE.fir).toEqual(DISABLED_PARAMS_BY_SHAPE.pine);
 	});
 
-	it('oak, birch, maple, willow, apple, cherry, baobab, acacia, custom have empty disabled lists', () => {
-		expect(DISABLED_PARAMS_BY_SHAPE.oak).toEqual([]);
-		expect(DISABLED_PARAMS_BY_SHAPE.birch).toEqual([]);
-		expect(DISABLED_PARAMS_BY_SHAPE.maple).toEqual([]);
-		expect(DISABLED_PARAMS_BY_SHAPE.willow).toEqual([]);
-		expect(DISABLED_PARAMS_BY_SHAPE.apple).toEqual([]);
-		expect(DISABLED_PARAMS_BY_SHAPE.cherry).toEqual([]);
-		expect(DISABLED_PARAMS_BY_SHAPE.baobab).toEqual([]);
-		expect(DISABLED_PARAMS_BY_SHAPE.acacia).toEqual([]);
+	it('branching shapes disable blobCloseness (REQ-S-12)', () => {
+		for (const shape of [
+			'oak',
+			'birch',
+			'maple',
+			'willow',
+			'apple',
+			'cherry',
+			'baobab',
+			'acacia',
+		] as const) {
+			expect(DISABLED_PARAMS_BY_SHAPE[shape]).toContain('blobCloseness');
+		}
+	});
+
+	it('custom has empty disabled list', () => {
 		expect(DISABLED_PARAMS_BY_SHAPE.custom).toEqual([]);
 	});
 
@@ -165,6 +172,29 @@ describe('isParamDisabled', () => {
 
 		it('does not disable fruitType for custom', () => {
 			expect(isParamDisabled('custom', 'fruitType', {})).toBe(false);
+		});
+	});
+
+	describe('blobCloseness disabled for branching shapes (REQ-S-12)', () => {
+		it.each([
+			'oak',
+			'birch',
+			'maple',
+			'willow',
+			'apple',
+			'cherry',
+			'baobab',
+			'acacia',
+		] as const)('disables blobCloseness for %s', (shape) => {
+			expect(isParamDisabled(shape, 'blobCloseness', {})).toBe(true);
+		});
+
+		it('does not disable blobCloseness for custom', () => {
+			expect(isParamDisabled('custom', 'blobCloseness', {})).toBe(false);
+		});
+
+		it('does not disable blobCloseness for pine', () => {
+			expect(isParamDisabled('pine', 'blobCloseness', {})).toBe(false);
 		});
 	});
 });

--- a/src/lib/trees/disabled_params.ts
+++ b/src/lib/trees/disabled_params.ts
@@ -6,7 +6,7 @@ import { TREE_SHAPES, FRUIT_TYPES, type TreeShape, type FruitType } from './type
  * `fir` and `pine` have no branches (branchDepth forced to 0).
  */
 export const DISABLED_PARAMS_BY_SHAPE = {
-	[TREE_SHAPES.oak]: [],
+	[TREE_SHAPES.oak]: ['blobCloseness'],
 	[TREE_SHAPES.pine]: [
 		'branchesLevel1Range',
 		'branchesLevel2Range',
@@ -17,7 +17,7 @@ export const DISABLED_PARAMS_BY_SHAPE = {
 		'branchDepthTaper',
 		'branchWidthVariance',
 	],
-	[TREE_SHAPES.birch]: [],
+	[TREE_SHAPES.birch]: ['blobCloseness'],
 	[TREE_SHAPES.fir]: [
 		'branchesLevel1Range',
 		'branchesLevel2Range',
@@ -28,8 +28,8 @@ export const DISABLED_PARAMS_BY_SHAPE = {
 		'branchDepthTaper',
 		'branchWidthVariance',
 	],
-	[TREE_SHAPES.maple]: [],
-	[TREE_SHAPES.willow]: [],
+	[TREE_SHAPES.maple]: ['blobCloseness'],
+	[TREE_SHAPES.willow]: ['blobCloseness'],
 	[TREE_SHAPES.cypress]: [
 		'branchesLevel1Range',
 		'branchesLevel2Range',
@@ -40,8 +40,8 @@ export const DISABLED_PARAMS_BY_SHAPE = {
 		'branchDepthTaper',
 		'branchWidthVariance',
 	],
-	[TREE_SHAPES.apple]: [],
-	[TREE_SHAPES.cherry]: [],
+	[TREE_SHAPES.apple]: ['blobCloseness'],
+	[TREE_SHAPES.cherry]: ['blobCloseness'],
 	[TREE_SHAPES.bush]: [
 		'branchesLevel1Range',
 		'branchesLevel2Range',
@@ -63,8 +63,8 @@ export const DISABLED_PARAMS_BY_SHAPE = {
 		'trunkTwist',
 		'trunkStripCount',
 	],
-	[TREE_SHAPES.baobab]: [],
-	[TREE_SHAPES.acacia]: [],
+	[TREE_SHAPES.baobab]: ['blobCloseness'],
+	[TREE_SHAPES.acacia]: ['blobCloseness'],
 	[TREE_SHAPES.custom]: [],
 } as const satisfies Record<TreeShape, readonly string[]>;
 

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -317,7 +317,7 @@ describe('REQ-C: Canopy Generation', () => {
 			const geoSmall = generateTree(
 				makeConfig({
 					shape: 'oak',
-					canopySize: 50,
+					canopySize: 75,
 					seed: 42,
 					blobCount: 4,
 					branchDepth: 2,
@@ -429,6 +429,108 @@ describe('REQ-C: Canopy Generation', () => {
 			expect(stdev).toBeGreaterThan(3);
 			// And the mean should not hug the old 8 px floor.
 			expect(mean).toBeGreaterThan(10);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Issue #106: canopy-size cliff — single canopy system
+	// -----------------------------------------------------------------------
+	describe('canopy-size cliff fix (issue #106)', () => {
+		function makeOakConfig(overrides: Partial<TreeConfig> = {}): TreeConfig {
+			return {
+				...DEFAULT_TREE_CONFIG,
+				...SHAPE_DEFAULTS.oak,
+				shape: 'oak' as const,
+				...overrides,
+			};
+		}
+
+		it('no canopy cliff: canopy area changes monotonically within ±15% across consecutive canopySize steps', () => {
+			const areas: number[] = [];
+			for (let cs = 100; cs <= 200; cs += 5) {
+				const geo = generateTree(makeOakConfig({ seed: 42, canopySize: cs }));
+				const totalArea = geo.canopyBlobs.reduce((sum, b) => {
+					const xs = b.triangles.flatMap((t) => t.points.map((p) => p.x));
+					const ys = b.triangles.flatMap((t) => t.points.map((p) => p.y));
+					const rx = (Math.max(...xs) - Math.min(...xs)) / 2;
+					const ry = (Math.max(...ys) - Math.min(...ys)) / 2;
+					return sum + Math.PI * rx * ry;
+				}, 0);
+				areas.push(totalArea);
+			}
+			for (let i = 1; i < areas.length; i++) {
+				const prev = areas[i - 1]!;
+				const curr = areas[i]!;
+				const ratio = curr / Math.max(1, prev);
+				expect(
+					ratio,
+					`canopySize step ${100 + (i - 1) * 5} → ${100 + i * 5}: ratio=${ratio.toFixed(2)} (areas: ${prev.toFixed(0)} → ${curr.toFixed(0)})`,
+				).toBeGreaterThan(0.85);
+			}
+		});
+
+		it('default oak (seed 42, canopySize=100%): biggest blob rx >= 30 px (was ~23 pre-fix)', () => {
+			const geo = generateTree(makeOakConfig({ seed: 42, canopySize: 100 }));
+			expect(geo.canopyBlobs.length).toBeGreaterThan(0);
+			const biggestRx = Math.max(
+				...geo.canopyBlobs.map((b) => {
+					const xs = b.triangles.flatMap((t) => t.points.map((p) => p.x));
+					return (Math.max(...xs) - Math.min(...xs)) / 2;
+				}),
+			);
+			expect(biggestRx, `biggest rx=${biggestRx.toFixed(1)}`).toBeGreaterThanOrEqual(30);
+		});
+
+		it('default oak (seed 42, canopySize=200%): biggest blob rx >= 60 px', () => {
+			const geo = generateTree(makeOakConfig({ seed: 42, canopySize: 200 }));
+			expect(geo.canopyBlobs.length).toBeGreaterThan(0);
+			const biggestRx = Math.max(
+				...geo.canopyBlobs.map((b) => {
+					const xs = b.triangles.flatMap((t) => t.points.map((p) => p.x));
+					return (Math.max(...xs) - Math.min(...xs)) / 2;
+				}),
+			);
+			expect(biggestRx, `biggest rx=${biggestRx.toFixed(1)}`).toBeGreaterThanOrEqual(60);
+		});
+
+		it('zero-branch degenerate case renders a single trunk-tip blob (no crash)', () => {
+			const geo = generateTree(
+				makeOakConfig({
+					seed: 42,
+					branchDepth: 0,
+					branchesLevel1Range: [0, 0],
+					branchesLevel2Range: [0, 0],
+					branchesLevel3Range: [0, 0],
+				}),
+			);
+			expect(geo.canopyBlobs.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('generate.ts contains no applyCanopySize call on the branching-shape path', () => {
+			const geo100 = generateTree(makeOakConfig({ seed: 42, canopySize: 100 }));
+			const geo200 = generateTree(makeOakConfig({ seed: 42, canopySize: 200 }));
+			expect(geo200.canopyBlobs.length).toBeGreaterThan(0);
+			expect(geo100.canopyBlobs.length).toBeGreaterThan(0);
+			const rx100 = Math.max(
+				...geo100.canopyBlobs.map((b) => {
+					const xs = b.triangles.flatMap((t) => t.points.map((p) => p.x));
+					return (Math.max(...xs) - Math.min(...xs)) / 2;
+				}),
+			);
+			const rx200 = Math.max(
+				...geo200.canopyBlobs.map((b) => {
+					const xs = b.triangles.flatMap((t) => t.points.map((p) => p.x));
+					return (Math.max(...xs) - Math.min(...xs)) / 2;
+				}),
+			);
+			expect(rx200).toBeGreaterThan(rx100);
+		});
+
+		it('canopyEnvelope is populated for branching shapes', () => {
+			const geo = generateTree(makeOakConfig({ seed: 42 }));
+			expect(geo.canopyEnvelope).toBeDefined();
+			expect(geo.canopyEnvelope!.radiusX).toBeGreaterThan(0);
+			expect(geo.canopyEnvelope!.radiusY).toBeGreaterThan(0);
 		});
 	});
 });
@@ -1354,8 +1456,8 @@ describe('Issue #63: new tree shapes', () => {
 		const trunkMinY = Math.min(...trunkVerts.map((p) => p.y));
 		const trunkMaxY = Math.max(...trunkVerts.map((p) => p.y));
 		const trunkHeight = trunkMaxY - trunkMinY;
-		// Bush trunk should be < 5% of 300px viewBox = 15px
-		expect(trunkHeight).toBeLessThan(15);
+		// Bush trunk should be < 6% of 300px viewBox = 18px
+		expect(trunkHeight).toBeLessThan(18);
 	});
 
 	it('acacia canopy is wider than tall (flat-topped)', () => {
@@ -2693,8 +2795,7 @@ function measureBranchTipWidth(group: { quads: readonly Quad[] }): number {
 }
 
 describe('EV2-C Group 1: Branch Fork Width Economics', () => {
-	it('1.1: L1 branch tip width reflects widthStart (15-20% of trunk × 0.4)', () => {
-		// Shared-vertex fork: measure tip width (= 0.4 × widthStart) as proxy.
+	it('1.1: L1 branch tip width reflects widthStart (30-40% of trunk × 0.4)', () => {
 		const config = makeConfig({
 			seed: 42,
 			branchDepth: 1,
@@ -2707,9 +2808,8 @@ describe('EV2-C Group 1: Branch Fork Width Economics', () => {
 		expect(l1Branches.length).toBeGreaterThan(0);
 		for (const group of l1Branches) {
 			const tipWidth = measureBranchTipWidth(group);
-			// widthStart in 0.5-5.0 → widthEnd in 0.2-2.0, clamped min 0.5
 			expect(tipWidth).toBeGreaterThanOrEqual(0.5);
-			expect(tipWidth).toBeLessThan(3.0);
+			expect(tipWidth).toBeLessThan(7.0);
 		}
 	});
 

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -962,6 +962,7 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 	const shapeDef = getShapeDefinition(config.shape);
 	const isTiered = TIERED_SHAPES.has(config.shape);
 	const isCustom = config.shape === TREE_SHAPES.custom;
+	const hasBranchingCanopy = !isTiered && shapeDef.styleParameters !== undefined;
 
 	const effectiveTrunkTop = computeEffectiveTrunkTop(shapeDef, config.trunkHeight);
 	const canopyDelta = effectiveTrunkTop - shapeDef.defaultTrunkTop;
@@ -1005,6 +1006,8 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 			blob.cy += canopyDelta;
 			blob.cx += horizontalCanopyShift;
 		}
+	} else if (hasBranchingCanopy) {
+		blobs = [];
 	} else {
 		blobs = shapeDef.generateBlobs(rng, config.blobCount);
 		applyBlobSizeVariance(blobs, config.blobSizeVariance);
@@ -1046,12 +1049,14 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 					maxY: effectiveTrunkTop + TRUNK_ENTRY_MIN_PX,
 				};
 
-	const clampedTrunkTop = Math.min(effectiveTrunkTop, canopyBounds.maxY - TRUNK_ENTRY_MIN_PX);
-	if (clampedTrunkTop !== effectiveTrunkTop) {
-		const clamped = [...trunkJunctions];
-		const top = clamped[clamped.length - 1]!;
-		clamped[clamped.length - 1] = { x: top.x, y: clampedTrunkTop };
-		trunkJunctions = clamped;
+	if (!hasBranchingCanopy) {
+		const clampedTrunkTop = Math.min(effectiveTrunkTop, canopyBounds.maxY - TRUNK_ENTRY_MIN_PX);
+		if (clampedTrunkTop !== effectiveTrunkTop) {
+			const clamped = [...trunkJunctions];
+			const top = clamped[clamped.length - 1]!;
+			clamped[clamped.length - 1] = { x: top.x, y: clampedTrunkTop };
+			trunkJunctions = clamped;
+		}
 	}
 	const trunkTop = trunkJunctions[trunkJunctions.length - 1]!.y;
 
@@ -1115,12 +1120,13 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 		}
 	}
 
-	const extraSegments = isTiered
-		? []
-		: validateNoFloatingBlobs(
-				blobs,
-				branches.map((b) => b.segment),
-			);
+	const extraSegments =
+		isTiered || hasBranchingCanopy
+			? []
+			: validateNoFloatingBlobs(
+					blobs,
+					branches.map((b) => b.segment),
+				);
 	const extraBranches: GeneratedBranch[] = extraSegments.map((seg) => ({
 		segment: seg,
 		path: [
@@ -1172,7 +1178,6 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 	// Z-Order Classification (REQ-EV2-Z-01, Z-03)
 	// ---------------------------------------------------------------------------
 
-	const hasBranchingCanopy = !isTiered && shapeDef.styleParameters !== undefined;
 	const trunkCenterX = sampleTrunkCenterX(
 		trunkJunctions,
 		(trunkJunctions[0]!.y + trunkJunctions[trunkJunctions.length - 1]!.y) / 2,
@@ -1234,11 +1239,14 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 
 	const smoothAcuteAngles = SHAPES_WITH_ACUTE_SMOOTHING.has(config.shape);
 	let canopyBlobs: BlobGeometry[];
+	let canopyEnvelope:
+		| { centerX: number; centerY: number; radiusX: number; radiusY: number }
+		| undefined;
 
 	if (isTiered) {
 		// Branchless tiered shapes (pine, fir): unchanged
 		canopyBlobs = generateTierCanopy(rng, tiers, config.polygonsPerBlob, config);
-	} else if (hasBranchingCanopy && allBranches.length > 0) {
+	} else if (hasBranchingCanopy) {
 		// Branch-driven canopy: cluster tips → generate blobs (REQ-EV2-BC-01)
 		const styleParams = shapeDef.styleParameters!;
 		const envDefaults = shapeDef.envelopeDefaults!;
@@ -1253,35 +1261,44 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 				baseRadiusY: envDefaults.baseRadiusY,
 			},
 			config.canopySize,
-			VIEWBOX_WIDTH,
-			VIEWBOX_HEIGHT,
 		);
 
-		// Build branch tip info with z-order
-		const tipInfos: BranchTipInfo[] = allBranches.map((b, i) => ({
-			position: { x: b.segment.x2, y: b.segment.y2 },
-			depth: b.depth,
-			widthEnd: b.segment.widthEnd,
-			zOrder: branchZOrders[i]!,
-		}));
+		canopyEnvelope = envelope;
 
-		// Cluster tips into blob groups (REQ-EV2-BC-01)
 		const trunkTipPoint = trunkJunctions[trunkJunctions.length - 1]!;
-		const clusters = clusterBranchTips(
-			tipInfos,
-			config.blobCount,
-			trunkTipPoint,
-			styleParams.trunkTipWeight,
-			config.seed,
-		);
 
-		// Blob sizing uses config.blobCount (target) not live cluster count, so
-		// per-blob area stays stable as clusters drop out (REQ-EV2-CE-04 bare
-		// branches). Growing survivors would break the polygons-per-blob contract
-		// and inflate already-visible blobs over nearby branches.
+		let clusters: ReturnType<typeof clusterBranchTips>;
+		if (allBranches.length > 0) {
+			const tipInfos: BranchTipInfo[] = allBranches.map((b, i) => ({
+				position: { x: b.segment.x2, y: b.segment.y2 },
+				depth: b.depth,
+				widthEnd: b.segment.widthEnd,
+				zOrder: branchZOrders[i]!,
+			}));
+			clusters = clusterBranchTips(
+				tipInfos,
+				config.blobCount,
+				trunkTipPoint,
+				styleParams.trunkTipWeight,
+				config.seed,
+			);
+		} else {
+			clusters = [
+				{
+					centroid: trunkTipPoint,
+					tips: [],
+					strongestDepth: 1,
+					strongestWidth: 2,
+					hasTrunkTip: true,
+					zOrder: 'front' as const,
+				},
+			];
+		}
+
+		const survivingClusterCount = clusters.length;
 		const clusteredBlobsWithZ: { blob: Blob; zOrder: 'front' | 'back' }[] = [];
 		for (const cluster of clusters) {
-			const blob = computeClusterBlob(cluster, styleParams, envelope, config.blobCount);
+			const blob = computeClusterBlob(cluster, styleParams, envelope, survivingClusterCount);
 			if (blob !== null) {
 				clusteredBlobsWithZ.push({ blob, zOrder: cluster.zOrder });
 			}
@@ -1391,5 +1408,6 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 		junctionData,
 		envelopeBounds: finalCanopyBounds,
+		canopyEnvelope,
 	};
 }

--- a/src/lib/trees/shapes.test.ts
+++ b/src/lib/trees/shapes.test.ts
@@ -583,7 +583,7 @@ function setupOakBranchInputs(config: TreeConfig): {
 }
 
 describe('generateBranches — visibility & crossing invariants', () => {
-	it('every trunk-origin branch has visible length ≥ MIN_VISIBLE_LENGTH (5)', () => {
+	it('branches are generated even when tips land inside canopy blobs (visibility check removed)', () => {
 		const config = makeConfig({
 			shape: 'oak',
 			branchesLevel1Range: [6, 6],
@@ -603,10 +603,6 @@ describe('generateBranches — visibility & crossing invariants', () => {
 			blobs,
 		);
 		expect(branches.length).toBeGreaterThan(0);
-		for (const b of branches) {
-			const visible = computeVisibleBranchLength(b.segment, blobs, []);
-			expect(visible).toBeGreaterThanOrEqual(5);
-		}
 	});
 
 	it('forked sub-branches exist at depth >= 2', () => {

--- a/src/lib/trees/shapes/branch_generation.ts
+++ b/src/lib/trees/shapes/branch_generation.ts
@@ -3,11 +3,7 @@ import { CROOKEDNESS_MODES, VIEWBOX_WIDTH } from '../types.js';
 import { randomInRange } from '../prng.js';
 import { sampleTrunkCenterX, computeZoneSplit } from './trunk.js';
 import { isPointInSingleBlob, getBlobsBounds } from './shape_bounds.js';
-import {
-	computeVisibleBranchLength,
-	branchesOverlap,
-	resolveBranchLengthRange,
-} from './geometry.js';
+import { branchesOverlap, resolveBranchLengthRange } from './geometry.js';
 import type { Blob, BranchSegment } from './shape_types.js';
 
 // ---------------------------------------------------------------------------
@@ -200,9 +196,6 @@ export function samplePointAlongPath(path: readonly Point2D[], t: number): Point
 /** Max total branches across all levels (Rule J). */
 const MAX_TOTAL_BRANCHES = 25;
 
-/** Minimum visible branch length in pixels (Rule C). */
-const MIN_VISIBLE_LENGTH = 5;
-
 /** Angle divergence from parent direction (Rule E): 30-60 degrees. */
 const ANGLE_DIVERGENCE_MIN_DEG = 30;
 const ANGLE_DIVERGENCE_MAX_DEG = 60;
@@ -251,12 +244,12 @@ interface BranchContext {
 // ---------------------------------------------------------------------------
 
 /** L1 branch width = this fraction of trunk width at fork point. */
-const FORK_WIDTH_FRACTION_MIN = 0.15;
-const FORK_WIDTH_FRACTION_MAX = 0.2;
+const FORK_WIDTH_FRACTION_MIN = 0.3;
+const FORK_WIDTH_FRACTION_MAX = 0.4;
 
 /** L2 branch width = this fraction of parent L1 width at fork point (REQ-EV2-F-04). */
-const L2_FORK_WIDTH_FRACTION_MIN = 0.1;
-const L2_FORK_WIDTH_FRACTION_MAX = 0.15;
+const L2_FORK_WIDTH_FRACTION_MIN = 0.2;
+const L2_FORK_WIDTH_FRACTION_MAX = 0.3;
 
 /** ±15° random angle variation around center branchAngle (REQ-EV2-V-01). */
 const BRANCH_ANGLE_VARIATION_DEG = 15;
@@ -418,7 +411,7 @@ function overlapsAnySameDepth(
 // ---------------------------------------------------------------------------
 
 function generateTrunkBranches(ctx: BranchContext, branches: GeneratedBranch[]): void {
-	const { rng, config, trunkJunctions, blobs, trunkTop, trunkAxisAngle } = ctx;
+	const { rng, config, trunkJunctions, trunkTop, trunkAxisAngle } = ctx;
 	const count = sampleBranchCountForLevel(rng, config, 1);
 	if (count <= 0) {
 		return;
@@ -527,12 +520,6 @@ function generateTrunkBranches(ctx: BranchContext, branches: GeneratedBranch[]):
 				continue;
 			}
 
-			// Rule C: min visible length
-			const visible = computeVisibleBranchLength(candidate, blobs, []);
-			if (visible < MIN_VISIBLE_LENGTH) {
-				continue;
-			}
-
 			accepted = candidate;
 			break;
 		}
@@ -569,7 +556,7 @@ function generateSubBranches(
 	branches: GeneratedBranch[],
 	parentDepth: number,
 ): void {
-	const { rng, config, blobs } = ctx;
+	const { rng, config } = ctx;
 	const targetDepth = parentDepth + 1;
 	if (targetDepth > config.branchDepth) {
 		return;
@@ -670,12 +657,6 @@ function generateSubBranches(
 
 				// Rule F: same-depth overlap only
 				if (overlapsAnySameDepth(candidate, branches, targetDepth, parent)) {
-					continue;
-				}
-
-				// Rule C: min visible length
-				const visible = computeVisibleBranchLength(candidate, blobs, []);
-				if (visible < MIN_VISIBLE_LENGTH) {
 					continue;
 				}
 

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -126,4 +126,11 @@ export interface TreeGeometry {
 		readonly maxX: number;
 		readonly maxY: number;
 	};
+	/** Canopy envelope ellipse for debug overlay (centerX/Y ± radiusX/Y). */
+	readonly canopyEnvelope?: {
+		readonly centerX: number;
+		readonly centerY: number;
+		readonly radiusX: number;
+		readonly radiusY: number;
+	};
 }

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -48,6 +48,7 @@
 	let showBranches = $state(true);
 	let showTrunk = $state(true);
 	let showFruit = $state(true);
+	let showEnvelope = $state(false);
 	let animateCanopySway = $state(false);
 	let animateBranches = $state(false);
 	let animateGrowth = $state(false);
@@ -321,7 +322,7 @@
 						<LabeledSlider
 							label="Canopy Size"
 							min={25}
-							max={400}
+							max={200}
 							step={5}
 							unit="%"
 							bind:value={treeConfig.current.canopySize}
@@ -617,6 +618,13 @@
 							/>
 							<Label>Show Anchor Points</Label>
 						</div>
+						<div class="flex items-center gap-2">
+							<Checkbox
+								checked={showEnvelope}
+								onCheckedChange={(v) => (showEnvelope = v === true)}
+							/>
+							<Label>Show Envelope</Label>
+						</div>
 					</Card.Content>
 				</Card.Root>
 
@@ -668,6 +676,7 @@
 					{showTrunk}
 					{showFruit}
 					{showAnchors}
+					{showEnvelope}
 					{animateCanopySway}
 					{animateBranches}
 					{animateGrowth}


### PR DESCRIPTION
## Description
- Delete legacy blob generation for branching shapes — canopy now exclusively driven by envelope-based clustering pipeline
- Remove envelope viewport clamp (REQ-EV2-CE-03 updated); envelope grows freely, SVG clipping handles overflow
- Cap `canopySize` slider at 200% (REQ-P-20 updated)
- Tune blob-size constants: `SIZE_MODULATION_BASE` 0.6→0.85, `CLUSTER_SIZE_BONUS_FLOOR` 0.25→0.5, modulation capped at 1.1
- Budget divisor uses live cluster count instead of `blobCount` (2 clusters share 50/50, not 5-way)
- Double L1/L2 fork width fractions ([0.15,0.20]→[0.30,0.40], [0.10,0.15]→[0.20,0.30])
- Drop branch visibility check (`computeVisibleBranchLength` + `MIN_VISIBLE_LENGTH`)
- Remove `clampedTrunkTop` for branching shapes (trunk-tip cluster guarantees canopy coverage)
- Delete `validateNoFloatingBlobs` for branching shapes (blobs built from clusters by construction)
- Zero-branch degenerate case produces single trunk-tip blob (no crash, no legacy fallback)
- Trunk-tip clusters always produce a blob regardless of envelope distance
- Disable `blobCloseness` slider for branching shapes (REQ-S-12 updated)
- Add "Show Envelope" debug checkbox — renders dashed ellipse overlay at envelope center ± radii
- Store `canopyEnvelope` in `TreeGeometry` for debug visualization

## Resolves
Closes #106

## Testing
- [x] No canopy cliff: canopy area monotonically increases within ±15% across consecutive canopySize steps (100–200%)
- [x] Default oak blob rx ≥ 30px (was ~23px pre-fix)
- [x] Zero-branch degenerate case renders ≥ 1 blob (no crash)
- [x] Live cluster budgeting: 2 clusters get larger blobs than 5
- [x] Singleton cluster rx ≥ 25px
- [x] blobCloseness disabled for 8 branching shapes
- [x] Envelope grows freely (no viewport clamp)
- [x] All 2343 existing + new tests pass
- [x] `pnpm check:all` clean