### PR TITLE
#128 feat(scene): SVG asset extraction + 10-layer scene depth system

### DIFF
--- a/src/lib/environment/effects/CloudsEffect.svelte
+++ b/src/lib/environment/effects/CloudsEffect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { generateCloudShapes } from '../environment_generators.js';
 	import { ENVIRONMENT_SEEDS, ENVIRONMENT_VIEW_WIDTH } from '../environment_config.js';
+	import CloudSvg from '$lib/trees/assets/overlays/CloudSvg.svelte';
 
 	const clouds = generateCloudShapes(5, ENVIRONMENT_SEEDS.clouds, ENVIRONMENT_VIEW_WIDTH);
 </script>
@@ -18,9 +19,7 @@
 			class="cloud-group"
 			style="--x: {cloud.x}px; --y: {cloud.y * 5}px; animation-delay: {i * 2}s;"
 		>
-			{#each cloud.triangles as pts, ti (ti)}
-				<polygon points={pts} fill="rgba(220,220,230,{cloud.opacity})" />
-			{/each}
+			<CloudSvg triangles={cloud.triangles} opacity={cloud.opacity} />
 		</g>
 	{/each}
 </svg>

--- a/src/lib/environment/effects/FirefliesEffect.svelte
+++ b/src/lib/environment/effects/FirefliesEffect.svelte
@@ -5,6 +5,7 @@
 		ENVIRONMENT_VIEW_HEIGHT,
 		ENVIRONMENT_VIEW_WIDTH,
 	} from '../environment_config.js';
+	import FireflySvg from '$lib/trees/assets/overlays/FireflySvg.svelte';
 
 	const fireflies = generateFireflyPositions(
 		20,
@@ -31,16 +32,15 @@
 		</filter>
 	</defs>
 	{#each fireflies as ff, index (index)}
-		<circle
-			data-testid="firefly"
-			cx={ff.x}
-			cy={ff.y}
-			r="3"
-			fill="#9FFF50"
-			filter="url(#firefly-glow)"
-			class="firefly"
-			style="animation-delay: {ff.delay}s; animation-duration: {ff.duration}s;"
-		/>
+		<g transform="translate({ff.x}, {ff.y})">
+			<g
+				data-testid="firefly"
+				class="firefly"
+				style="animation-delay: {ff.delay}s; animation-duration: {ff.duration}s;"
+			>
+				<FireflySvg />
+			</g>
+		</g>
 	{/each}
 </svg>
 

--- a/src/lib/environment/effects/RainEffect.svelte
+++ b/src/lib/environment/effects/RainEffect.svelte
@@ -5,6 +5,7 @@
 		ENVIRONMENT_VIEW_HEIGHT,
 		ENVIRONMENT_VIEW_WIDTH,
 	} from '../environment_config.js';
+	import RaindropSvg from '$lib/trees/assets/overlays/RaindropSvg.svelte';
 
 	interface Props {
 		intensity: number;
@@ -30,17 +31,15 @@
 	xmlns="http://www.w3.org/2000/svg"
 >
 	{#each drops as drop, index (index)}
-		<line
-			data-testid="rain-drop"
-			x1={drop.x}
-			y1={drop.y}
-			x2={drop.x + 2}
-			y2={drop.y + drop.length}
-			stroke="rgba(174,194,224,0.5)"
-			stroke-width="1.5"
-			class="rain-drop"
-			style="animation-delay: {drop.delay}s; animation-duration: {drop.speed}s;"
-		/>
+		<g transform="translate({drop.x}, {drop.y})">
+			<g
+				data-testid="rain-drop"
+				class="rain-drop"
+				style="animation-delay: {drop.delay}s; animation-duration: {drop.speed}s;"
+			>
+				<RaindropSvg length={drop.length} />
+			</g>
+		</g>
 	{/each}
 </svg>
 

--- a/src/lib/environment/effects/SnowEffect.svelte
+++ b/src/lib/environment/effects/SnowEffect.svelte
@@ -5,6 +5,7 @@
 		ENVIRONMENT_VIEW_HEIGHT,
 		ENVIRONMENT_VIEW_WIDTH,
 	} from '../environment_config.js';
+	import SnowflakeSvg from '$lib/trees/assets/overlays/SnowflakeSvg.svelte';
 
 	const flakes = generateSnowflakes(
 		40,
@@ -22,16 +23,15 @@
 	xmlns="http://www.w3.org/2000/svg"
 >
 	{#each flakes as flake, index (index)}
-		<circle
-			data-testid="snow-particle"
-			cx={flake.x}
-			cy={flake.y}
-			r={flake.size}
-			fill="white"
-			fill-opacity="0.8"
-			class="snow-flake"
-			style="animation-delay: {flake.delay}s; animation-duration: {flake.speed}s; --drift: {flake.drift}px;"
-		/>
+		<g transform="translate({flake.x}, {flake.y})">
+			<g
+				data-testid="snow-particle"
+				class="snow-flake"
+				style="animation-delay: {flake.delay}s; animation-duration: {flake.speed}s; --drift: {flake.drift}px;"
+			>
+				<SnowflakeSvg size={flake.size} />
+			</g>
+		</g>
 	{/each}
 </svg>
 

--- a/src/lib/environment/effects/WindParticlesEffect.svelte
+++ b/src/lib/environment/effects/WindParticlesEffect.svelte
@@ -5,6 +5,7 @@
 		ENVIRONMENT_VIEW_HEIGHT,
 		ENVIRONMENT_VIEW_WIDTH,
 	} from '../environment_config.js';
+	import WindParticleSvg from '$lib/trees/assets/overlays/WindParticleSvg.svelte';
 
 	const particles = generateWindParticles(
 		15,
@@ -22,18 +23,16 @@
 	xmlns="http://www.w3.org/2000/svg"
 >
 	{#each particles as particle, index (index)}
-		<path
+		<g
 			data-testid="wind-particle"
-			d="M0,-{particle.size} C{particle.size / 2},-{particle.size / 2} {particle.size /
-				2},{particle.size / 2} 0,{particle.size} C-{particle.size / 3},0 -{particle.size /
-				3},0 0,-{particle.size}Z"
-			fill="rgba(139,119,101,0.4)"
 			class="wind-particle"
 			style="
 				transform: translate({particle.x}px, {particle.y}px) rotate({particle.rotation}deg);
 				animation-delay: {particle.delay}s;
 			"
-		/>
+		>
+			<WindParticleSvg size={particle.size} />
+		</g>
 	{/each}
 </svg>
 

--- a/src/lib/scene/scene_config.ts
+++ b/src/lib/scene/scene_config.ts
@@ -39,25 +39,21 @@ export const SCENE_LIMITS = {
 	depthSpreadMax: 100,
 } as const;
 
-/** Maximum number of trees in the front row before overflow to back. */
-export const FRONT_ROW_CAPACITY = 10;
+/** Total number of depth layers in the scene. */
+export const LAYER_COUNT = 10;
 
-/** Minimum scale for back-row trees. */
-export const BACK_SCALE_MIN = 0.65;
+/** Maximum trees per layer. */
+export const TREES_PER_LAYER = 10;
 
-/** Maximum scale for back-row trees. */
-export const BACK_SCALE_MAX = 0.8;
+/** Scale factor for front-most layer (layer 1). */
+export const SCALE_FRONT = 1.0;
 
-/** Minimum back-row depth when depthSpread is 0. */
-export const BACK_DEPTH_FALLBACK = 15;
+/** Scale factor for back-most layer (layer 10). */
+export const SCALE_BACK = 0.65;
 
 /** Input descriptor for a tree in the scene, before layout. */
 export interface SceneTreeInput {
 	readonly id?: string;
-	/** 0 = background (always back row), 1 = foreground (front row preferred). Defaults to 1. */
-	readonly priority?: 0 | 1;
-	/** ID of another tree this one must be placed behind (y >= blocker's y). */
-	readonly blockedBy?: string;
 }
 
 /** A positioned tree in the scene, ready for rendering. */
@@ -69,6 +65,8 @@ export interface SceneTreePlacement {
 	readonly x: number;
 	/** Depth position — 0 = front (baseline), higher y = further from viewer (back). */
 	readonly y: number;
-	/** Scale factor derived from depth: 1.0 at front, ~0.65 at back. */
+	/** Scale factor derived from depth: 1.0 at front, 0.65 at back. */
 	readonly scale: number;
+	/** Layer number (1 = front, 10 = back). */
+	readonly layer: number;
 }

--- a/src/lib/scene/scene_layout.test.ts
+++ b/src/lib/scene/scene_layout.test.ts
@@ -1,23 +1,38 @@
 import { describe, expect, it } from 'vitest';
 import { generateSceneLayout } from './scene_layout.js';
-import type { SceneConfig } from './scene_config.js';
-import { BACK_SCALE_MIN, BACK_SCALE_MAX, BACK_DEPTH_FALLBACK } from './scene_config.js';
+import {
+	SCENE_SHAPES,
+	LAYER_COUNT,
+	SCALE_FRONT,
+	SCALE_BACK,
+	type SceneConfig,
+} from './scene_config.js';
 
 const BASE_CONFIG: SceneConfig = { treeCount: 3, depthSpread: 0, baseSeed: 42 };
 
 describe('generateSceneLayout', () => {
-	describe('Group 1: Front row basics (<=10 trees)', () => {
+	describe('Group 1: Layer 1 basics (<=10 trees)', () => {
 		it('treeCount=0 returns empty array', () => {
 			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 0 });
 			expect(result).toEqual([]);
 		});
 
-		it('treeCount=3 produces 3 placements at y=0, scale=1.0, x equidistant at 25/50/75', () => {
+		it('treeCount=1: x=50, y=0, scale=1.0, layer=1', () => {
+			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 1 });
+			expect(result).toHaveLength(1);
+			expect(result[0].x).toBeCloseTo(50, 5);
+			expect(result[0].y).toBe(0);
+			expect(result[0].scale).toBeCloseTo(1.0, 5);
+			expect(result[0].layer).toBe(1);
+		});
+
+		it('treeCount=3 (layer 1 only): equidistant x at 25/50/75, y=0, scale=1.0, layer=1', () => {
 			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 3 });
 			expect(result).toHaveLength(3);
 			for (const tree of result) {
 				expect(tree.y).toBe(0);
 				expect(tree.scale).toBeCloseTo(1.0, 5);
+				expect(tree.layer).toBe(1);
 			}
 			const xs = result.map((t) => t.x).sort((a, b) => a - b);
 			expect(xs[0]).toBeCloseTo(25, 5);
@@ -25,254 +40,256 @@ describe('generateSceneLayout', () => {
 			expect(xs[2]).toBeCloseTo(75, 5);
 		});
 
-		it('treeCount=1 produces x=50, y=0, scale=1.0', () => {
-			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 1 });
-			expect(result).toHaveLength(1);
-			expect(result[0].x).toBeCloseTo(50, 5);
-			expect(result[0].y).toBe(0);
-			expect(result[0].scale).toBeCloseTo(1.0, 5);
-		});
-
-		it('treeCount=10 produces all y=0, scale=1.0, equidistant x', () => {
+		it('treeCount=10 (full layer 1): equidistant x, y=0, scale=1.0, layer=1', () => {
 			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 10 });
 			expect(result).toHaveLength(10);
-			const xs = result.map((t) => t.x).sort((a, b) => a - b);
-			for (let i = 0; i < 10; i++) {
-				expect(result[i].y).toBe(0);
-				expect(result[i].scale).toBeCloseTo(1.0, 5);
+			for (const tree of result) {
+				expect(tree.y).toBe(0);
+				expect(tree.scale).toBeCloseTo(1.0, 5);
+				expect(tree.layer).toBe(1);
 			}
+			const xs = result.map((t) => t.x).sort((a, b) => a - b);
 			for (let i = 0; i < 10; i++) {
 				const expectedX = ((i + 1) * 100) / 11;
 				expect(xs[i]).toBeCloseTo(expectedX, 5);
 			}
 		});
 
-		it('assigns only non-custom shapes', () => {
+		it('assigns only non-custom shapes from SCENE_SHAPES', () => {
 			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 10 });
 			for (const tree of result) {
 				expect(tree.shape).not.toBe('custom');
+				expect(SCENE_SHAPES).toContain(tree.shape);
 			}
 		});
 
-		it('produces unique seeds per tree', () => {
+		it('unique seeds per tree', () => {
 			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 10 });
 			const seeds = result.map((t) => t.seed);
 			expect(new Set(seeds).size).toBe(seeds.length);
 		});
 	});
 
-	describe('Group 2: Back row overflow (>10 trees)', () => {
-		it('treeCount=11 produces 10 front (y=0, scale=1.0) + 1 back (y>0, scale in [0.65, 0.8])', () => {
-			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 11 });
+	describe('Group 2: Multi-layer fill (>10 trees)', () => {
+		it('treeCount=11 with depthSpread=50: 10 in layer 1, 1 in layer 2', () => {
+			const result = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 11,
+				depthSpread: 50,
+			});
 			expect(result).toHaveLength(11);
-			const front = result.filter((t) => t.y === 0);
-			const back = result.filter((t) => t.y > 0);
-			expect(front).toHaveLength(10);
-			expect(back).toHaveLength(1);
-			for (const t of front) {
-				expect(t.scale).toBeCloseTo(1.0, 5);
-			}
-			for (const t of back) {
-				expect(t.scale).toBeGreaterThanOrEqual(BACK_SCALE_MIN);
-				expect(t.scale).toBeLessThanOrEqual(BACK_SCALE_MAX);
-			}
-		});
-
-		it('treeCount=15 produces 10 front + 5 back', () => {
-			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 15 });
-			const front = result.filter((t) => t.y === 0);
-			const back = result.filter((t) => t.y > 0);
-			expect(front).toHaveLength(10);
-			expect(back).toHaveLength(5);
-		});
-
-		it('back row x positions within [0, 100]', () => {
-			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 20 });
-			const back = result.filter((t) => t.y > 0);
-			for (const t of back) {
-				expect(t.x).toBeGreaterThanOrEqual(0);
-				expect(t.x).toBeLessThanOrEqual(100);
-			}
-		});
-
-		it('back row y values within effective depth range', () => {
-			const depthSpread = 0;
-			const effectiveDepth = Math.max(depthSpread, BACK_DEPTH_FALLBACK);
-			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 15, depthSpread: 0 });
-			const back = result.filter((t) => t.y > 0);
-			for (const t of back) {
-				expect(t.y).toBeGreaterThanOrEqual(effectiveDepth * 0.3);
-				expect(t.y).toBeLessThanOrEqual(effectiveDepth);
-			}
-		});
-
-		it('back row respects depthSpread when larger than fallback', () => {
-			const depthSpread = 50;
-			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 15, depthSpread });
-			const back = result.filter((t) => t.y > 0);
-			for (const t of back) {
-				expect(t.y).toBeGreaterThanOrEqual(depthSpread * 0.3);
-				expect(t.y).toBeLessThanOrEqual(depthSpread);
-			}
-		});
-	});
-
-	describe('Group 3: Priority field', () => {
-		it('priority=0 forces tree to back row even when front has capacity', () => {
-			const config: SceneConfig = {
-				...BASE_CONFIG,
-				treeCount: 5,
-				trees: [
-					{ priority: 0 },
-					{ priority: 1 },
-					{ priority: 1 },
-					{ priority: 1 },
-					{ priority: 1 },
-				],
-			};
-			const result = generateSceneLayout(config);
-			const front = result.filter((t) => t.y === 0);
-			const back = result.filter((t) => t.y > 0);
-			expect(front).toHaveLength(4);
-			expect(back).toHaveLength(1);
-		});
-
-		it('priority=1 or undefined defaults to front row', () => {
-			const config: SceneConfig = {
-				...BASE_CONFIG,
-				treeCount: 3,
-				trees: [{ priority: 1 }, {}, { priority: 1 }],
-			};
-			const result = generateSceneLayout(config);
-			for (const t of result) {
+			const layer1 = result.filter((t) => t.layer === 1);
+			const layer2 = result.filter((t) => t.layer === 2);
+			expect(layer1).toHaveLength(10);
+			expect(layer2).toHaveLength(1);
+			for (const t of layer1) {
 				expect(t.y).toBe(0);
-				expect(t.scale).toBeCloseTo(1.0, 5);
+				expect(t.scale).toBeCloseTo(SCALE_FRONT, 5);
+			}
+			for (const t of layer2) {
+				expect(t.y).toBeCloseTo(25, 5);
+				// scale = 1.0 - (2-1) * 0.35/9 = 1.0 - 0.0389 ≈ 0.961
+				expect(t.scale).toBeCloseTo(
+					SCALE_FRONT - (SCALE_FRONT - SCALE_BACK) / (LAYER_COUNT - 1),
+					3,
+				);
 			}
 		});
 
-		it('mixed: 8 trees with 3 having priority=0 produces 5 front, 3 back', () => {
-			const config: SceneConfig = {
+		it('treeCount=20: layers 1-2 each have 10 trees', () => {
+			const result = generateSceneLayout({
 				...BASE_CONFIG,
-				treeCount: 8,
-				trees: [
-					{ priority: 0 },
-					{ priority: 1 },
-					{ priority: 0 },
-					{ priority: 1 },
-					{ priority: 1 },
-					{ priority: 0 },
-					{ priority: 1 },
-					{ priority: 1 },
-				],
-			};
-			const result = generateSceneLayout(config);
-			const front = result.filter((t) => t.y === 0);
-			const back = result.filter((t) => t.y > 0);
-			expect(front).toHaveLength(5);
-			expect(back).toHaveLength(3);
-		});
-	});
-
-	describe('Group 4: blockedBy field', () => {
-		it('tree with blockedBy has y >= blocker y', () => {
-			const config: SceneConfig = {
-				...BASE_CONFIG,
-				treeCount: 3,
+				treeCount: 20,
 				depthSpread: 50,
-				trees: [
-					{ id: 'blocker', priority: 0 },
-					{ id: 'blocked', priority: 0, blockedBy: 'blocker' },
-					{ priority: 1 },
-				],
-			};
-			const result = generateSceneLayout(config);
-			const blocker = result.find((t) => t.id === 'blocker');
-			const blocked = result.find((t) => t.id === 'blocked');
-			expect(blocker).toBeDefined();
-			expect(blocked).toBeDefined();
-			expect(blocked!.y).toBeGreaterThanOrEqual(blocker!.y);
+			});
+			expect(result).toHaveLength(20);
+			const layer1 = result.filter((t) => t.layer === 1);
+			const layer2 = result.filter((t) => t.layer === 2);
+			expect(layer1).toHaveLength(10);
+			expect(layer2).toHaveLength(10);
 		});
 
-		it('nonexistent blockedBy ID is ignored, tree positioned normally', () => {
-			const config: SceneConfig = {
+		it('100 trees = 10 full layers, all positioned correctly', () => {
+			const result = generateSceneLayout({
 				...BASE_CONFIG,
-				treeCount: 2,
-				trees: [{ id: 'a', blockedBy: 'nonexistent' }, { id: 'b' }],
-			};
-			const result = generateSceneLayout(config);
-			expect(result).toHaveLength(2);
-			// No crash, both placed
-			for (const t of result) {
-				expect(t.x).toBeGreaterThanOrEqual(0);
-				expect(t.x).toBeLessThanOrEqual(100);
+				treeCount: 100,
+				depthSpread: 100,
+			});
+			expect(result).toHaveLength(100);
+			for (let layerNumber = 1; layerNumber <= 10; layerNumber++) {
+				const layerTrees = result.filter((t) => t.layer === layerNumber);
+				expect(layerTrees).toHaveLength(10);
 			}
 		});
 
-		it('circular blockedBy does not cause infinite loop, both trees still placed', () => {
-			const config: SceneConfig = {
+		it('each placement has correct layer number', () => {
+			const result = generateSceneLayout({
 				...BASE_CONFIG,
-				treeCount: 2,
+				treeCount: 25,
 				depthSpread: 50,
-				trees: [
-					{ id: 'a', priority: 0, blockedBy: 'b' },
-					{ id: 'b', priority: 0, blockedBy: 'a' },
-				],
-			};
-			const result = generateSceneLayout(config);
-			expect(result).toHaveLength(2);
-			expect(result.find((t) => t.id === 'a')).toBeDefined();
-			expect(result.find((t) => t.id === 'b')).toBeDefined();
+			});
+			// Trees 1-10 → layer 1, 11-20 → layer 2, 21-25 → layer 3
+			const layer1 = result.filter((t) => t.layer === 1);
+			const layer2 = result.filter((t) => t.layer === 2);
+			const layer3 = result.filter((t) => t.layer === 3);
+			expect(layer1).toHaveLength(10);
+			expect(layer2).toHaveLength(10);
+			expect(layer3).toHaveLength(5);
 		});
 	});
 
-	describe('Group 5: Determinism & sorting', () => {
-		it('same config + seed produces identical output', () => {
-			const config: SceneConfig = { ...BASE_CONFIG, treeCount: 15, depthSpread: 50 };
+	describe('Group 3: Horizontal stagger (even vs odd layers)', () => {
+		it('even layer horizontal stagger: layer 2 x positions offset by half inter-tree distance', () => {
+			const result = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 20,
+				depthSpread: 50,
+			});
+			const layer1 = result.filter((t) => t.layer === 1);
+			const layer2 = result.filter((t) => t.layer === 2);
+
+			// Layer 1: 10 trees, inter-tree = 100/11
+			// Layer 2: 10 trees, inter-tree = 100/11, offset = 100/11/2
+			const interTree = 100 / 11;
+			const offset = interTree / 2;
+
+			const layer1xs = layer1.map((t) => t.x).sort((a, b) => a - b);
+			const layer2xs = layer2.map((t) => t.x).sort((a, b) => a - b);
+
+			// Layer 1 positions: interTree*1, interTree*2, ...
+			for (let i = 0; i < 10; i++) {
+				expect(layer1xs[i]).toBeCloseTo((i + 1) * interTree, 5);
+			}
+			// Layer 2 positions: offset + interTree*1, offset + interTree*2, ...
+			for (let i = 0; i < 10; i++) {
+				expect(layer2xs[i]).toBeCloseTo(offset + (i + 1) * interTree, 5);
+			}
+		});
+
+		it('odd layer alignment: layer 3 x positions match layer 1 alignment (no stagger)', () => {
+			const result = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 30,
+				depthSpread: 50,
+			});
+			const layer1 = result.filter((t) => t.layer === 1);
+			const layer3 = result.filter((t) => t.layer === 3);
+
+			const layer1xs = layer1.map((t) => t.x).sort((a, b) => a - b);
+			const layer3xs = layer3.map((t) => t.x).sort((a, b) => a - b);
+
+			// Both have 10 trees, same formula, no offset
+			expect(layer1xs).toHaveLength(10);
+			expect(layer3xs).toHaveLength(10);
+			for (let i = 0; i < 10; i++) {
+				expect(layer3xs[i]).toBeCloseTo(layer1xs[i], 5);
+			}
+		});
+	});
+
+	describe('Group 4: Depth spread formula', () => {
+		it('depthSpread=0: ALL layers at y=0 regardless of layer number', () => {
+			const result = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 30,
+				depthSpread: 0,
+			});
+			for (const tree of result) {
+				expect(tree.y).toBe(0);
+			}
+		});
+
+		it('depthSpread=50 formula: layer 2 y=25, layer 3 y=50, layer 10 y=225', () => {
+			const result = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 100,
+				depthSpread: 50,
+			});
+
+			const layer2 = result.filter((t) => t.layer === 2);
+			const layer3 = result.filter((t) => t.layer === 3);
+			const layer10 = result.filter((t) => t.layer === 10);
+
+			// y = depthSpread * (layerNumber-1) / 2
+			// layer 2: 50 * 1 / 2 = 25
+			expect(layer2[0].y).toBeCloseTo(25, 5);
+			// layer 3: 50 * 2 / 2 = 50
+			expect(layer3[0].y).toBeCloseTo(50, 5);
+			// layer 10: 50 * 9 / 2 = 225
+			expect(layer10[0].y).toBeCloseTo(225, 5);
+		});
+	});
+
+	describe('Group 5: Scale interpolation', () => {
+		it('scale decreases with layer: layer 1 = 1.0, layer 10 = 0.65, linear interpolation', () => {
+			const result = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 100,
+				depthSpread: 50,
+			});
+
+			for (let layerNumber = 1; layerNumber <= 10; layerNumber++) {
+				const layerTrees = result.filter((t) => t.layer === layerNumber);
+				const expectedScale =
+					SCALE_FRONT - ((layerNumber - 1) * (SCALE_FRONT - SCALE_BACK)) / 9;
+				for (const tree of layerTrees) {
+					expect(tree.scale).toBeCloseTo(expectedScale, 5);
+				}
+			}
+		});
+	});
+
+	describe('Group 6: Determinism & sorting', () => {
+		it('deterministic: same config+seed produces identical output', () => {
+			const config: SceneConfig = { ...BASE_CONFIG, treeCount: 50, depthSpread: 50 };
 			const a = generateSceneLayout(config);
 			const b = generateSceneLayout(config);
 			expect(a).toEqual(b);
 		});
 
-		it('different seeds produce different layouts', () => {
+		it('different seeds produce different shape assignments', () => {
 			const a = generateSceneLayout({
 				...BASE_CONFIG,
-				treeCount: 15,
+				treeCount: 20,
 				depthSpread: 50,
 				baseSeed: 1,
 			});
 			const b = generateSceneLayout({
 				...BASE_CONFIG,
-				treeCount: 15,
+				treeCount: 20,
 				depthSpread: 50,
 				baseSeed: 2,
 			});
-			const aPositions = a.map((t) => ({ x: t.x, y: t.y }));
-			const bPositions = b.map((t) => ({ x: t.x, y: t.y }));
-			expect(aPositions).not.toEqual(bPositions);
+			const aShapes = a.map((t) => t.shape);
+			const bShapes = b.map((t) => t.shape);
+			expect(aShapes).not.toEqual(bShapes);
 		});
 
-		it('output sorted descending by y (back-to-front for painter algorithm)', () => {
-			const result = generateSceneLayout({ ...BASE_CONFIG, treeCount: 20, depthSpread: 50 });
+		it('output sorted descending by y (painter algorithm — back trees first)', () => {
+			const result = generateSceneLayout({
+				...BASE_CONFIG,
+				treeCount: 50,
+				depthSpread: 50,
+			});
 			for (let i = 1; i < result.length; i++) {
 				expect(result[i].y).toBeLessThanOrEqual(result[i - 1].y);
 			}
 		});
 	});
 
-	describe('Group 6: Backward compatibility', () => {
-		it('config without trees field still works, all front row', () => {
+	describe('Group 7: Backward compatibility (config without trees, ID passthrough)', () => {
+		it('config without trees field works', () => {
 			const config: SceneConfig = { treeCount: 5, depthSpread: 0, baseSeed: 42 };
 			const result = generateSceneLayout(config);
 			expect(result).toHaveLength(5);
 			for (const t of result) {
 				expect(t.y).toBe(0);
 				expect(t.scale).toBeCloseTo(1.0, 5);
+				expect(t.layer).toBe(1);
 			}
 		});
-	});
 
-	describe('Group 7: ID passthrough', () => {
-		it('when trees have id, corresponding placement has id', () => {
+		it('ID passthrough when trees array has ids', () => {
 			const config: SceneConfig = {
 				...BASE_CONFIG,
 				treeCount: 3,

--- a/src/lib/scene/scene_layout.ts
+++ b/src/lib/scene/scene_layout.ts
@@ -1,22 +1,21 @@
-import { createPrng, randomInRange } from '$lib/trees/prng.js';
+import { createPrng } from '$lib/trees/prng.js';
 import {
 	SCENE_SHAPES,
-	FRONT_ROW_CAPACITY,
-	BACK_SCALE_MIN,
-	BACK_SCALE_MAX,
-	BACK_DEPTH_FALLBACK,
+	LAYER_COUNT,
+	TREES_PER_LAYER,
+	SCALE_FRONT,
+	SCALE_BACK,
 	type SceneConfig,
 	type SceneTreeInput,
 	type SceneTreePlacement,
 } from './scene_config.js';
 
 /**
- * Generate deterministic scene tree placements from a config.
+ * Generate deterministic scene tree placements using a 10-layer sequential system.
  *
- * Trees are partitioned into front row (equidistant at y=0, scale=1) and
- * back row (semi-random positions/scale). Priority and blockedBy fields
- * control placement. Output sorted descending by y (back-to-front) for
- * painter's algorithm — back trees first in DOM, front trees last.
+ * Trees fill layers sequentially: trees 1-10 → layer 1, 11-20 → layer 2, etc.
+ * Odd layers share x alignment with layer 1; even layers are staggered by half
+ * the inter-tree distance. Output sorted descending by y (painter's algorithm).
  */
 export function generateSceneLayout(config: SceneConfig): SceneTreePlacement[] {
 	const { treeCount, depthSpread, baseSeed } = config;
@@ -26,154 +25,58 @@ export function generateSceneLayout(config: SceneConfig): SceneTreePlacement[] {
 
 	const rng = createPrng(baseSeed);
 
-	// Build input descriptors — use config.trees if provided, else default foreground
+	// Build input descriptors — use config.trees if provided, else empty
 	const inputs: SceneTreeInput[] = Array.from(
 		{ length: treeCount },
 		(_, i) => config.trees?.[i] ?? {},
 	);
 
-	// Assign shapes and seeds upfront
+	// Assign shapes and seeds upfront using PRNG for determinism
 	const shapeSeeds = inputs.map((_, i) => {
 		const shape = SCENE_SHAPES[Math.floor(rng() * SCENE_SHAPES.length)];
 		const seed = baseSeed + i * 1000 + Math.floor(rng() * 999);
 		return { shape, seed };
 	});
 
-	// Partition into front and back indices
-	const frontIndices: number[] = [];
-	const backIndices: number[] = [];
+	const placements: SceneTreePlacement[] = [];
 
-	for (let i = 0; i < inputs.length; i++) {
-		const input = inputs[i];
-		if (input.priority === 0) {
-			backIndices.push(i);
-		} else if (frontIndices.length < FRONT_ROW_CAPACITY) {
-			frontIndices.push(i);
-		} else {
-			backIndices.push(i);
-		}
+	for (let i = 0; i < treeCount; i++) {
+		const layerNumber = Math.floor(i / TREES_PER_LAYER) + 1;
+		const slotInLayer = i % TREES_PER_LAYER;
+
+		// Count how many trees are in this layer
+		const layerStartIndex = (layerNumber - 1) * TREES_PER_LAYER;
+		const countInLayer = Math.min(TREES_PER_LAYER, treeCount - layerStartIndex);
+
+		// X position: equidistant within [0, 100]
+		const interTreeDistance = 100 / (countInLayer + 1);
+		const baseX = (slotInLayer + 1) * interTreeDistance;
+
+		// Even layers get horizontal offset of half inter-tree distance
+		const isEvenLayer = layerNumber % 2 === 0;
+		const horizontalOffset = isEvenLayer ? interTreeDistance / 2 : 0;
+		const x = baseX + horizontalOffset;
+
+		// Y offset: depthSpread * (layerNumber - 1) / 2
+		const y = (depthSpread * (layerNumber - 1)) / 2;
+
+		// Scale: linear interpolation from SCALE_FRONT (layer 1) to SCALE_BACK (layer 10)
+		const scale =
+			SCALE_FRONT - ((layerNumber - 1) * (SCALE_FRONT - SCALE_BACK)) / (LAYER_COUNT - 1);
+
+		placements.push({
+			id: inputs[i].id,
+			shape: shapeSeeds[i].shape,
+			seed: shapeSeeds[i].seed,
+			x,
+			y,
+			scale,
+			layer: layerNumber,
+		});
 	}
 
-	const effectiveDepth = Math.max(depthSpread, BACK_DEPTH_FALLBACK);
+	// Sort descending by y (painter's algorithm — back trees first in DOM)
+	placements.sort((a, b) => b.y - a.y);
 
-	const buildPlacement = (
-		idx: number,
-		x: number,
-		y: number,
-		scale: number,
-	): SceneTreePlacement => ({
-		id: inputs[idx].id,
-		shape: shapeSeeds[idx].shape,
-		seed: shapeSeeds[idx].seed,
-		x,
-		y,
-		scale,
-	});
-
-	// Position front row: equidistant, y=0, scale=1.0
-	const frontCount = frontIndices.length;
-	const placements = new Map<number, SceneTreePlacement>();
-
-	for (let slot = 0; slot < frontCount; slot++) {
-		const idx = frontIndices[slot];
-		const x = ((slot + 1) * 100) / (frontCount + 1);
-		placements.set(idx, buildPlacement(idx, x, 0, 1.0));
-	}
-
-	// Position back row: semi-random within depth range
-	for (const idx of backIndices) {
-		const x = randomInRange(rng, 5, 95);
-		const y = randomInRange(rng, effectiveDepth * 0.3, effectiveDepth);
-		const scale = randomInRange(rng, BACK_SCALE_MIN, BACK_SCALE_MAX);
-		placements.set(idx, buildPlacement(idx, x, y, scale));
-	}
-
-	// Enforce blockedBy constraints (blocked tree must have y >= blocker's y)
-	enforceBlockedBy(inputs, placements);
-
-	// Collect, sort descending by y (back-to-front for painter's algorithm)
-	// Higher y = further back → first in DOM → painted behind front trees
-	const result = Array.from(placements.values());
-	result.sort((a, b) => b.y - a.y);
-	return result;
-}
-
-/**
- * Enforce blockedBy: if tree A has blockedBy "X", ensure A.y >= X.y.
- * Uses fixpoint iteration to handle transitive chains (A→B→C).
- * Detects cycles and skips them. Ignores nonexistent IDs.
- */
-function enforceBlockedBy(
-	inputs: SceneTreeInput[],
-	placements: Map<number, SceneTreePlacement>,
-): void {
-	// Build id-to-index map
-	const idToIndex = new Map<string, number>();
-	for (let i = 0; i < inputs.length; i++) {
-		const id = inputs[i].id;
-		if (id !== undefined) {
-			idToIndex.set(id, i);
-		}
-	}
-
-	// Fixpoint: iterate until no changes (handles transitive chains)
-	let changed = true;
-	while (changed) {
-		changed = false;
-		for (let i = 0; i < inputs.length; i++) {
-			const blockedById = inputs[i].blockedBy;
-			if (blockedById === undefined) {
-				continue;
-			}
-
-			const blockerIndex = idToIndex.get(blockedById);
-			if (blockerIndex === undefined) {
-				continue;
-			}
-
-			if (hasCycle(inputs, idToIndex, i)) {
-				continue;
-			}
-
-			const blockerPlacement = placements.get(blockerIndex);
-			const currentPlacement = placements.get(i);
-			if (!blockerPlacement || !currentPlacement) {
-				continue;
-			}
-
-			if (currentPlacement.y < blockerPlacement.y) {
-				placements.set(i, { ...currentPlacement, y: blockerPlacement.y });
-				changed = true;
-			}
-		}
-	}
-}
-
-/** Check if following the blockedBy chain from startIndex leads back to itself. */
-function hasCycle(
-	inputs: SceneTreeInput[],
-	idToIndex: Map<string, number>,
-	startIndex: number,
-): boolean {
-	const visited = new Set<number>();
-	visited.add(startIndex);
-
-	let currentIndex = startIndex;
-	while (true) {
-		const blockedById = inputs[currentIndex].blockedBy;
-		if (blockedById === undefined) {
-			return false;
-		}
-
-		const nextIndex = idToIndex.get(blockedById);
-		if (nextIndex === undefined) {
-			return false;
-		}
-
-		if (visited.has(nextIndex)) {
-			return true;
-		}
-		visited.add(nextIndex);
-		currentIndex = nextIndex;
-	}
+	return placements;
 }

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -32,6 +32,7 @@
 	import WiltingEffect from '$lib/trees/overlays/WiltingEffect.svelte';
 	import GroundElements from '$lib/trees/ground/GroundElements.svelte';
 	import { SeedSvg, SproutingSvg, StumpSvg } from '$lib/trees/assets/stages/index.js';
+	import LeafSvg from '$lib/trees/assets/overlays/LeafSvg.svelte';
 	import {
 		OVERLAY_DEFAULTS,
 		OVERLAY_VIEWBOX_HEADROOM,
@@ -430,7 +431,7 @@
 						class="falling-leaf"
 						style="--leaf-start-x: {leaf.x}px; --leaf-start-y: {leaf.y}px; --leaf-delay: {leaf.delay}s; --leaf-duration: {leaf.duration}s; --leaf-rotation: {leaf.rotation}deg;"
 					>
-						<path d="M0,-2 L1.5,0 L0,2 L-1.5,0 Z" fill={leaf.color} opacity="0.85" />
+						<LeafSvg color={leaf.color} />
 					</g>
 				{/each}
 			</g>

--- a/src/lib/trees/assets/ground/GrassSvg.svelte
+++ b/src/lib/trees/assets/ground/GrassSvg.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	interface Props {
+		variant: number;
+	}
+
+	let { variant }: Props = $props();
+</script>
+
+<g>
+	{#if variant === 0}
+		<path d="M0,0 L-1,-6 L0,-4 L1,-7 L2,-3 L1,-5 L2,0" fill="#5a8a3a" stroke="none" />
+	{:else}
+		<path d="M0,0 L-2,-5 L-1,-3 L0,-7 L1,-4 L2,-6 L1,0" fill="#4a7a2a" stroke="none" />
+	{/if}
+</g>

--- a/src/lib/trees/assets/ground/StoneSvg.svelte
+++ b/src/lib/trees/assets/ground/StoneSvg.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	interface Props {
+		variant: number;
+	}
+
+	let { variant }: Props = $props();
+</script>
+
+<g>
+	{#if variant === 0}
+		<polygon
+			points="-4,0 -2,-3 2,-4 5,-1 3,2 -1,2"
+			fill="#8a8a7a"
+			stroke="#7a7a6a"
+			stroke-width="0.3"
+		/>
+	{:else if variant === 1}
+		<polygon
+			points="-3,0 -1,-3 3,-2 4,1 0,2"
+			fill="#9a9080"
+			stroke="#8a8070"
+			stroke-width="0.3"
+		/>
+	{:else}
+		<polygon
+			points="-5,1 -3,-2 0,-3 4,-1 3,2 -2,2"
+			fill="#7a7a6a"
+			stroke="#6a6a5a"
+			stroke-width="0.3"
+		/>
+	{/if}
+</g>

--- a/src/lib/trees/assets/overlays/CloudSvg.svelte
+++ b/src/lib/trees/assets/overlays/CloudSvg.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	interface Props {
+		triangles: readonly string[];
+		opacity: number;
+	}
+
+	let { triangles, opacity }: Props = $props();
+</script>
+
+<g>
+	{#each triangles as points (points)}
+		<polygon {points} fill="rgba(220,220,230,{opacity})" />
+	{/each}
+</g>

--- a/src/lib/trees/assets/overlays/FireflySvg.svelte
+++ b/src/lib/trees/assets/overlays/FireflySvg.svelte
@@ -1,0 +1,3 @@
+<g>
+	<circle cx="0" cy="0" r="3" fill="#9FFF50" filter="url(#firefly-glow)" />
+</g>

--- a/src/lib/trees/assets/overlays/LeafSvg.svelte
+++ b/src/lib/trees/assets/overlays/LeafSvg.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	interface Props {
+		color: string;
+	}
+
+	let { color }: Props = $props();
+</script>
+
+<path d="M0,-2 L1.5,0 L0,2 L-1.5,0 Z" fill={color} opacity="0.85" />

--- a/src/lib/trees/assets/overlays/RaindropSvg.svelte
+++ b/src/lib/trees/assets/overlays/RaindropSvg.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	interface Props {
+		length: number;
+	}
+
+	let { length }: Props = $props();
+</script>
+
+<line x1="0" y1="0" x2="2" y2={length} stroke="rgba(174,194,224,0.5)" stroke-width="1.5" />

--- a/src/lib/trees/assets/overlays/SnowflakeSvg.svelte
+++ b/src/lib/trees/assets/overlays/SnowflakeSvg.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	interface Props {
+		size: number;
+	}
+
+	let { size }: Props = $props();
+</script>
+
+<circle cx="0" cy="0" r={size} fill="white" fill-opacity="0.8" />

--- a/src/lib/trees/assets/overlays/WindParticleSvg.svelte
+++ b/src/lib/trees/assets/overlays/WindParticleSvg.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	interface Props {
+		size: number;
+	}
+
+	let { size }: Props = $props();
+</script>
+
+<path
+	d="M0,-{size} C{size / 2},-{size / 2} {size / 2},{size / 2} 0,{size} C-{size / 3},0 -{size /
+		3},0 0,-{size}Z"
+	fill="rgba(139,119,101,0.4)"
+/>

--- a/src/lib/trees/ground/GroundElements.svelte
+++ b/src/lib/trees/ground/GroundElements.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { Point2D } from '$lib/trees/types/core.js';
 	import { generateGroundPlacements } from './ground_generators.js';
+	import StoneSvg from '$lib/trees/assets/ground/StoneSvg.svelte';
+	import GrassSvg from '$lib/trees/assets/ground/GrassSvg.svelte';
 
 	interface Props {
 		seed: number;
@@ -19,32 +21,9 @@
 			transform="translate({placement.x}, {placement.y}) scale({placement.scale}) rotate({placement.rotation})"
 		>
 			{#if placement.type === 'stone'}
-				{#if placement.variant === 0}
-					<polygon
-						points="-4,0 -2,-3 2,-4 5,-1 3,2 -1,2"
-						fill="#8a8a7a"
-						stroke="#7a7a6a"
-						stroke-width="0.3"
-					/>
-				{:else if placement.variant === 1}
-					<polygon
-						points="-3,0 -1,-3 3,-2 4,1 0,2"
-						fill="#9a9080"
-						stroke="#8a8070"
-						stroke-width="0.3"
-					/>
-				{:else}
-					<polygon
-						points="-5,1 -3,-2 0,-3 4,-1 3,2 -2,2"
-						fill="#7a7a6a"
-						stroke="#6a6a5a"
-						stroke-width="0.3"
-					/>
-				{/if}
-			{:else if placement.variant === 0}
-				<path d="M0,0 L-1,-6 L0,-4 L1,-7 L2,-3 L1,-5 L2,0" fill="#5a8a3a" stroke="none" />
+				<StoneSvg variant={placement.variant} />
 			{:else}
-				<path d="M0,0 L-2,-5 L-1,-3 L0,-7 L1,-4 L2,-6 L1,0" fill="#4a7a2a" stroke="none" />
+				<GrassSvg variant={placement.variant} />
 			{/if}
 		</g>
 	{/each}


### PR DESCRIPTION
## Description
- Extract all inline SVG shapes from logic components into standalone Svelte components (`assets/ground/StoneSvg`, `GrassSvg`; `assets/overlays/LeafSvg`, `CloudSvg`, `RaindropSvg`, `SnowflakeSvg`, `FireflySvg`, `WindParticleSvg`)
- Rewrite `generateSceneLayout()` from 2-row random system to deterministic 10-layer sequential fill with even-layer horizontal stagger and formula-based depth/scale interpolation
- Remove obsolete `priority`/`blockedBy` fields from `SceneTreeInput` and old constants (`FRONT_ROW_CAPACITY`, `BACK_SCALE_MIN/MAX`, `BACK_DEPTH_FALLBACK`)
- Add `LAYER_COUNT`, `TREES_PER_LAYER`, `SCALE_FRONT`, `SCALE_BACK` constants and `layer` field on `SceneTreePlacement`

## Resolves
Closes #128

## Testing
- [x] 20 TDD tests covering all 10-layer behaviors (layer fill, stagger, depth spread, scale, determinism, sorting)
- [x] 2484 unit tests passing
- [x] Static checks clean (prettier, oxlint, stylelint, knip, svelte-check, eslint)
- [x] No inline SVG shapes remain in logic components