### PR TITLE
#88 fix(auth): auth reliability + settings visibility when signed out

### DIFF
--- a/src/routes/auth/sign-in/+page.svelte
+++ b/src/routes/auth/sign-in/+page.svelte
@@ -33,9 +33,15 @@
 	async function signInWithSocial(provider: SocialProvider) {
 		errorMessage = null;
 		pendingAction = provider;
-		const result = await authClient.signIn.social({ provider, callbackURL: resolve('/') });
-		if (result.error) {
-			errorMessage = result.error.message ?? `${PROVIDER_LABEL[provider]} sign-in failed.`;
+		try {
+			const result = await authClient.signIn.social({ provider, callbackURL: resolve('/') });
+			if (result.error) {
+				errorMessage =
+					result.error.message ?? `${PROVIDER_LABEL[provider]} sign-in failed.`;
+			}
+		} catch {
+			errorMessage = `${PROVIDER_LABEL[provider]} sign-in failed.`;
+		} finally {
 			pendingAction = null;
 		}
 	}
@@ -43,25 +49,35 @@
 	async function signInWithPasskey() {
 		errorMessage = null;
 		pendingAction = 'passkey';
-		const result = await authClient.signIn.passkey();
-		if (result?.error) {
-			errorMessage = result.error.message ?? 'Passkey sign-in failed.';
+		try {
+			const result = await authClient.signIn.passkey();
+			if (result?.error) {
+				errorMessage = result.error.message ?? 'Passkey sign-in failed.';
+				return;
+			}
+			await goto(resolve('/'));
+		} catch {
+			errorMessage = 'Passkey sign-in failed.';
+		} finally {
 			pendingAction = null;
-			return;
 		}
-		await goto(resolve('/'));
 	}
 
 	async function handleEmailSubmit() {
 		errorMessage = null;
 		pendingAction = 'email';
-		const result = await authClient.signIn.email({ email, password });
-		if (result.error) {
-			errorMessage = result.error.message ?? 'Sign-in failed.';
+		try {
+			const result = await authClient.signIn.email({ email, password });
+			if (result.error) {
+				errorMessage = result.error.message ?? 'Sign-in failed.';
+				return;
+			}
+			await goto(resolve('/'));
+		} catch {
+			errorMessage = 'Sign-in failed.';
+		} finally {
 			pendingAction = null;
-			return;
 		}
-		await goto(resolve('/'));
 	}
 </script>
 

--- a/src/routes/auth/sign-up/+page.svelte
+++ b/src/routes/auth/sign-up/+page.svelte
@@ -34,9 +34,15 @@
 	async function signInWithSocial(provider: SocialProvider) {
 		errorMessage = null;
 		pendingAction = provider;
-		const result = await authClient.signIn.social({ provider, callbackURL: resolve('/') });
-		if (result.error) {
-			errorMessage = result.error.message ?? `${PROVIDER_LABEL[provider]} sign-in failed.`;
+		try {
+			const result = await authClient.signIn.social({ provider, callbackURL: resolve('/') });
+			if (result.error) {
+				errorMessage =
+					result.error.message ?? `${PROVIDER_LABEL[provider]} sign-in failed.`;
+			}
+		} catch {
+			errorMessage = `${PROVIDER_LABEL[provider]} sign-in failed.`;
+		} finally {
 			pendingAction = null;
 		}
 	}
@@ -50,13 +56,18 @@
 		}
 
 		pendingAction = 'email';
-		const result = await authClient.signUp.email({ email, password, name });
-		if (result.error) {
-			errorMessage = result.error.message ?? 'Sign-up failed.';
+		try {
+			const result = await authClient.signUp.email({ email, password, name });
+			if (result.error) {
+				errorMessage = result.error.message ?? 'Sign-up failed.';
+				return;
+			}
+			await goto(resolve('/'));
+		} catch {
+			errorMessage = 'Sign-up failed.';
+		} finally {
 			pendingAction = null;
-			return;
 		}
-		await goto(resolve('/'));
 	}
 </script>
 

--- a/src/routes/gallery/+page.server.ts
+++ b/src/routes/gallery/+page.server.ts
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = ({ locals }) => {
+	if (!locals.user) {
+		redirect(303, '/auth/sign-in');
+	}
+};

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -57,9 +57,8 @@ test.describe('/auth/sign-up page', () => {
 		await expect(page).toHaveURL(/\/auth\/sign-in$/);
 	});
 
-	// Skip: pre-existing flaky test - alert element not found (broken on dev branch too)
-	test.skip('shows password mismatch error', async ({ page }) => {
-		await page.goto('/auth/sign-up');
+	test('shows password mismatch error', async ({ page }) => {
+		await page.goto('/auth/sign-up', { waitUntil: 'networkidle' });
 		await page.getByTestId('auth-name').fill('Test User');
 		await page.getByTestId('auth-email').fill('test@example.com');
 		await page.getByTestId('auth-password').fill('password123');

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -31,4 +31,14 @@ test.describe('app shell sidebar (anonymous)', () => {
 		await expect(saveButton).toBeDisabled();
 		await expect(saveButton).toHaveText(/Sign in to save/i);
 	});
+
+	test('all tree editing controls are visible when signed out', async ({ page }) => {
+		await page.goto('/editor');
+		const cardTitle = (name: string) =>
+			page.locator('[data-slot="card-title"]', { hasText: name });
+		await expect(cardTitle('Shape')).toBeVisible();
+		await expect(cardTitle('Geometry')).toBeVisible();
+		await expect(cardTitle('Growables')).toBeVisible();
+		await expect(cardTitle('Trunk & Branches')).toBeVisible();
+	});
 });


### PR DESCRIPTION
## Description
- Wrap all auth form functions in try/catch/finally to prevent stuck UI states (disabled buttons) on network errors or exceptions
- Add server-side auth guard to gallery route (matching settings pattern)
- Fix flaky password-mismatch E2E test (hydration timing with `networkidle` wait)
- Add E2E test verifying editor controls visible when signed out

## Resolves
Closes #88

## Testing
- [x] All 2486 unit tests pass
- [x] All 91 E2E tests pass (including previously skipped password mismatch test)
- [x] Static checks pass (format + lint + typecheck + stylelint + knip)
- [x] Svelte autofixer reports no issues