### PR TITLE
#116 feat(engine): canopy depth layering, light direction tuning, facet noise

### DIFF
--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -232,6 +232,15 @@ const CONICAL_TAPER_FRACTION = 0.25;
 /** Seed offset for junction strip ratio computation. */
 const JUNCTION_STRIP_SEED_OFFSET = 900;
 const BIRCH_STRIPE_SEED_OFFSET = 9999;
+const BLOB_FACET_NOISE_SEED_MULTIPLIER = 3333;
+const TIER_FACET_NOISE_SEED_MULTIPLIER = 4444;
+
+const DEPTH_DARKENING_FLOOR = 0.75;
+const DEPTH_DARKENING_RANGE = 0.25;
+
+function computeDepthDarkeningFactor(normalizedDepth: number): number {
+	return DEPTH_DARKENING_FLOOR + DEPTH_DARKENING_RANGE * normalizedDepth;
+}
 
 // ---------------------------------------------------------------------------
 // Engine v2: Junction-Based Strip Ratios (REQ-EV2-S-01, S-02, S-03)
@@ -768,6 +777,7 @@ function generateBlobCanopy(
 	const totalArea = blobs.reduce((sum, b) => sum + b.rx * b.ry, 0);
 	const averageArea = blobs.length > 0 ? totalArea / blobs.length : 1;
 	const depths = assignBlobDepths(blobs, rng);
+	const maxDepth = Math.max(...depths);
 
 	const blobGeos: { geo: BlobGeometry; depth: number }[] = [];
 
@@ -837,13 +847,15 @@ function generateBlobCanopy(
 			),
 		);
 
+		const depth = depths[i]!;
+		const depthDarkeningFactor =
+			maxDepth > 0 ? computeDepthDarkeningFactor(depth / maxDepth) : 1;
+		const blobRng = createPrng(config.seed + i * BLOB_FACET_NOISE_SEED_MULTIPLIER);
 		const coloredTris: Triangle[] = filtered.map((tri) => ({
 			points: tri,
-			color: computeCanopyColor(tri, blobBounds, config),
+			color: computeCanopyColor(tri, blobBounds, config, blobRng, depthDarkeningFactor),
 			group: GEOMETRY_GROUPS.canopy,
 		}));
-
-		const depth = depths[i]!;
 		blobGeos.push({
 			geo: { triangles: coloredTris, center: { x: blob.cx, y: blob.cy }, depth },
 			depth,
@@ -913,9 +925,12 @@ function generateTierCanopy(
 			isTriangleInsideRegion(tri, (x, y) => isPointInTier(x, y, tier)),
 		);
 
+		const depthDarkeningFactor =
+			count <= 1 ? 1 : computeDepthDarkeningFactor((count - 1 - i) / (count - 1));
+		const tierRng = createPrng(config.seed + i * TIER_FACET_NOISE_SEED_MULTIPLIER);
 		const coloredTris: Triangle[] = filtered.map((tri) => ({
 			points: tri,
-			color: computeCanopyColor(tri, tierBounds, config),
+			color: computeCanopyColor(tri, tierBounds, config, tierRng, depthDarkeningFactor),
 			group: GEOMETRY_GROUPS.canopy,
 		}));
 

--- a/src/lib/trees/lighting.test.ts
+++ b/src/lib/trees/lighting.test.ts
@@ -107,9 +107,8 @@ describe('computeCanopyColor — two-color interpolation', () => {
 	});
 
 	it('lit-side triangles reach near-light color', () => {
-		// Triangle on the lit side of the hemisphere (toward light at 130 degrees)
-		// should produce lightness within 2 units of canopyLightColor. Position
-		// chosen inside the hemisphere disk (r2 < 1) to avoid rim darkening.
+		// Triangle on the lit side of the hemisphere (toward light at 130 degrees).
+		// Tolerance is 4 because z=0.3 shifts peak specular off-axis.
 		const litTri: TrianglePoints = [
 			{ x: 22, y: 17 },
 			{ x: 27, y: 17 },
@@ -117,7 +116,7 @@ describe('computeCanopyColor — two-color interpolation', () => {
 		];
 		const lightL = hexToHsl(oakConfig.canopyLightColor).l;
 		const resultL = hexToHsl(computeCanopyColor(litTri, BOUNDS, oakConfig)).l;
-		expect(Math.abs(resultL - lightL)).toBeLessThanOrEqual(2);
+		expect(Math.abs(resultL - lightL)).toBeLessThanOrEqual(4);
 	});
 
 	it('wide contrast range across the canopy', () => {
@@ -193,6 +192,88 @@ const TRUNK_BOUNDS = { minX: 80, maxX: 120 };
 function noJitterRng(): number {
 	return 0.5;
 }
+
+// ---------------------------------------------------------------------------
+// Canopy depth layering & facet noise (issue #116)
+// ---------------------------------------------------------------------------
+
+describe('computeCanopyColor — facet noise via rng parameter', () => {
+	it('with varying rng, same triangle produces different colors on repeated calls', () => {
+		let callCount = 0;
+		const varyingRng = () => {
+			callCount++;
+			return callCount % 3 === 0 ? 0.1 : callCount % 3 === 1 ? 0.9 : 0.5;
+		};
+		const a = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, varyingRng);
+		const b = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, varyingRng);
+		expect(a).not.toBe(b);
+	});
+
+	it('with rng returning 0.5, output equals no-rng case', () => {
+		const noRngResult = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig);
+		const midRng = () => 0.5;
+		const withRngResult = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, midRng);
+		expect(withRngResult).toBe(noRngResult);
+	});
+});
+
+describe('computeCanopyColor — depth darkening factor', () => {
+	it('depthDarkeningFactor=0.75 produces darker output than 1.0', () => {
+		const darkened = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, undefined, 0.75);
+		const normal = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, undefined, 1.0);
+		const darkenedL = hexToHsl(darkened).l;
+		const normalL = hexToHsl(normal).l;
+		expect(darkenedL).toBeLessThan(normalL);
+	});
+
+	it('default (no parameter) behaves same as depthDarkeningFactor=1.0', () => {
+		const defaultResult = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig);
+		const explicitResult = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, undefined, 1.0);
+		expect(defaultResult).toBe(explicitResult);
+	});
+});
+
+describe('computeCanopyColor — facet noise bounds', () => {
+	it('rng returning 0 still produces valid hex color', () => {
+		const rng = () => 0;
+		const color = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, rng);
+		expect(color).toMatch(/^#[0-9a-f]{6}$/);
+	});
+
+	it('rng returning 1 still produces valid hex color', () => {
+		const rng = () => 1;
+		const color = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, rng);
+		expect(color).toMatch(/^#[0-9a-f]{6}$/);
+	});
+
+	it('extreme rng values keep lightness within dark-light range', () => {
+		const darkL = hexToHsl(oakConfig.canopyDarkColor).l;
+		const lightL = hexToHsl(oakConfig.canopyLightColor).l;
+		for (const rngVal of [0, 1]) {
+			const rng = () => rngVal;
+			const hsl = hexToHsl(computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, rng));
+			expect(hsl.l).toBeGreaterThanOrEqual(darkL - 1);
+			expect(hsl.l).toBeLessThanOrEqual(lightL + 1);
+		}
+	});
+});
+
+describe('computeCanopyColor — deterministic facet noise with seeded rng', () => {
+	it('same seeded rng produces identical output', () => {
+		const makeRng = () => {
+			let s = 42;
+			return () => {
+				s = (s + 0x6d2b79f5) | 0;
+				let t = Math.imul(s ^ (s >>> 15), 1 | s);
+				t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+				return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+			};
+		};
+		const a = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, makeRng());
+		const b = computeCanopyColor(CENTER_TRI, BOUNDS, oakConfig, makeRng());
+		expect(a).toBe(b);
+	});
+});
 
 describe('VQ-2: trunk triangles on lit side are brighter than shadowed side', () => {
 	it('with lightAngle=0 (light from right), right-side triangles are brighter', () => {

--- a/src/lib/trees/lighting.ts
+++ b/src/lib/trees/lighting.ts
@@ -20,7 +20,7 @@ function lightDirection(angleDeg: number): { x: number; y: number; z: number } {
 	return {
 		x: Math.cos(rad),
 		y: -Math.sin(rad),
-		z: 0.5,
+		z: 0.3,
 	};
 }
 
@@ -76,11 +76,18 @@ function triangleCentroid(points: readonly [Point2D, Point2D, Point2D]): Point2D
  * and `canopyLightColor` in HSL space using the computed lighting factor
  * (REQ-L-01, REQ-L-02, REQ-L-07). Fully-lit faces map exactly to
  * `canopyLightColor`; fully-shadowed faces reach near `canopyDarkColor`.
+ *
+ * Optional `rng` adds per-triangle facet noise for visual variety.
+ * Optional `depthDarkeningFactor` darkens back-layer blobs (< 1 = darker).
  */
+const FACET_NOISE_AMPLITUDE = 0.08;
+
 export function computeCanopyColor(
 	points: readonly [Point2D, Point2D, Point2D],
 	canopyBounds: { minX: number; minY: number; maxX: number; maxY: number },
 	config: LightConfig,
+	rng?: () => number,
+	depthDarkeningFactor?: number,
 ): string {
 	const centroid = triangleCentroid(points);
 	const light = normalize3(lightDirection(config.lightAngle));
@@ -108,7 +115,16 @@ export function computeCanopyColor(
 	const linearLighting = clamp((0.05 + 0.95 * diffuse) * rimFactor, 0, 1);
 	const lighting = Math.pow(linearLighting, 1.4);
 
-	return interpolateHslInHexSpace(config.canopyDarkColor, config.canopyLightColor, lighting);
+	// Depth darkening: back-layer blobs receive a multiplier < 1
+	let finalLighting = lighting * (depthDarkeningFactor ?? 1);
+
+	// Per-triangle facet noise for visual variety
+	if (rng) {
+		finalLighting += (rng() - 0.5) * FACET_NOISE_AMPLITUDE;
+	}
+	finalLighting = clamp(finalLighting, 0, 1);
+
+	return interpolateHslInHexSpace(config.canopyDarkColor, config.canopyLightColor, finalLighting);
 }
 
 /**


### PR DESCRIPTION
## Description
- Light direction z-component reduced from 0.5 to 0.3 for more lateral, dramatic directional lighting
- Back-layer canopy blobs receive depth-based darkening multiplier (0.75–1.0) for visible depth layering
- Per-triangle facet noise added via optional seeded RNG parameter (±0.04 lighting offset)
- Tier depth ordering corrected so back tiers are darkest, front tiers lightest

## Resolves
Closes #116

## Testing
- [x] 8 new unit tests for facet noise, depth darkening, bounds, and determinism
- [x] Existing lighting tests updated and passing (lit-side tolerance adjusted for z=0.3)
- [x] All 2468 tests pass
- [x] Full static check suite green (format + lint + typecheck + stylelint + knip)