### PR TITLE
#149 fix(ui): remove settings card grouping wrappers

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -413,20 +413,18 @@
 				</p>
 			</SectionCard>
 
-			<div class="col-span-full grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
-				<CanopyColorCard
-					bind:lightColor={treeConfig.current.canopyLightColor}
-					bind:darkColor={treeConfig.current.canopyDarkColor}
-					disabled={usePerShapeDefaults.current}
-				/>
+			<CanopyColorCard
+				bind:lightColor={treeConfig.current.canopyLightColor}
+				bind:darkColor={treeConfig.current.canopyDarkColor}
+				disabled={usePerShapeDefaults.current}
+			/>
 
-				<TrunkColorCard
-					bind:hue={treeConfig.current.trunkHue}
-					bind:saturation={treeConfig.current.trunkSaturation}
-					bind:lightness={treeConfig.current.trunkLightness}
-					disabled={usePerShapeDefaults.current}
-				/>
-			</div>
+			<TrunkColorCard
+				bind:hue={treeConfig.current.trunkHue}
+				bind:saturation={treeConfig.current.trunkSaturation}
+				bind:lightness={treeConfig.current.trunkLightness}
+				disabled={usePerShapeDefaults.current}
+			/>
 
 			{#if isIntermediate}
 				<SectionCard title="Environment" contentClass="space-y-4">

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -443,18 +443,16 @@
 				</Card.Root>
 			{/if}
 
-			<div class="col-span-full grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
-				<CanopyColorCard
-					bind:lightColor={treeConfig.current.canopyLightColor}
-					bind:darkColor={treeConfig.current.canopyDarkColor}
-				/>
+			<CanopyColorCard
+				bind:lightColor={treeConfig.current.canopyLightColor}
+				bind:darkColor={treeConfig.current.canopyDarkColor}
+			/>
 
-				<TrunkColorCard
-					bind:hue={treeConfig.current.trunkHue}
-					bind:saturation={treeConfig.current.trunkSaturation}
-					bind:lightness={treeConfig.current.trunkLightness}
-				/>
-			</div>
+			<TrunkColorCard
+				bind:hue={treeConfig.current.trunkHue}
+				bind:saturation={treeConfig.current.trunkSaturation}
+				bind:lightness={treeConfig.current.trunkLightness}
+			/>
 
 			<Card.Root>
 				<Card.Header>


### PR DESCRIPTION
## Description
- Removed col-span-full wrapper divs around CanopyColorCard and TrunkColorCard in both scene and editor pages
- Color cards now flow naturally as flat grid siblings instead of forcing each onto its own row
- Eliminates excessive whitespace in the settings grid layout

## Resolves
Closes #149

## Testing
- [ ] Verify color cards display correctly in grid without wrapper
- [ ] Check both scene editor and single editor layouts
- [ ] Confirm no visual regressions in card alignment