### PR TITLE
#76 fix(engine): growth animation, dynamic branch maximums, stage SVGs

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -790,20 +790,20 @@ Trunk color UI includes preset swatch buttons that set all three HSL sliders at 
 
 - [ ] **REQ-EV2-TZ-03** Updated SHAPE_DEFAULTS for `trunkSegments`:
 
-                                                                                                                                                          | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
-                                                                                                                                                          |---------|---------|--------|-------------|---------------------------|
-                                                                                                                                                          | oak     | 5       | 3      | 5           | 1 + 4                     |
-                                                                                                                                                          | maple   | 3       | 5      | 7           | 2 + 5                     |
-                                                                                                                                                          | willow  | 5       | 5      | 7           | 2 + 5                     |
-                                                                                                                                                          | cherry  | 3       | 4      | 6           | 1 + 5                     |
-                                                                                                                                                          | birch   | 3       | 2      | 4           | 1 + 3                     |
-                                                                                                                                                          | apple   | 3       | 2      | 3           | 1 + 2                     |
-                                                                                                                                                          | baobab  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                                                                                          | acacia  | 3       | 3      | 5           | 1 + 4                     |
-                                                                                                                                                          | pine    | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                                                                          | fir     | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                                                                          | cypress | 3       | 0      | 3           | unchanged (no branches)    |
-                                                                                                                                                          | bush    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                                    | Shape   | Current | Max L1 | New Default | Zone Split (lower + upper) |
+                                                                                                                                                                    |---------|---------|--------|-------------|---------------------------|
+                                                                                                                                                                    | oak     | 5       | 3      | 5           | 1 + 4                     |
+                                                                                                                                                                    | maple   | 3       | 5      | 7           | 2 + 5                     |
+                                                                                                                                                                    | willow  | 5       | 5      | 7           | 2 + 5                     |
+                                                                                                                                                                    | cherry  | 3       | 4      | 6           | 1 + 5                     |
+                                                                                                                                                                    | birch   | 3       | 2      | 4           | 1 + 3                     |
+                                                                                                                                                                    | apple   | 3       | 2      | 3           | 1 + 2                     |
+                                                                                                                                                                    | baobab  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                                                                                                    | acacia  | 3       | 3      | 5           | 1 + 4                     |
+                                                                                                                                                                    | pine    | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                                    | fir     | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                                    | cypress | 3       | 0      | 3           | unchanged (no branches)    |
+                                                                                                                                                                    | bush    | 3       | 0      | 3           | unchanged (no branches)    |
 
 ### 13.6 Bottom-Up Sequential Generation
 
@@ -1043,16 +1043,16 @@ Phase 1 must deliver these interfaces for Phase 2 to consume:
 
 - [x] **REQ-EV2-SS-02** Shape-specific identity preserved via style parameters:
 
-                                                                                                                                                          | Shape   | Key Characteristics                                                 |
-                                                                                                                                                          |---------|---------------------------------------------------------------------|
-                                                                                                                                                          | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
-                                                                                                                                                          | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
-                                                                                                                                                          | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
-                                                                                                                                                          | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
-                                                                                                                                                          | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
-                                                                                                                                                          | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
-                                                                                                                                                          | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
-                                                                                                                                                          | apple   | Compact round canopy. Minimal branching. Large single blob.         |
+                                                                                                                                                                    | Shape   | Key Characteristics                                                 |
+                                                                                                                                                                    |---------|---------------------------------------------------------------------|
+                                                                                                                                                                    | oak     | Round crown. Trunk tip high weight → central blob. Balanced rx/ry.  |
+                                                                                                                                                                    | maple   | Blobs on side branches. Trunk tip = fork, no blob. Medium blobs.    |
+                                                                                                                                                                    | willow  | Blobs offset downward (droop). Branches at low angle. Low canopy.   |
+                                                                                                                                                                    | birch   | Alternating-side blobs. Airy canopy. Thin trunk.                    |
+                                                                                                                                                                    | cherry  | Horizontal spread. Blobs in wide band. Pink coloring.               |
+                                                                                                                                                                    | baobab  | Small blobs at very top. Dominant trunk. Short branches.             |
+                                                                                                                                                                    | acacia  | Flat parasol. Very wide rx, tiny ry. Branches horizontal.           |
+                                                                                                                                                                    | apple   | Compact round canopy. Minimal branching. Large single blob.         |
 
 - [x] **REQ-EV2-SS-03** Some branch tips will naturally not have blobs — those that fall outside
       the canopy envelope. This is acceptable and realistic (bare branch poking out of canopy).

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -31,6 +31,7 @@
 	import GlowEffect from '$lib/trees/overlays/GlowEffect.svelte';
 	import WiltingEffect from '$lib/trees/overlays/WiltingEffect.svelte';
 	import GroundElements from '$lib/trees/ground/GroundElements.svelte';
+	import { SeedSvg, SproutingSvg, StumpSvg } from '$lib/trees/assets/stages/index.js';
 	import {
 		OVERLAY_DEFAULTS,
 		OVERLAY_VIEWBOX_HEADROOM,
@@ -85,6 +86,26 @@
 	const geometry = $derived(generateTree(config));
 	const hasReadyGlow = $derived(config.stage === TREE_STAGES.ready);
 	const hasOverlayGlow = $derived(overlayConfig.glow.enabled);
+
+	const stageSvgComponent = $derived(
+		config.stage === TREE_STAGES.seed
+			? SeedSvg
+			: config.stage === TREE_STAGES.sprouting
+				? SproutingSvg
+				: config.stage === TREE_STAGES.stump
+					? StumpSvg
+					: null,
+	);
+
+	const isGrowing = $derived(animateGrowth || growthProgress < 1);
+	const growthTrunkStyle = $derived(
+		isGrowing
+			? `transform: scaleY(${growthProgress}); transform-origin: ${geometry.anchors.trunkBase.x}px ${geometry.anchors.trunkBase.y}px`
+			: undefined,
+	);
+	const growthCanopyStyle = $derived(
+		isGrowing ? `clip-path: inset(${(1 - growthProgress) * 100}% 0 0 0)` : undefined,
+	);
 
 	const glowFilterId = $derived(`glow-${config.seed}`);
 	const expandViewbox = $derived(needsViewboxExpansion(overlayConfig));
@@ -214,12 +235,7 @@
 	filter={hasOverlayGlow ? `url(#${glowFilterId})` : undefined}
 >
 	<GlowEffect config={overlayConfig.glow} filterId={glowFilterId} />
-	<g
-		class="tree-root"
-		class:animate-growth={animateGrowth}
-		style="--growth-origin-x: {geometry.anchors.trunkBase.x}px; --growth-origin-y: {geometry
-			.anchors.trunkBase.y}px; --growth-progress: {growthProgress};"
-	>
+	<g class="tree-root">
 		{#snippet branchGroupSnippet(branchGroup: BranchGeometry, branchIndex: number)}
 			<g
 				class="branch-group"
@@ -277,7 +293,11 @@
 		<!-- REQ-EV2-Z-04: 5-layer rendering for branching shapes -->
 		<!-- Layer 1: Back branches (behind trunk) -->
 		{#if showBranches && backRootBranches.length > 0}
-			<g class="back-branches">
+			<g
+				class="back-branches"
+				class:animate-trunk-growth={animateGrowth}
+				style={growthTrunkStyle}
+			>
 				{#each backRootBranches as { group, index: groupIndex } (groupIndex)}
 					{@render branchGroupSnippet(group, groupIndex)}
 				{/each}
@@ -286,41 +306,51 @@
 
 		<!-- Layer 2: Trunk -->
 		{#if showTrunk}
-			<g class="trunk">
-				{#each geometry.trunkQuads as quad (quad)}
-					<polygon
-						points="{quad.points[0].x},{quad.points[0].y} {quad.points[1].x},{quad
-							.points[1].y} {quad.points[2].x},{quad.points[2].y} {quad.points[3]
-							.x},{quad.points[3].y}"
-						fill={quad.color}
-						stroke={quad.color}
-						stroke-width="0.5"
-					/>
-				{/each}
-				{#each geometry.trunkTriangles as tri (tri)}
-					<polygon
-						points="{tri.points[0].x},{tri.points[0].y} {tri.points[1].x},{tri.points[1]
-							.y} {tri.points[2].x},{tri.points[2].y}"
-						fill={tri.color}
-						stroke={tri.color}
-						stroke-width="0.5"
-					/>
-				{/each}
-				{#each geometry.birchStripes as stripe (stripe)}
-					<rect
-						x={stripe.centerX - stripe.width / 2}
-						y={stripe.y - stripe.height / 2}
-						width={stripe.width}
-						height={stripe.height}
-						fill={stripe.color}
-					/>
-				{/each}
+			<g class="trunk" class:animate-trunk-growth={animateGrowth} style={growthTrunkStyle}>
+				{#if stageSvgComponent}
+					{@const StageSvg = stageSvgComponent}
+					<g
+						transform="translate({geometry.anchors.trunkBase.x},{geometry.anchors
+							.trunkBase.y})"
+					>
+						<StageSvg />
+					</g>
+				{:else}
+					{#each geometry.trunkQuads as quad (quad)}
+						<polygon
+							points="{quad.points[0].x},{quad.points[0].y} {quad.points[1].x},{quad
+								.points[1].y} {quad.points[2].x},{quad.points[2].y} {quad.points[3]
+								.x},{quad.points[3].y}"
+							fill={quad.color}
+							stroke={quad.color}
+							stroke-width="0.5"
+						/>
+					{/each}
+					{#each geometry.trunkTriangles as tri (tri)}
+						<polygon
+							points="{tri.points[0].x},{tri.points[0].y} {tri.points[1].x},{tri
+								.points[1].y} {tri.points[2].x},{tri.points[2].y}"
+							fill={tri.color}
+							stroke={tri.color}
+							stroke-width="0.5"
+						/>
+					{/each}
+					{#each geometry.birchStripes as stripe (stripe)}
+						<rect
+							x={stripe.centerX - stripe.width / 2}
+							y={stripe.y - stripe.height / 2}
+							width={stripe.width}
+							height={stripe.height}
+							fill={stripe.color}
+						/>
+					{/each}
+				{/if}
 			</g>
 		{/if}
 
 		<!-- Layer 3: Front branches -->
 		{#if showBranches}
-			<g class="branches">
+			<g class="branches" class:animate-trunk-growth={animateGrowth} style={growthTrunkStyle}>
 				{#each frontRootBranches as { group, index: groupIndex } (groupIndex)}
 					{@render branchGroupSnippet(group, groupIndex)}
 				{/each}
@@ -328,9 +358,13 @@
 		{/if}
 
 		<!-- Layer 4: Back canopy blobs -->
-		{#if showCanopy && backCanopyBlobs.length > 0}
+		{#if showCanopy && !stageSvgComponent && backCanopyBlobs.length > 0}
 			<WiltingEffect enabled={overlayConfig.wilting.enabled}>
-				<g class="back-canopy">
+				<g
+					class="back-canopy"
+					class:animate-canopy-growth={animateGrowth}
+					style={growthCanopyStyle}
+				>
 					{#each backCanopyBlobs as { blob, index: blobIndex } (blob)}
 						{@render canopyBlobSnippet(blob, blobIndex)}
 					{/each}
@@ -339,9 +373,13 @@
 		{/if}
 
 		<!-- Layer 5: Front canopy blobs -->
-		{#if showCanopy}
+		{#if showCanopy && !stageSvgComponent}
 			<WiltingEffect enabled={overlayConfig.wilting.enabled}>
-				<g class="canopy">
+				<g
+					class="canopy"
+					class:animate-canopy-growth={animateGrowth}
+					style={growthCanopyStyle}
+				>
 					{#each frontCanopyBlobs as { blob, index: blobIndex } (blob)}
 						{@render canopyBlobSnippet(blob, blobIndex)}
 					{/each}
@@ -543,13 +581,23 @@
 		}
 	}
 
-	@keyframes tree-growth {
+	@keyframes trunk-growth {
 		0% {
-			transform: scaleY(0.05) scaleX(1);
+			transform: scaleY(0.05);
 		}
 
 		100% {
-			transform: scaleY(1) scaleX(1);
+			transform: scaleY(1);
+		}
+	}
+
+	@keyframes canopy-reveal {
+		0% {
+			clip-path: inset(95% 0 0 0);
+		}
+
+		100% {
+			clip-path: inset(0 0 0 0);
 		}
 	}
 
@@ -584,10 +632,14 @@
 		will-change: transform;
 	}
 
-	.tree-root.animate-growth {
-		animation: tree-growth 2s ease-in-out infinite alternate;
-		transform-origin: var(--growth-origin-x) var(--growth-origin-y);
+	.animate-trunk-growth {
+		animation: trunk-growth 2s ease-in-out infinite alternate;
 		will-change: transform;
+	}
+
+	.animate-canopy-growth {
+		animation: canopy-reveal 2s ease-in-out infinite alternate;
+		will-change: clip-path;
 	}
 
 	.falling-leaf {

--- a/src/lib/trees/assets/stages/SeedSvg.svelte
+++ b/src/lib/trees/assets/stages/SeedSvg.svelte
@@ -1,0 +1,12 @@
+<!--
+  Seed stage — small seed shape with soil mound.
+  Centered at origin, ~14 units tall.
+-->
+<g>
+	<!-- Soil mound -->
+	<polygon points="-20,2 20,2 12,-2 -12,-2" fill="#6B4226" />
+	<polygon points="-12,-2 12,-2 0,-5" fill="#7A5033" />
+	<!-- Seed body (two-tone diamond) -->
+	<polygon points="-6,-4 6,-4 0,-14" fill="#8B6914" />
+	<polygon points="-6,-4 6,-4 0,2" fill="#5C4400" />
+</g>

--- a/src/lib/trees/assets/stages/SproutingSvg.svelte
+++ b/src/lib/trees/assets/stages/SproutingSvg.svelte
@@ -1,0 +1,12 @@
+<!--
+  Sprouting stage — thin stem with two unfurling leaves.
+  Centered at origin, ~30 units tall.
+-->
+<g>
+	<!-- Stem -->
+	<polygon points="-2,0 2,0 0,-30" fill="#5C4400" />
+	<!-- Left leaf -->
+	<polygon points="0,-26 -12,-30 -2,-36" fill="#7BC043" />
+	<!-- Right leaf -->
+	<polygon points="0,-26 12,-30 2,-36" fill="#4A7C28" />
+</g>

--- a/src/lib/trees/assets/stages/StumpSvg.svelte
+++ b/src/lib/trees/assets/stages/StumpSvg.svelte
@@ -1,0 +1,14 @@
+<!--
+  Stump stage — cut-off stump with visible ring.
+  Centered at origin, ~23 units tall.
+-->
+<g>
+	<!-- Left face -->
+	<polygon points="-12,0 0,0 -10,-20" fill="#5C4A32" />
+	<!-- Right face -->
+	<polygon points="0,0 12,0 10,-20" fill="#8B7355" />
+	<!-- Center fill -->
+	<polygon points="-10,-20 10,-20 0,0" fill="#5C4A32" />
+	<!-- Top surface -->
+	<polygon points="-10,-20 10,-20 0,-23" fill="#A08060" />
+</g>

--- a/src/lib/trees/assets/stages/index.ts
+++ b/src/lib/trees/assets/stages/index.ts
@@ -1,0 +1,3 @@
+export { default as SeedSvg } from './SeedSvg.svelte';
+export { default as SproutingSvg } from './SproutingSvg.svelte';
+export { default as StumpSvg } from './StumpSvg.svelte';

--- a/src/lib/trees/generate.test.ts
+++ b/src/lib/trees/generate.test.ts
@@ -2441,7 +2441,10 @@ describe('B8: all shapes x all stages cross-product', () => {
 								: {}),
 						}),
 					);
-					for (const tri of allTrianglesAndQuads(geo)) {
+					const polygons = allTrianglesAndQuads(geo);
+					// SVG-based stages (seed, sprouting, stump) produce empty geometry
+					expect(Array.isArray(polygons)).toBe(true);
+					for (const tri of polygons) {
 						for (const p of tri.points) {
 							expect(Number.isNaN(p.x)).toBe(false);
 							expect(Number.isNaN(p.y)).toBe(false);

--- a/src/lib/trees/shapes.ts
+++ b/src/lib/trees/shapes.ts
@@ -55,3 +55,5 @@ export {
 	CUSTOM_BLOB_CANOPY_CENTER_Y,
 	TRUNK_ENTRY_MIN_PX,
 } from './shapes/blob_generators.js';
+
+export { computeMaxBranches, clampBranchMaximums } from './shapes/branch_maximums.js';

--- a/src/lib/trees/shapes/branch_maximums.test.ts
+++ b/src/lib/trees/shapes/branch_maximums.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { TREE_SHAPES, BRANCH_MIRRORING, type TreeShape } from '../types.js';
+import { computeMaxBranches, clampBranchMaximums } from './branch_maximums.js';
+
+describe('computeMaxBranches', () => {
+	it('L1 max scales with trunk height — trunkHeight=100 > trunkHeight=10', () => {
+		const tall = computeMaxBranches(TREE_SHAPES.oak, 100);
+		const short = computeMaxBranches(TREE_SHAPES.oak, 10);
+		expect(tall.maxLevel1).toBeGreaterThan(short.maxLevel1);
+	});
+
+	it('L1 max is always >= 1 even with minimum trunk height', () => {
+		const result = computeMaxBranches(TREE_SHAPES.oak, 1);
+		expect(result.maxLevel1).toBeGreaterThanOrEqual(1);
+	});
+
+	it('L2 max is always >= 1', () => {
+		const result = computeMaxBranches(TREE_SHAPES.oak, 1);
+		expect(result.maxLevel2).toBeGreaterThanOrEqual(1);
+	});
+
+	it('L3 max is always >= 1', () => {
+		const result = computeMaxBranches(TREE_SHAPES.oak, 1);
+		expect(result.maxLevel3).toBeGreaterThanOrEqual(1);
+	});
+
+	it('short trunk produces small L1 max (1-3)', () => {
+		const result = computeMaxBranches(TREE_SHAPES.oak, 10);
+		expect(result.maxLevel1).toBeGreaterThanOrEqual(1);
+		expect(result.maxLevel1).toBeLessThanOrEqual(3);
+	});
+
+	it('tall trunk produces reasonable L1 max (>= 5)', () => {
+		const result = computeMaxBranches(TREE_SHAPES.oak, 100);
+		expect(result.maxLevel1).toBeGreaterThanOrEqual(5);
+	});
+
+	it('all tree shapes produce valid maximums', () => {
+		const shapes = Object.values(TREE_SHAPES) as TreeShape[];
+		for (const shape of shapes) {
+			const result = computeMaxBranches(shape, 50);
+			expect(result.maxLevel1, `${shape} maxLevel1`).toBeGreaterThanOrEqual(1);
+			expect(result.maxLevel2, `${shape} maxLevel2`).toBeGreaterThanOrEqual(1);
+			expect(result.maxLevel3, `${shape} maxLevel3`).toBeGreaterThanOrEqual(1);
+		}
+	});
+});
+
+describe('clampBranchMaximums', () => {
+	it('respects mirroring=preferred L1 min — maxLevel1 >= 2', () => {
+		const result = clampBranchMaximums(
+			{ maxLevel1: 1, maxLevel2: 1, maxLevel3: 1 },
+			BRANCH_MIRRORING.preferred,
+			false,
+		);
+		expect(result.maxLevel1).toBeGreaterThanOrEqual(2);
+	});
+
+	it('respects trunkFork L1 min — maxLevel1 >= 2', () => {
+		const result = clampBranchMaximums(
+			{ maxLevel1: 1, maxLevel2: 1, maxLevel3: 1 },
+			BRANCH_MIRRORING.off,
+			true,
+		);
+		expect(result.maxLevel1).toBeGreaterThanOrEqual(2);
+	});
+
+	it('respects mirroring=preferred L2 min — maxLevel2 >= 2', () => {
+		const result = clampBranchMaximums(
+			{ maxLevel1: 3, maxLevel2: 1, maxLevel3: 1 },
+			BRANCH_MIRRORING.preferred,
+			false,
+		);
+		expect(result.maxLevel2).toBeGreaterThanOrEqual(2);
+	});
+
+	it('does not change values when no constraints apply', () => {
+		const input = { maxLevel1: 5, maxLevel2: 3, maxLevel3: 2 };
+		const result = clampBranchMaximums(input, BRANCH_MIRRORING.off, false);
+		expect(result).toEqual(input);
+	});
+});

--- a/src/lib/trees/shapes/branch_maximums.ts
+++ b/src/lib/trees/shapes/branch_maximums.ts
@@ -1,0 +1,59 @@
+import { BRANCH_MIRRORING, type TreeShape, type BranchMirroring } from '../types.js';
+import { getShapeDefinition } from './blob_generators.js';
+import { computeEffectiveTrunkTop } from './trunk.js';
+
+const MIN_BRANCH_SPACING = 20;
+const CHILD_LEVEL_SCALE_FACTOR = 0.6;
+const MIN_BRANCHES_PER_LEVEL = 1;
+
+interface BranchMaximums {
+	readonly maxLevel1: number;
+	readonly maxLevel2: number;
+	readonly maxLevel3: number;
+}
+
+export function computeMaxBranches(shape: TreeShape, trunkHeight: number): BranchMaximums {
+	const shapeDef = getShapeDefinition(shape);
+	const effectiveTrunkTop = computeEffectiveTrunkTop(shapeDef, trunkHeight);
+	const totalTrunkLength = shapeDef.trunkBottom - effectiveTrunkTop;
+
+	const maxLevel1 = Math.max(
+		MIN_BRANCHES_PER_LEVEL,
+		Math.floor(totalTrunkLength / MIN_BRANCH_SPACING),
+	);
+	const maxLevel2 = Math.max(
+		MIN_BRANCHES_PER_LEVEL,
+		Math.floor(maxLevel1 * CHILD_LEVEL_SCALE_FACTOR),
+	);
+	const maxLevel3 = Math.max(
+		MIN_BRANCHES_PER_LEVEL,
+		Math.floor(maxLevel2 * CHILD_LEVEL_SCALE_FACTOR),
+	);
+
+	return { maxLevel1, maxLevel2, maxLevel3 };
+}
+
+/**
+ * Clamp branch maximums so they respect symmetry-forced minimums.
+ *
+ * When branchMirroring is 'preferred' or trunkFork is true, L1 needs at least 2.
+ * When branchMirroring is 'preferred', L2 needs at least 2.
+ */
+export function clampBranchMaximums(
+	maxBranches: BranchMaximums,
+	branchMirroring: BranchMirroring,
+	trunkFork: boolean,
+): BranchMaximums {
+	let { maxLevel1, maxLevel2 } = maxBranches;
+	const { maxLevel3 } = maxBranches;
+
+	if (branchMirroring === BRANCH_MIRRORING.preferred || trunkFork) {
+		maxLevel1 = Math.max(maxLevel1, 2);
+	}
+
+	if (branchMirroring === BRANCH_MIRRORING.preferred) {
+		maxLevel2 = Math.max(maxLevel2, 2);
+	}
+
+	return { maxLevel1, maxLevel2, maxLevel3 };
+}

--- a/src/lib/trees/stages/seed_generator.ts
+++ b/src/lib/trees/stages/seed_generator.ts
@@ -1,44 +1,11 @@
-import type { TreeGeometry, Triangle } from '../types.js';
-import { GEOMETRY_GROUPS, VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
+import type { TreeGeometry } from '../types.js';
+import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
 import { GROUND_LINE_Y } from './constants.js';
 
-const SEED_COLOR_LIGHT = '#8B6914';
-const SEED_COLOR_DARK = '#5C4400';
-const SOIL_COLOR = '#6B4226';
-
+/** Seed geometry — visual rendering handled by SeedSvg component. */
 export function generateSeedGeometry(): TreeGeometry {
 	const cx = VIEWBOX_WIDTH / 2;
 	const groundY = GROUND_LINE_Y;
-
-	const seedTriangles: Triangle[] = [
-		{
-			points: [
-				{ x: cx - 6, y: groundY - 4 },
-				{ x: cx + 6, y: groundY - 4 },
-				{ x: cx, y: groundY - 14 },
-			],
-			color: SEED_COLOR_LIGHT,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-		{
-			points: [
-				{ x: cx - 6, y: groundY - 4 },
-				{ x: cx + 6, y: groundY - 4 },
-				{ x: cx, y: groundY + 2 },
-			],
-			color: SEED_COLOR_DARK,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-		{
-			points: [
-				{ x: cx - 20, y: groundY + 2 },
-				{ x: cx + 20, y: groundY + 2 },
-				{ x: cx, y: groundY - 2 },
-			],
-			color: SOIL_COLOR,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-	];
 
 	const anchors = {
 		trunkTop: { x: cx, y: groundY - 14 },
@@ -53,7 +20,7 @@ export function generateSeedGeometry(): TreeGeometry {
 
 	return {
 		trunkQuads: [],
-		trunkTriangles: seedTriangles,
+		trunkTriangles: [],
 		branchGroups: [],
 		canopyBlobs: [],
 		fruitTriangles: [],

--- a/src/lib/trees/stages/sprouting_generator.ts
+++ b/src/lib/trees/stages/sprouting_generator.ts
@@ -1,48 +1,12 @@
-import type { TreeGeometry, Triangle } from '../types.js';
-import { GEOMETRY_GROUPS, VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
+import type { TreeGeometry } from '../types.js';
+import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
 import { GROUND_LINE_Y } from './constants.js';
 
-const STEM_COLOR = '#5C4400';
-const LEAF_COLOR_LIGHT = '#7BC043';
-const LEAF_COLOR_DARK = '#4A7C28';
-
+/** Sprouting geometry — visual rendering handled by SproutingSvg component. */
 export function generateSproutingGeometry(): TreeGeometry {
 	const cx = VIEWBOX_WIDTH / 2;
 	const groundY = GROUND_LINE_Y;
 	const stemTop = groundY - 30;
-
-	const trunkTriangles: Triangle[] = [
-		{
-			points: [
-				{ x: cx - 2, y: groundY },
-				{ x: cx + 2, y: groundY },
-				{ x: cx, y: stemTop },
-			],
-			color: STEM_COLOR,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-	];
-
-	const canopyTriangles: Triangle[] = [
-		{
-			points: [
-				{ x: cx, y: stemTop + 4 },
-				{ x: cx - 12, y: stemTop - 4 },
-				{ x: cx - 2, y: stemTop - 10 },
-			],
-			color: LEAF_COLOR_LIGHT,
-			group: GEOMETRY_GROUPS.canopy,
-		},
-		{
-			points: [
-				{ x: cx, y: stemTop + 4 },
-				{ x: cx + 12, y: stemTop - 4 },
-				{ x: cx + 2, y: stemTop - 10 },
-			],
-			color: LEAF_COLOR_DARK,
-			group: GEOMETRY_GROUPS.canopy,
-		},
-	];
 
 	const anchors = {
 		trunkTop: { x: cx, y: stemTop },
@@ -57,9 +21,9 @@ export function generateSproutingGeometry(): TreeGeometry {
 
 	return {
 		trunkQuads: [],
-		trunkTriangles,
+		trunkTriangles: [],
 		branchGroups: [],
-		canopyBlobs: [{ triangles: canopyTriangles, center: { x: cx, y: stemTop - 3 }, depth: 0 }],
+		canopyBlobs: [],
 		fruitTriangles: [],
 		stakeTriangles: [],
 		fruitSlots: [],

--- a/src/lib/trees/stages/stages.test.ts
+++ b/src/lib/trees/stages/stages.test.ts
@@ -88,23 +88,21 @@ describe('seed stage', () => {
 		expect(geo.branchGroups).toHaveLength(0);
 	});
 
-	it('produces trunk triangles (seed polygons)', () => {
+	it('produces empty trunk triangles (rendered via SVG component)', () => {
 		const geo = generateTree(makeConfig({ stage: TREE_STAGES.seed }));
-		expect(geo.trunkTriangles.length).toBeGreaterThan(0);
+		expect(geo.trunkTriangles).toHaveLength(0);
 	});
 });
 
 describe('sprouting stage', () => {
-	it('produces minimal canopy (leaf triangles)', () => {
+	it('produces empty canopy blobs (rendered via SVG component)', () => {
 		const geo = generateTree(makeConfig({ stage: TREE_STAGES.sprouting }));
-		expect(geo.canopyBlobs.length).toBeGreaterThan(0);
-		const totalCanopyTris = geo.canopyBlobs.reduce((s, b) => s + b.triangles.length, 0);
-		expect(totalCanopyTris).toBeLessThanOrEqual(4);
+		expect(geo.canopyBlobs).toHaveLength(0);
 	});
 
-	it('produces a trunk (stem)', () => {
+	it('produces empty trunk triangles (rendered via SVG component)', () => {
 		const geo = generateTree(makeConfig({ stage: TREE_STAGES.sprouting }));
-		expect(geo.trunkTriangles.length).toBeGreaterThan(0);
+		expect(geo.trunkTriangles).toHaveLength(0);
 	});
 });
 
@@ -285,9 +283,9 @@ describe('stump stage', () => {
 		expect(geo.branchGroups).toHaveLength(0);
 	});
 
-	it('produces trunk triangles', () => {
+	it('produces empty trunk triangles (rendered via SVG component)', () => {
 		const geo = generateTree(makeConfig({ stage: TREE_STAGES.stump }));
-		expect(geo.trunkTriangles.length).toBeGreaterThan(0);
+		expect(geo.trunkTriangles).toHaveLength(0);
 	});
 });
 

--- a/src/lib/trees/stages/stump_generator.ts
+++ b/src/lib/trees/stages/stump_generator.ts
@@ -1,55 +1,12 @@
-import type { TreeGeometry, Triangle } from '../types.js';
-import { GEOMETRY_GROUPS, VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
+import type { TreeGeometry } from '../types.js';
+import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
 import { GROUND_LINE_Y } from './constants.js';
 
-const STUMP_COLOR_LIGHT = '#8B7355';
-const STUMP_COLOR_DARK = '#5C4A32';
-const STUMP_TOP_COLOR = '#A08060';
-
+/** Stump geometry — visual rendering handled by StumpSvg component. */
 export function generateStumpGeometry(): TreeGeometry {
 	const cx = VIEWBOX_WIDTH / 2;
 	const groundY = GROUND_LINE_Y;
 	const stumpTop = groundY - 20;
-	const halfWidth = 12;
-
-	const trunkTriangles: Triangle[] = [
-		{
-			points: [
-				{ x: cx - halfWidth, y: groundY },
-				{ x: cx, y: groundY },
-				{ x: cx - halfWidth + 2, y: stumpTop },
-			],
-			color: STUMP_COLOR_DARK,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-		{
-			points: [
-				{ x: cx, y: groundY },
-				{ x: cx + halfWidth, y: groundY },
-				{ x: cx + halfWidth - 2, y: stumpTop },
-			],
-			color: STUMP_COLOR_LIGHT,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-		{
-			points: [
-				{ x: cx - halfWidth + 2, y: stumpTop },
-				{ x: cx + halfWidth - 2, y: stumpTop },
-				{ x: cx, y: groundY },
-			],
-			color: STUMP_COLOR_DARK,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-		{
-			points: [
-				{ x: cx - halfWidth + 2, y: stumpTop },
-				{ x: cx + halfWidth - 2, y: stumpTop },
-				{ x: cx, y: stumpTop - 3 },
-			],
-			color: STUMP_TOP_COLOR,
-			group: GEOMETRY_GROUPS.trunk,
-		},
-	];
 
 	const anchors = {
 		trunkTop: { x: cx, y: stumpTop - 3 },
@@ -64,7 +21,7 @@ export function generateStumpGeometry(): TreeGeometry {
 
 	return {
 		trunkQuads: [],
-		trunkTriangles,
+		trunkTriangles: [],
 		branchGroups: [],
 		canopyBlobs: [],
 		fruitTriangles: [],

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -34,7 +34,7 @@
 	} from '$lib/trees/tools/tool_types.js';
 	import ToolAccessoriesCard from '$lib/components/composed/ToolAccessoriesCard.svelte';
 	import OverlaysCard from '$lib/components/composed/OverlaysCard.svelte';
-	import { growCustomBlobs } from '$lib/trees/shapes.js';
+	import { growCustomBlobs, computeMaxBranches, clampBranchMaximums } from '$lib/trees/shapes.js';
 	import { isParamDisabled } from '$lib/trees/disabled_params.js';
 	import { getSavedTree, saveTree } from '$lib/trees/saved_trees.remote.js';
 	import { createTreeConfigContext } from '$lib/trees/tree_config.context.svelte.js';
@@ -99,6 +99,42 @@
 			branchDepth: treeConfig.current.branchDepth,
 		}),
 	);
+
+	const branchMaximums = $derived.by(() => {
+		const raw = computeMaxBranches(treeConfig.current.shape, treeConfig.current.trunkHeight);
+		return clampBranchMaximums(
+			raw,
+			treeConfig.current.branchMirroring,
+			treeConfig.current.trunkFork,
+		);
+	});
+
+	// Clamp current slider values when dynamic max drops below current range
+	$effect(() => {
+		const max1 = branchMaximums.maxLevel1;
+		const max2 = branchMaximums.maxLevel2;
+		const max3 = branchMaximums.maxLevel3;
+		const cfg = treeConfig.current;
+
+		if (cfg.branchesLevel1Range[1] > max1) {
+			treeConfig.current.branchesLevel1Range = [
+				Math.min(cfg.branchesLevel1Range[0], max1),
+				max1,
+			];
+		}
+		if (cfg.branchesLevel2Range[1] > max2) {
+			treeConfig.current.branchesLevel2Range = [
+				Math.min(cfg.branchesLevel2Range[0], max2),
+				max2,
+			];
+		}
+		if (cfg.branchesLevel3Range[1] > max3) {
+			treeConfig.current.branchesLevel3Range = [
+				Math.min(cfg.branchesLevel3Range[0], max3),
+				max3,
+			];
+		}
+	});
 
 	const savedId = $derived(page.url.searchParams.get('saved'));
 	const savedTreeQuery = $derived(savedId === null ? null : getSavedTree(savedId));
@@ -492,7 +528,7 @@
 							<LabeledRangeSliderDual
 								label="L1 Branches"
 								min={0}
-								max={10}
+								max={branchMaximums.maxLevel1}
 								value={[...treeConfig.current.branchesLevel1Range]}
 								onValueChange={(v) => (treeConfig.current.branchesLevel1Range = v)}
 								disabled={level1Disabled}
@@ -502,7 +538,7 @@
 							<LabeledRangeSliderDual
 								label="L2 Branches"
 								min={0}
-								max={5}
+								max={branchMaximums.maxLevel2}
 								value={[...treeConfig.current.branchesLevel2Range]}
 								onValueChange={(v) => (treeConfig.current.branchesLevel2Range = v)}
 								disabled={level2Disabled}
@@ -512,7 +548,7 @@
 							<LabeledRangeSliderDual
 								label="L3 Branches"
 								min={0}
-								max={3}
+								max={branchMaximums.maxLevel3}
 								value={[...treeConfig.current.branchesLevel3Range]}
 								onValueChange={(v) => (treeConfig.current.branchesLevel3Range = v)}
 								disabled={level3Disabled}

--- a/tests/e2e/animation.spec.ts
+++ b/tests/e2e/animation.spec.ts
@@ -52,15 +52,19 @@ test.describe('Scene page animation controls', () => {
 		await expect(branchGroup).not.toHaveClass(/animate-branch-sway/);
 	});
 
-	test('growth checkbox toggles animation on tree root', async ({ page }) => {
-		const treeRoot = page.locator('.tree-root').first();
-		await expect(treeRoot).toBeAttached();
+	test('growth checkbox toggles animation on trunk and canopy layers', async ({ page }) => {
+		const trunk = page.locator('.trunk').first();
+		await expect(trunk).toBeAttached();
 
 		await page.locator('[data-testid="animate-growth"]').click();
-		await expect(treeRoot).toHaveClass(/animate-growth/);
+		await expect(trunk).toHaveClass(/animate-trunk-growth/);
+
+		const canopy = page.locator('.canopy').first();
+		await expect(canopy).toHaveClass(/animate-canopy-growth/);
 
 		await page.locator('[data-testid="animate-growth"]').click();
-		await expect(treeRoot).not.toHaveClass(/animate-growth/);
+		await expect(trunk).not.toHaveClass(/animate-trunk-growth/);
+		await expect(canopy).not.toHaveClass(/animate-canopy-growth/);
 	});
 
 	test('multiple animations can be enabled simultaneously', async ({ page }) => {
@@ -68,9 +72,9 @@ test.describe('Scene page animation controls', () => {
 		await page.locator('[data-testid="animate-growth"]').click();
 
 		const canopyBlob = page.locator('.canopy-blob').first();
-		const treeRoot = page.locator('.tree-root').first();
+		const trunk = page.locator('.trunk').first();
 		await expect(canopyBlob).toHaveClass(/animate-canopy-sway/);
-		await expect(treeRoot).toHaveClass(/animate-growth/);
+		await expect(trunk).toHaveClass(/animate-trunk-growth/);
 	});
 });
 
@@ -98,10 +102,10 @@ test.describe('Editor page animation controls', () => {
 		await expect(canopyBlob).toHaveClass(/animate-canopy-sway/);
 	});
 
-	test('growth checkbox toggles animation on tree root', async ({ page }) => {
+	test('growth checkbox toggles animation on trunk layer', async ({ page }) => {
 		await page.locator('[data-testid="animate-growth"]').click();
 
-		const treeRoot = page.locator('.tree-root').first();
-		await expect(treeRoot).toHaveClass(/animate-growth/);
+		const trunk = page.locator('.trunk').first();
+		await expect(trunk).toHaveClass(/animate-trunk-growth/);
 	});
 });


### PR DESCRIPTION
## Description
- Growth animation now independently scales trunk/branches (scaleY from trunkBase) and reveals canopy progressively (clip-path inset) instead of uniform scaleY on the entire tree
- Branch count slider maximums computed dynamically from available trunk length (`computeMaxBranches`), with reactive clamping when trunk height changes
- Dynamic maximums respect symmetry-forced minimums from #111 (`clampBranchMaximums`)
- Seed, sprouting, and stump stages now render from hand-drawn SVG Svelte components instead of hardcoded triangle geometry

## Resolves
Closes #76

## Testing
- [x] 11 unit tests for `computeMaxBranches` and `clampBranchMaximums`
- [x] Updated stage tests for SVG-based rendering (empty geometry, preserved anchors)
- [x] All 2479 tests pass
- [x] `check:all` passes (format + lint + typecheck + stylelint + knip)