### PR TITLE
#115 feat(engine): canopy lighting contrast — ambient floor, normal scaling, power curve

### DIFF
--- a/src/lib/trees/lighting.test.ts
+++ b/src/lib/trees/lighting.test.ts
@@ -91,6 +91,86 @@ describe('computeCanopyColor — two-color interpolation', () => {
 		const color = computeCanopyColor(center, BOUNDS, flat);
 		expect(color).toMatch(/^#[0-9a-f]{6}$/);
 	});
+
+	it('shadow-side triangles reach near-dark color', () => {
+		// Triangle at lower-right edge (away from light at 130 degrees) should
+		// produce lightness within 2 units of canopyDarkColor — validates that
+		// the lowered ambient floor lets shadows reach near-minimum.
+		const shadowTri: TrianglePoints = [
+			{ x: 92, y: 92 },
+			{ x: 97, y: 92 },
+			{ x: 95, y: 97 },
+		];
+		const darkL = hexToHsl(oakConfig.canopyDarkColor).l;
+		const resultL = hexToHsl(computeCanopyColor(shadowTri, BOUNDS, oakConfig)).l;
+		expect(Math.abs(resultL - darkL)).toBeLessThanOrEqual(2);
+	});
+
+	it('lit-side triangles reach near-light color', () => {
+		// Triangle on the lit side of the hemisphere (toward light at 130 degrees)
+		// should produce lightness within 2 units of canopyLightColor. Position
+		// chosen inside the hemisphere disk (r2 < 1) to avoid rim darkening.
+		const litTri: TrianglePoints = [
+			{ x: 22, y: 17 },
+			{ x: 27, y: 17 },
+			{ x: 24, y: 22 },
+		];
+		const lightL = hexToHsl(oakConfig.canopyLightColor).l;
+		const resultL = hexToHsl(computeCanopyColor(litTri, BOUNDS, oakConfig)).l;
+		expect(Math.abs(resultL - lightL)).toBeLessThanOrEqual(2);
+	});
+
+	it('wide contrast range across the canopy', () => {
+		// Sample a uniform grid across the canopy — the observed lightness range
+		// should exceed 95% of the full dark-to-light range, validating that
+		// both extremes are reachable with the steeper normals and lower ambient.
+		const darkL = hexToHsl(oakConfig.canopyDarkColor).l;
+		const lightL = hexToHsl(oakConfig.canopyLightColor).l;
+		const fullRange = lightL - darkL;
+
+		const lightnesses: number[] = [];
+		for (let gx = 5; gx <= 95; gx += 10) {
+			for (let gy = 5; gy <= 95; gy += 10) {
+				const tri: TrianglePoints = [
+					{ x: gx, y: gy },
+					{ x: gx + 4, y: gy },
+					{ x: gx + 2, y: gy + 4 },
+				];
+				lightnesses.push(hexToHsl(computeCanopyColor(tri, BOUNDS, oakConfig)).l);
+			}
+		}
+
+		const minL = Math.min(...lightnesses);
+		const maxL = Math.max(...lightnesses);
+		expect(maxL - minL).toBeGreaterThan(fullRange * 0.95);
+	});
+
+	it('shadow bias — median lightness below midpoint', () => {
+		// Uniformly distributed triangles should have median lightness below
+		// the midpoint of dark-to-light range (power curve pushes toward shadow)
+		const darkL = hexToHsl(oakConfig.canopyDarkColor).l;
+		const lightL = hexToHsl(oakConfig.canopyLightColor).l;
+		const midpoint = (darkL + lightL) / 2;
+
+		const lightnesses: number[] = [];
+		for (let gx = 5; gx <= 95; gx += 10) {
+			for (let gy = 5; gy <= 95; gy += 10) {
+				const tri: TrianglePoints = [
+					{ x: gx, y: gy },
+					{ x: gx + 4, y: gy },
+					{ x: gx + 2, y: gy + 4 },
+				];
+				lightnesses.push(hexToHsl(computeCanopyColor(tri, BOUNDS, oakConfig)).l);
+			}
+		}
+
+		lightnesses.sort((a, b) => a - b);
+		const median = lightnesses[Math.floor(lightnesses.length / 2)];
+		// Power curve biases median well below the midpoint (at least 8 units).
+		// Old linear formula had median ~34.5 vs midpoint ~38.3 (gap ~3.8);
+		// the power curve pushes it to ~25.5 (gap ~12.8).
+		expect(median).toBeLessThan(midpoint - 8);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/trees/lighting.ts
+++ b/src/lib/trees/lighting.ts
@@ -95,7 +95,7 @@ export function computeCanopyColor(
 	// depthVariance (0 → uniform lighting, 1 → standard, 2 → exaggerated).
 	const r2 = nx * nx + ny * ny;
 	const z = (r2 < 1 ? Math.sqrt(1 - r2) : 0.05) * config.depthVariance;
-	const normal = normalize3({ x: nx * 0.7, y: ny * 0.7, z });
+	const normal = normalize3({ x: nx * 0.95, y: ny * 0.95, z });
 
 	// Diffuse lighting clamped to [0, 1]
 	const diffuse = clamp(dot3(normal, light), 0, 1);
@@ -103,10 +103,10 @@ export function computeCanopyColor(
 	// Rim darkening — triangles outside the hemisphere disk
 	const rimFactor = r2 < 1 ? 1 : 0.7;
 
-	// REQ-L-02: ambient 0.15 + diffuse 0.85 × diffuse. Rim factor applies
-	// last and only reduces edge brightness, so fully-lit non-rim faces
-	// still reach lighting = 1 and land on canopyLightColor exactly.
-	const lighting = clamp((0.15 + 0.85 * diffuse) * rimFactor, 0, 1);
+	// REQ-L-02: ambient 0.05 + diffuse 0.95, then power curve 1.4 to bias
+	// toward shadows. Rim factor applies last.
+	const linearLighting = clamp((0.05 + 0.95 * diffuse) * rimFactor, 0, 1);
+	const lighting = Math.pow(linearLighting, 1.4);
 
 	return interpolateHslInHexSpace(config.canopyDarkColor, config.canopyLightColor, lighting);
 }

--- a/src/lib/trees/lighting.ts
+++ b/src/lib/trees/lighting.ts
@@ -75,7 +75,7 @@ function triangleCentroid(points: readonly [Point2D, Point2D, Point2D]): Point2D
  * The output color is produced by interpolating between `canopyDarkColor`
  * and `canopyLightColor` in HSL space using the computed lighting factor
  * (REQ-L-01, REQ-L-02, REQ-L-07). Fully-lit faces map exactly to
- * `canopyLightColor`; fully-shadowed faces map exactly to `canopyDarkColor`.
+ * `canopyLightColor`; fully-shadowed faces reach near `canopyDarkColor`.
  */
 export function computeCanopyColor(
 	points: readonly [Point2D, Point2D, Point2D],


### PR DESCRIPTION
## Description
- Lowered canopy ambient floor from 0.15 to 0.05 so shadow faces reach near-dark color
- Raised normal xy scale from 0.7 to 0.95 for sharper light/dark directional split
- Applied power curve (lighting^1.4) to push more faces toward shadows, making bright highlights accent-like
- Added 4 new tests: shadow-side reach, lit-side reach, contrast range, shadow bias

## Resolves
Closes #115

## Testing
- [x] Shadow-side triangles reach within 2 lightness units of canopyDarkColor
- [x] Lit-side triangles reach within 2 lightness units of canopyLightColor
- [x] Contrast range spans >95% of full dark-to-light range
- [x] Median lightness biased >8 units below midpoint (power curve shadow bias)
- [x] All 2460 existing tests pass — no regressions
- [x] Static checks pass (format, lint, typecheck, stylelint, knip)