### PR TITLE
#85 fix(engine): birch stripes, pine height, dead stage, willow drooping

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -790,20 +790,20 @@ Trunk color UI includes preset swatch buttons that set all three HSL sliders at 
 
 - [ ] **REQ-EV2-TZ-03** Updated SHAPE_DEFAULTS for `trunkSegments`:
 
-                                                                                                                                                | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
-                                                                                                                                                |---------|---------|--------|-------------|---------------------------|
-                                                                                                                                                | oak     | 5       | 3      | 5           | 1 + 4                     |
-                                                                                                                                                | maple   | 3       | 5      | 7           | 2 + 5                     |
-                                                                                                                                                | willow  | 5       | 5      | 7           | 2 + 5                     |
-                                                                                                                                                | cherry  | 3       | 4      | 6           | 1 + 5                     |
-                                                                                                                                                | birch   | 3       | 2      | 4           | 1 + 3                     |
-                                                                                                                                                | apple   | 3       | 2      | 3           | 1 + 2                     |
-                                                                                                                                                | baobab  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                                                                                | acacia  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                                                                                | pine    | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                                                                | fir     | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                                                                | cypress | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                                                                | bush    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                          | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
+                                                                                                                                                          |---------|---------|--------|-------------|---------------------------|
+                                                                                                                                                          | oak     | 5       | 3      | 5           | 1 + 4                     |
+                                                                                                                                                          | maple   | 3       | 5      | 7           | 2 + 5                     |
+                                                                                                                                                          | willow  | 5       | 5      | 7           | 2 + 5                     |
+                                                                                                                                                          | cherry  | 3       | 4      | 6           | 1 + 5                     |
+                                                                                                                                                          | birch   | 3       | 2      | 4           | 1 + 3                     |
+                                                                                                                                                          | apple   | 3       | 2      | 3           | 1 + 2                     |
+                                                                                                                                                          | baobab  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                                                                                          | acacia  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                                                                                          | pine    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                          | fir     | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                          | cypress | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                          | bush    | 3       | 0      | 3           | unchanged (no branches)    |
 
 ### 13.6 Bottom-Up Sequential Generation
 
@@ -1043,16 +1043,16 @@ Phase 1 must deliver these interfaces for Phase 2 to consume:
 
 - [x] **REQ-EV2-SS-02** Shape-specific identity preserved via style parameters:
 
-                                                                                                                                                | Shape   | Key Characteristics                                                 |
-                                                                                                                                                |---------|---------------------------------------------------------------------|
-                                                                                                                                                | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
-                                                                                                                                                | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
-                                                                                                                                                | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
-                                                                                                                                                | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
-                                                                                                                                                | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
-                                                                                                                                                | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
-                                                                                                                                                | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
-                                                                                                                                                | apple   | Compact round canopy. Minimal branching. Large single blob.         |
+                                                                                                                                                          | Shape   | Key Characteristics                                                 |
+                                                                                                                                                          |---------|---------------------------------------------------------------------|
+                                                                                                                                                          | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
+                                                                                                                                                          | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
+                                                                                                                                                          | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
+                                                                                                                                                          | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
+                                                                                                                                                          | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
+                                                                                                                                                          | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
+                                                                                                                                                          | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
+                                                                                                                                                          | apple   | Compact round canopy. Minimal branching. Large single blob.         |
 
 - [x] **REQ-EV2-SS-03** Some branch tips will naturally not have blobs — those that fall outside
       the canopy envelope. This is acceptable and realistic (bare branch poking out of canopy).

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -282,6 +282,15 @@
 						stroke-width="0.5"
 					/>
 				{/each}
+				{#each geometry.birchStripes as stripe (stripe)}
+					<rect
+						x={stripe.centerX - stripe.width / 2}
+						y={stripe.y - stripe.height / 2}
+						width={stripe.width}
+						height={stripe.height}
+						fill={stripe.color}
+					/>
+				{/each}
 			</g>
 		{/if}
 

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -631,21 +631,20 @@ describe('REQ-T: Trunk & Branch Generation', () => {
 			expect(canopyShift).toBeCloseTo(trunkShift, 5);
 		});
 
-		it('trunk top enters canopy (sampled) for pine at 50/100/150', () => {
-			// Branching shapes (oak, birch) use clustering; their canopy bottom
-			// may not extend to the trunk top. Pine (branchless tiered) still
-			// guarantees the trunk-into-canopy invariant.
-			for (const trunkHeight of [50, 100, 150]) {
-				const geo = generateTree(makeConfig({ trunkHeight, seed: 42, shape: 'pine' }));
-				const allCanopyYs = geo.canopyBlobs.flatMap((b) =>
-					b.triangles.flatMap((t) => t.points.map((p) => p.y)),
-				);
-				if (allCanopyYs.length === 0) {
-					continue;
-				}
-				const canopyMaxY = Math.max(...allCanopyYs);
-				expect(geo.anchors.trunkTop.y + 3).toBeLessThanOrEqual(canopyMaxY);
-			}
+		it('pine trunk top respects trunkHeight slider (tiered shapes skip trunk-penetration clamp)', () => {
+			// Tiered shapes (pine/fir) should NOT be clamped into the canopy.
+			// The trunk sits below the tiers naturally.
+			const tallPine = generateTree(
+				makeConfig({ trunkHeight: 100, seed: 42, shape: 'pine' }),
+			);
+			const shortPine = generateTree(
+				makeConfig({ trunkHeight: 10, seed: 42, shape: 'pine' }),
+			);
+			// Trunk top Y should differ significantly with different trunkHeight values
+			expect(shortPine.anchors.trunkTop.y).toBeGreaterThan(tallPine.anchors.trunkTop.y);
+			expect(
+				shortPine.anchors.trunkTop.y - tallPine.anchors.trunkTop.y,
+			).toBeGreaterThanOrEqual(20);
 		});
 	});
 
@@ -1277,24 +1276,13 @@ describe('Issue #8: new tree shapes (fir/maple/willow)', () => {
 		}
 	});
 
-	// Branching shapes (maple, willow) use clustering; canopy bottom may not
-	// extend to trunk top. Only test branchless/tiered shapes (fir).
-	it.each(['fir'] as const)(
-		'%s: trunk top enters the sampled canopy (sampled penetration ≥ 5 px)',
-		(shape) => {
-			for (const trunkHeight of [50, 100, 150]) {
-				const geo = generateTree(makeConfig({ shape, trunkHeight, seed: 42 }));
-				const allCanopyYs = geo.canopyBlobs.flatMap((b) =>
-					b.triangles.flatMap((t) => t.points.map((p) => p.y)),
-				);
-				if (allCanopyYs.length === 0) {
-					continue;
-				}
-				const canopyMaxY = Math.max(...allCanopyYs);
-				expect(geo.anchors.trunkTop.y + 5).toBeLessThanOrEqual(canopyMaxY);
-			}
-		},
-	);
+	// Tiered shapes (fir) skip trunk-penetration clamp; trunk respects trunkHeight slider.
+	it('fir trunk top respects trunkHeight slider (tiered shapes skip trunk-penetration clamp)', () => {
+		const tallFir = generateTree(makeConfig({ shape: 'fir', trunkHeight: 100, seed: 42 }));
+		const shortFir = generateTree(makeConfig({ shape: 'fir', trunkHeight: 10, seed: 42 }));
+		expect(shortFir.anchors.trunkTop.y).toBeGreaterThan(tallFir.anchors.trunkTop.y);
+		expect(shortFir.anchors.trunkTop.y - tallFir.anchors.trunkTop.y).toBeGreaterThanOrEqual(20);
+	});
 
 	// Maple emits branches toward canopy blobs (issue #8 spec). Validate
 	// reach via bounding-box containment: at least one branch quad vertex

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -9,6 +9,7 @@ import type {
 	BlobGeometry,
 	BranchGeometry,
 	JunctionData,
+	BirchStripe,
 	Tier,
 	TreeShape,
 } from './types.js';
@@ -230,6 +231,7 @@ const CONICAL_TAPER_FRACTION = 0.25;
 
 /** Seed offset for junction strip ratio computation. */
 const JUNCTION_STRIP_SEED_OFFSET = 900;
+const BIRCH_STRIPE_SEED_OFFSET = 9999;
 
 // ---------------------------------------------------------------------------
 // Engine v2: Junction-Based Strip Ratios (REQ-EV2-S-01, S-02, S-03)
@@ -932,6 +934,71 @@ function generateTierCanopy(
 }
 
 // ---------------------------------------------------------------------------
+// Birch trunk stripes
+// ---------------------------------------------------------------------------
+
+/** Interpolate trunk centerX and width at a given y by finding bracketing junctions. */
+function interpolateTrunkAtY(
+	y: number,
+	junctions: readonly { x: number; y: number }[],
+	junctionWidths: readonly number[],
+): { centerX: number; width: number } {
+	// Junctions are ordered bottom-to-top (index 0 = bottom = highest Y).
+	// Find two junctions that bracket the given y.
+	for (let i = 0; i < junctions.length - 1; i++) {
+		const lower = junctions[i]!; // higher Y (lower on screen)
+		const upper = junctions[i + 1]!; // lower Y (higher on screen)
+		if (y <= lower.y && y >= upper.y) {
+			const range = lower.y - upper.y;
+			const t = range > 0 ? (lower.y - y) / range : 0;
+			const centerX = lower.x + (upper.x - lower.x) * t;
+			const lowerWidth = junctionWidths[i] ?? 0;
+			const upperWidth = junctionWidths[i + 1] ?? 0;
+			const width = lowerWidth + (upperWidth - lowerWidth) * t;
+			return { centerX, width };
+		}
+	}
+	// Fallback: use the closest junction
+	const last = junctions[junctions.length - 1]!;
+	return { centerX: last.x, width: junctionWidths[junctions.length - 1] ?? 0 };
+}
+
+function generateBirchStripes(
+	junctions: readonly { x: number; y: number }[],
+	junctionWidths: readonly number[],
+	rng: () => number,
+): BirchStripe[] {
+	if (junctions.length < 2) {
+		return [];
+	}
+	const topY = junctions[junctions.length - 1]!.y;
+	const bottomY = junctions[0]!.y;
+	const trunkHeight = bottomY - topY;
+	if (trunkHeight <= 0) {
+		return [];
+	}
+	// 3-6 stripes evenly distributed along trunk height
+	const stripeCount = 3 + Math.floor(rng() * 4);
+	const stripes: BirchStripe[] = [];
+	for (let i = 0; i < stripeCount; i++) {
+		const t = (i + 0.5) / stripeCount; // normalized position (0=top, 1=bottom)
+		const y = topY + trunkHeight * t;
+		const { centerX, width } = interpolateTrunkAtY(y, junctions, junctionWidths);
+		const stripeHeight = 1.5 + rng() * 1.5; // 1.5-3px tall
+		const stripeWidth = width * (0.7 + rng() * 0.25); // 70-95% of trunk width
+		const lightness = 15 + Math.floor(rng() * 15); // dark grey
+		stripes.push({
+			y,
+			centerX,
+			width: stripeWidth,
+			height: stripeHeight,
+			color: `hsl(0, 0%, ${lightness}%)`,
+		});
+	}
+	return stripes;
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -1062,7 +1129,7 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 					maxY: effectiveTrunkTop + TRUNK_ENTRY_MIN_PX,
 				};
 
-	if (!hasBranchingCanopy) {
+	if (!hasBranchingCanopy && !isTiered) {
 		const clampedTrunkTop = Math.min(effectiveTrunkTop, canopyBounds.maxY - TRUNK_ENTRY_MIN_PX);
 		if (clampedTrunkTop !== effectiveTrunkTop) {
 			const clamped = [...trunkJunctions];
@@ -1414,6 +1481,15 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 		bisectorAngle: Math.atan2(trunkResult.bisectors[i]!.perpY, trunkResult.bisectors[i]!.perpX),
 	}));
 
+	const birchStripes =
+		config.shape === TREE_SHAPES.birch
+			? generateBirchStripes(
+					trunkJunctions,
+					trunkResult.junctionWidths,
+					createPrng(config.seed + BIRCH_STRIPE_SEED_OFFSET),
+				)
+			: [];
+
 	return {
 		trunkQuads,
 		trunkTriangles: [],
@@ -1424,6 +1500,7 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 		fruitSlots: fruitSlotsResult,
 		flowerSlots: flowerSlotsResult,
 		showFallingLeaves: flags.addFallingLeaves,
+		birchStripes,
 		anchors: anchorsWithTipDepths,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 		junctionData,

--- a/src/lib/trees/oak_prd_generator.ts
+++ b/src/lib/trees/oak_prd_generator.ts
@@ -86,6 +86,7 @@ function scaleGeometry(geometry: TreeGeometry): TreeGeometry {
 		fruitSlots: geometry.fruitSlots.map(scalePoint),
 		flowerSlots: geometry.flowerSlots.map(scalePoint),
 		showFallingLeaves: geometry.showFallingLeaves,
+		birchStripes: [],
 		anchors: scaleAnchors(geometry.anchors),
 		viewBox: OAK_PRD_VIEWBOX,
 	};

--- a/src/lib/trees/potted_plant_generator.ts
+++ b/src/lib/trees/potted_plant_generator.ts
@@ -260,6 +260,7 @@ export function generatePottedPlant(config: PottedPlantConfig): TreeGeometry {
 		fruitSlots,
 		flowerSlots: fruitSlots,
 		showFallingLeaves: false,
+		birchStripes: [],
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/shapes/blob_generators.ts
+++ b/src/lib/trees/shapes/blob_generators.ts
@@ -677,7 +677,7 @@ const shapeDefinitions: Record<TreeShape, ShapeDefinition> = {
 		generateBlobs: generateWillowBlobs,
 		styleParameters: {
 			blobRxRyRatio: 1.3,
-			blobVerticalOffset: 15,
+			blobVerticalOffset: 25,
 			blobBoundary: 'circle',
 			blobClusterBehavior: 0.3,
 			trunkTipWeight: 0.5,

--- a/src/lib/trees/stages/seed_generator.ts
+++ b/src/lib/trees/stages/seed_generator.ts
@@ -61,6 +61,7 @@ export function generateSeedGeometry(): TreeGeometry {
 		fruitSlots: [],
 		flowerSlots: [],
 		showFallingLeaves: false,
+		birchStripes: [],
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/stages/sprouting_generator.ts
+++ b/src/lib/trees/stages/sprouting_generator.ts
@@ -65,6 +65,7 @@ export function generateSproutingGeometry(): TreeGeometry {
 		fruitSlots: [],
 		flowerSlots: [],
 		showFallingLeaves: false,
+		birchStripes: [],
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/stages/stage_modifiers.ts
+++ b/src/lib/trees/stages/stage_modifiers.ts
@@ -118,7 +118,9 @@ const STAGE_HANDLERS = {
 	[TREE_STAGES.dead]: (_config: TreeConfig): StageResult => ({
 		kind: 'modifiedConfig',
 		config: modifyConfig(_config, {
-			trunkLean: 30,
+			trunkLean: 15,
+			trunkCrookedness: 50,
+			trunkSegments: 5,
 			branchesLevel1Range: [1, 2],
 			branchLength: 40,
 			blobCount: 0,

--- a/src/lib/trees/stages/stages.test.ts
+++ b/src/lib/trees/stages/stages.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { generateTree } from '../generate.js';
 import type { TreeConfig, TreeGeometry } from '../types.js';
-import { DEFAULT_TREE_CONFIG, TREE_STAGES, TREE_STAGE_OPTIONS, type TreeStage } from '../types.js';
+import {
+	DEFAULT_TREE_CONFIG,
+	TREE_STAGES,
+	TREE_STAGE_OPTIONS,
+	TREE_SHAPES,
+	CROOKEDNESS_MODES,
+	type TreeStage,
+} from '../types.js';
+import { applyStageModifiers } from './index.js';
 
 function makeConfig(overrides: Partial<TreeConfig> = {}): TreeConfig {
 	return { ...DEFAULT_TREE_CONFIG, ...overrides };
@@ -256,6 +264,18 @@ describe('dead stage', () => {
 		const overlap = [...deadColors].filter((c) => leafyColors.has(c));
 		expect(overlap.length).toBeLessThan(deadColors.size);
 	});
+
+	it('config overrides: trunkLean=15, trunkCrookedness=50, trunkSegments=5', () => {
+		const result = applyStageModifiers(makeConfig({ stage: TREE_STAGES.dead }));
+		expect(result.kind).toBe('modifiedConfig');
+		if (result.kind !== 'modifiedConfig') {
+			return;
+		}
+		expect(result.config.trunkLean).toBe(15);
+		expect(result.config.trunkCrookedness).toBe(50);
+		expect(result.config.trunkSegments).toBe(5);
+		expect(result.config.crookednessMode).toBe(CROOKEDNESS_MODES.random);
+	});
 });
 
 describe('stump stage', () => {
@@ -268,6 +288,77 @@ describe('stump stage', () => {
 	it('produces trunk triangles', () => {
 		const geo = generateTree(makeConfig({ stage: TREE_STAGES.stump }));
 		expect(geo.trunkTriangles.length).toBeGreaterThan(0);
+	});
+});
+
+describe('pine trunk height respects trunkHeight slider', () => {
+	it('pine with trunkHeight=10 has trunk top y > pine with trunkHeight=100 (shorter trunk = lower on screen)', () => {
+		const tallPine = generateTree(
+			makeConfig({ shape: TREE_SHAPES.pine, trunkHeight: 100, seed: 42 }),
+		);
+		const shortPine = generateTree(
+			makeConfig({ shape: TREE_SHAPES.pine, trunkHeight: 10, seed: 42 }),
+		);
+		// Trunk top = last junction = highest point (lowest Y)
+		const tallTrunkTopY = tallPine.anchors.trunkTop.y;
+		const shortTrunkTopY = shortPine.anchors.trunkTop.y;
+		// Short trunk should have higher Y (lower on screen) than tall trunk
+		expect(shortTrunkTopY).toBeGreaterThan(tallTrunkTopY);
+		// Delta should be significant (at least 20px for 300px viewbox)
+		expect(shortTrunkTopY - tallTrunkTopY).toBeGreaterThanOrEqual(20);
+	});
+
+	it('pine trunk top is not clamped into canopy (tiered shapes skip trunk-penetration clamp)', () => {
+		// Pine defaultTrunkTop = H*0.8 = 240. Without the isTiered guard,
+		// the trunk-penetration clamp forces trunkTop up to canopyBounds.maxY - 15,
+		// overriding the slider. With the guard, trunkTop stays at ~240.
+		const pine = generateTree(
+			makeConfig({ shape: TREE_SHAPES.pine, trunkHeight: 100, seed: 42 }),
+		);
+		// Pine trunk top should be near defaultTrunkTop (240), not clamped to ~165
+		expect(pine.anchors.trunkTop.y).toBeGreaterThan(200);
+	});
+});
+
+describe('birch stripes', () => {
+	it('birch shape produces 3-6 stripes', () => {
+		const geo = generateTree(makeConfig({ shape: TREE_SHAPES.birch, seed: 42 }));
+		expect(geo.birchStripes.length).toBeGreaterThanOrEqual(3);
+		expect(geo.birchStripes.length).toBeLessThanOrEqual(6);
+	});
+
+	it('non-birch shapes produce empty birchStripes array', () => {
+		const oakGeo = generateTree(makeConfig({ shape: TREE_SHAPES.oak, seed: 42 }));
+		expect(oakGeo.birchStripes).toHaveLength(0);
+		const pineGeo = generateTree(makeConfig({ shape: TREE_SHAPES.pine, seed: 42 }));
+		expect(pineGeo.birchStripes).toHaveLength(0);
+	});
+
+	it('birch stripe y-values are between trunk top and trunk bottom', () => {
+		const geo = generateTree(makeConfig({ shape: TREE_SHAPES.birch, seed: 42 }));
+		const trunkTopY = geo.anchors.trunkTop.y;
+		const trunkBaseY = geo.anchors.trunkBase.y;
+		for (const stripe of geo.birchStripes) {
+			expect(stripe.y).toBeGreaterThanOrEqual(trunkTopY);
+			expect(stripe.y).toBeLessThanOrEqual(trunkBaseY);
+		}
+	});
+
+	it('birch stripe colors are dark (low lightness HSL)', () => {
+		const geo = generateTree(makeConfig({ shape: TREE_SHAPES.birch, seed: 42 }));
+		for (const stripe of geo.birchStripes) {
+			// Color format: hsl(0, 0%, N%) where N is 15-29
+			expect(stripe.color).toMatch(/^hsl\(0, 0%, \d+%\)$/);
+			const lightness = parseInt(stripe.color.match(/(\d+)%\)$/)![1]!, 10);
+			expect(lightness).toBeGreaterThanOrEqual(15);
+			expect(lightness).toBeLessThan(30);
+		}
+	});
+
+	it('birch stripes are deterministic (same seed produces same stripes)', () => {
+		const geo1 = generateTree(makeConfig({ shape: TREE_SHAPES.birch, seed: 123 }));
+		const geo2 = generateTree(makeConfig({ shape: TREE_SHAPES.birch, seed: 123 }));
+		expect(geo1.birchStripes).toEqual(geo2.birchStripes);
 	});
 });
 

--- a/src/lib/trees/stages/stump_generator.ts
+++ b/src/lib/trees/stages/stump_generator.ts
@@ -72,6 +72,7 @@ export function generateStumpGeometry(): TreeGeometry {
 		fruitSlots: [],
 		flowerSlots: [],
 		showFallingLeaves: false,
+		birchStripes: [],
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/types.test.ts
+++ b/src/lib/trees/types.test.ts
@@ -7,6 +7,7 @@ import {
 	TREE_SHAPE_OPTIONS,
 	type TreeShape,
 } from './types.js';
+import { getShapeDefinition } from './shapes/blob_generators.js';
 
 describe('TREE_SHAPES union', () => {
 	const allShapes = [
@@ -209,7 +210,7 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			branchesLevel1Range: [3, 5],
 			branchesLevel2Range: [1, 2],
 			branchesLevel3Range: [0, 1],
-			branchAngle: 30,
+			branchAngle: 15,
 			trunkTwist: 35,
 			blobSizeVariance: 2.0,
 			blobCloseness: 35,
@@ -227,6 +228,11 @@ describe('SHAPE_DEFAULTS §2.5', () => {
 			fruitType: 'catkin_willow',
 			fruitCount: 3,
 		});
+	});
+
+	it('willow blobVerticalOffset is 25 (drooping canopy)', () => {
+		const willowDef = getShapeDefinition(TREE_SHAPES.willow);
+		expect(willowDef.styleParameters?.blobVerticalOffset).toBe(25);
 	});
 
 	it('every shape entry has crookednessMode, trunkSegments >= 1, trunkCrookedness >= 0', () => {

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -9,6 +9,7 @@ export {
 	type BlobGeometry,
 	type BranchGeometry,
 	type JunctionData,
+	type BirchStripe,
 	type TreeGeometry,
 } from './types/core.js';
 

--- a/src/lib/trees/types/config.ts
+++ b/src/lib/trees/types/config.ts
@@ -341,7 +341,7 @@ export const SHAPE_DEFAULTS = {
 		branchesLevel1Range: [3, 5] as readonly [number, number],
 		branchesLevel2Range: [1, 2] as readonly [number, number],
 		branchesLevel3Range: [0, 1] as readonly [number, number],
-		branchAngle: 30,
+		branchAngle: 15,
 		branchMirroring: BRANCH_MIRRORING.off,
 		trunkFork: false,
 		trunkTwist: 35,

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -101,6 +101,14 @@ export interface JunctionData {
 	readonly bisectorAngle: number;
 }
 
+export interface BirchStripe {
+	readonly y: number;
+	readonly centerX: number;
+	readonly width: number;
+	readonly height: number;
+	readonly color: string;
+}
+
 export interface TreeGeometry {
 	/** Stacked trapezoid quads for trunk (BR-1). Empty for simple stages. */
 	readonly trunkQuads: readonly Quad[];
@@ -117,6 +125,8 @@ export interface TreeGeometry {
 	readonly showFallingLeaves: boolean;
 	readonly anchors: TreeAnchors;
 	readonly viewBox: { readonly width: number; readonly height: number };
+	/** Dark horizontal stripes on birch trunks. Empty for non-birch shapes. */
+	readonly birchStripes: readonly BirchStripe[];
 	/** Junction positions/widths/ratios for Phase 2 (REQ-EV2-C-01). */
 	readonly junctionData?: readonly JunctionData[];
 	/** Canopy envelope bounds for Phase 2 (REQ-EV2-C-04). */


### PR DESCRIPTION
## Description
- Add dark horizontal birch trunk stripes (3-6 SVG rects overlaid on trunk quads)
- Fix pine/fir trunk height slider: skip trunk-penetration clamp for tiered shapes
- Update dead stage overrides: trunkLean=15, trunkCrookedness=50, trunkSegments=5, crookednessMode=random
- Tune willow drooping: branchAngle 30→15, blobVerticalOffset 15→25

## Resolves
Closes #85

## Testing
- [x] Dead stage config override values verified via applyStageModifiers
- [x] Pine trunkHeight=10 produces shorter trunk than trunkHeight=100
- [x] Birch generates 3-6 stripes with dark colors within trunk bounds
- [x] Willow branchAngle and blobVerticalOffset updated
- [x] All 2429 tests pass
- [x] check:all (prettier + oxlint + stylelint + knip + svelte-check + eslint) passes