### PR TITLE
#161 feat(tools): add grill tool with flame animation

### DIFF
--- a/src/lib/trees/TreeTool.svelte
+++ b/src/lib/trees/TreeTool.svelte
@@ -161,6 +161,17 @@
 		}
 	}
 
+	@keyframes tool-grill-idle {
+		0%,
+		100% {
+			transform: rotate(0deg);
+		}
+
+		50% {
+			transform: rotate(0.5deg);
+		}
+	}
+
 	.tool-anim.animate-tool {
 		transform-origin: var(--pivot-x) var(--pivot-y);
 		will-change: transform;
@@ -188,6 +199,10 @@
 
 	.tool-anim.animate-tool[data-tool-type='woodpecker'] {
 		animation: tool-woodpecker-idle var(--tool-duration) ease-in-out infinite;
+	}
+
+	.tool-anim.animate-tool[data-tool-type='grill'] {
+		animation: tool-grill-idle var(--tool-duration) ease-in-out infinite;
 	}
 
 	.woodpecker-badge text {

--- a/src/lib/trees/assets/tools/FlameSvg.svelte
+++ b/src/lib/trees/assets/tools/FlameSvg.svelte
@@ -1,0 +1,69 @@
+<!--
+	Flame SVG — animated teardrop/organic flame shape.
+	Props: animationDelay (seconds) for staggered animation.
+	Animation activates only when parent has .animate-tool class.
+-->
+<script lang="ts">
+	interface Props {
+		animationDelay?: number;
+	}
+
+	let { animationDelay = 0 }: Props = $props();
+</script>
+
+<g class="flame" style="--flame-delay: {animationDelay}s;">
+	<!-- Outer flame (orange) -->
+	<path
+		d="M0,-8 C-3,-4 -4,0 -3,3 C-2,5 -1,6 0,6 C1,6 2,5 3,3 C4,0 3,-4 0,-8Z"
+		fill="#F97316"
+		opacity="0.9"
+	/>
+	<!-- Inner flame (yellow) -->
+	<path
+		d="M0,-5 C-2,-2 -2.5,0 -2,2 C-1.5,3.5 -0.5,4.5 0,4.5 C0.5,4.5 1.5,3.5 2,2 C2.5,0 2,-2 0,-5Z"
+		fill="#FBBF24"
+		opacity="0.85"
+	/>
+	<!-- Core (bright yellow-white) -->
+	<path
+		d="M0,-2 C-1,0 -1,1 -0.5,2.5 C0,3.5 0.5,2.5 0.5,2.5 C1,1 1,0 0,-2Z"
+		fill="#FDE68A"
+		opacity="0.8"
+	/>
+</g>
+
+<style>
+	@keyframes flame-flicker {
+		0%,
+		100% {
+			opacity: 0.3;
+			transform: translateX(0);
+		}
+
+		25% {
+			opacity: 0.8;
+			transform: translateX(-2px);
+		}
+
+		50% {
+			opacity: 1;
+			transform: translateX(0);
+		}
+
+		75% {
+			opacity: 0.7;
+			transform: translateX(2px);
+		}
+	}
+
+	.flame {
+		display: none;
+	}
+
+	:global(.animate-tool) .flame {
+		display: block;
+		animation: flame-flicker 1.5s ease-in-out infinite;
+		animation-delay: var(--flame-delay);
+		animation-fill-mode: both;
+	}
+</style>

--- a/src/lib/trees/assets/tools/GrillSvg.svelte
+++ b/src/lib/trees/assets/tools/GrillSvg.svelte
@@ -1,0 +1,36 @@
+<!--
+	Grill placeholder SVG — charcoal grill with grate lines and flames.
+	Snap point at local (10, 20) — matching snapOffset.
+	Flames animate only when parent has .animate-tool class.
+-->
+<script lang="ts">
+	import FlameSvg from './FlameSvg.svelte';
+</script>
+
+<g>
+	<!-- Grill body (bowl) -->
+	<ellipse cx="10" cy="20" rx="14" ry="5" fill="#2A2A2A" />
+	<rect x="-4" y="12" width="28" height="8" rx="2" fill="#333333" />
+
+	<!-- Grate lines -->
+	<line x1="-2" y1="12" x2="22" y2="12" stroke="#555555" stroke-width="1.5" />
+	<line x1="-2" y1="15" x2="22" y2="15" stroke="#555555" stroke-width="1" />
+	<line x1="-2" y1="18" x2="22" y2="18" stroke="#555555" stroke-width="1" />
+
+	<!-- Legs -->
+	<line x1="0" y1="20" x2="-2" y2="30" stroke="#444444" stroke-width="2" />
+	<line x1="6" y1="20" x2="4" y2="30" stroke="#444444" stroke-width="2" />
+	<line x1="14" y1="20" x2="16" y2="30" stroke="#444444" stroke-width="2" />
+	<line x1="20" y1="20" x2="22" y2="30" stroke="#444444" stroke-width="2" />
+
+	<!-- Flames above the grate -->
+	<g transform="translate(4, 6)">
+		<FlameSvg animationDelay={0} />
+	</g>
+	<g transform="translate(10, 4)">
+		<FlameSvg animationDelay={0.3} />
+	</g>
+	<g transform="translate(16, 6)">
+		<FlameSvg animationDelay={0.6} />
+	</g>
+</g>

--- a/src/lib/trees/assets/tools/index.ts
+++ b/src/lib/trees/assets/tools/index.ts
@@ -1,4 +1,5 @@
 export { default as AxeSvg } from './AxeSvg.svelte';
+export { default as GrillSvg } from './GrillSvg.svelte';
 export { default as LadderSvg } from './LadderSvg.svelte';
 export { default as RakeSvg } from './RakeSvg.svelte';
 export { default as ShovelSvg } from './ShovelSvg.svelte';

--- a/src/lib/trees/tools/tool_animations.test.ts
+++ b/src/lib/trees/tools/tool_animations.test.ts
@@ -4,7 +4,7 @@ import type { ToolAnimationConfig } from './tool_animations.js';
 import { TOOL_TYPES } from './tool_types.js';
 
 describe('TOOL_ANIMATIONS', () => {
-	it('has animation config for all 6 tool types', () => {
+	it('has animation config for all 7 tool types', () => {
 		for (const toolType of Object.values(TOOL_TYPES)) {
 			expect(TOOL_ANIMATIONS).toHaveProperty(toolType);
 		}
@@ -42,6 +42,10 @@ describe('TOOL_ANIMATIONS', () => {
 
 	it('woodpecker duration is 1.5s', () => {
 		expect(TOOL_ANIMATIONS.woodpecker.duration).toBe(1.5);
+	});
+
+	it('grill duration is 2s', () => {
+		expect(TOOL_ANIMATIONS.grill.duration).toBe(2);
 	});
 
 	it('each tool has a pivotPoint with x and y', () => {

--- a/src/lib/trees/tools/tool_animations.ts
+++ b/src/lib/trees/tools/tool_animations.ts
@@ -30,4 +30,8 @@ export const TOOL_ANIMATIONS = {
 		duration: 1.5,
 		pivotPoint: { x: 6, y: 10 },
 	},
+	grill: {
+		duration: 2,
+		pivotPoint: { x: 10, y: 20 },
+	},
 } as const satisfies Record<ToolType, ToolAnimationConfig>;

--- a/src/lib/trees/tools/tool_definitions.test.ts
+++ b/src/lib/trees/tools/tool_definitions.test.ts
@@ -4,7 +4,7 @@ import { TOOL_TYPES, TOOL_ANCHOR_MAP } from './tool_types.js';
 import type { ToolType } from './tool_types.js';
 
 describe('TOOL_DEFINITIONS', () => {
-	it('has entries for all 6 tool types', () => {
+	it('has entries for all 7 tool types', () => {
 		for (const toolType of Object.values(TOOL_TYPES)) {
 			expect(TOOL_DEFINITIONS).toHaveProperty(toolType);
 		}
@@ -65,5 +65,13 @@ describe('TOOL_DEFINITIONS', () => {
 
 	it('woodpecker has correct snapOffset', () => {
 		expect(TOOL_DEFINITIONS.woodpecker.snapOffset).toEqual({ x: 6, y: 10 });
+	});
+
+	it('grill has correct snapOffset', () => {
+		expect(TOOL_DEFINITIONS.grill.snapOffset).toEqual({ x: 10, y: 20 });
+	});
+
+	it('grill anchorTarget is trunkBase', () => {
+		expect(TOOL_DEFINITIONS.grill.anchorTarget).toBe('trunkBase');
 	});
 });

--- a/src/lib/trees/tools/tool_definitions.ts
+++ b/src/lib/trees/tools/tool_definitions.ts
@@ -8,6 +8,7 @@ import LadderSvg from '$lib/trees/assets/tools/LadderSvg.svelte';
 import AxeSvg from '$lib/trees/assets/tools/AxeSvg.svelte';
 import RakeSvg from '$lib/trees/assets/tools/RakeSvg.svelte';
 import WoodpeckerSvg from '$lib/trees/assets/tools/WoodpeckerSvg.svelte';
+import GrillSvg from '$lib/trees/assets/tools/GrillSvg.svelte';
 
 export interface ToolDefinition {
 	readonly svgComponent: Component;
@@ -45,5 +46,10 @@ export const TOOL_DEFINITIONS = {
 		svgComponent: WoodpeckerSvg,
 		anchorTarget: 'trunkMiddle',
 		snapOffset: { x: 6, y: 10 },
+	},
+	[TOOL_TYPES.grill]: {
+		svgComponent: GrillSvg,
+		anchorTarget: 'trunkBase',
+		snapOffset: { x: 10, y: 20 },
 	},
 } as const satisfies Record<ToolType, ToolDefinition>;

--- a/src/lib/trees/tools/tool_types.test.ts
+++ b/src/lib/trees/tools/tool_types.test.ts
@@ -7,18 +7,19 @@ import {
 } from './tool_types.js';
 
 describe('TOOL_TYPES', () => {
-	it('defines exactly 6 tools', () => {
+	it('defines exactly 7 tools', () => {
 		const types = Object.values(TOOL_TYPES);
-		expect(types).toHaveLength(6);
+		expect(types).toHaveLength(7);
 	});
 
-	it('contains shovel, wateringCan, ladder, axe, rake, woodpecker', () => {
+	it('contains shovel, wateringCan, ladder, axe, rake, woodpecker, grill', () => {
 		expect(TOOL_TYPES.shovel).toBe('shovel');
 		expect(TOOL_TYPES.wateringCan).toBe('wateringCan');
 		expect(TOOL_TYPES.ladder).toBe('ladder');
 		expect(TOOL_TYPES.axe).toBe('axe');
 		expect(TOOL_TYPES.rake).toBe('rake');
 		expect(TOOL_TYPES.woodpecker).toBe('woodpecker');
+		expect(TOOL_TYPES.grill).toBe('grill');
 	});
 
 	it('does not contain birdNest', () => {
@@ -57,6 +58,10 @@ describe('TOOL_ANCHOR_MAP', () => {
 	it('woodpecker snaps to trunkMiddle', () => {
 		expect(TOOL_ANCHOR_MAP[TOOL_TYPES.woodpecker]).toBe('trunkMiddle');
 	});
+
+	it('grill snaps to trunkBase', () => {
+		expect(TOOL_ANCHOR_MAP[TOOL_TYPES.grill]).toBe('trunkBase');
+	});
 });
 
 describe('TOOL_OPTIONS', () => {
@@ -79,7 +84,7 @@ describe('TOOL_OPTIONS', () => {
 		}
 	});
 
-	it('has correct labels for all 6 tools', () => {
+	it('has correct labels for all 7 tools', () => {
 		const labelMap = new Map(TOOL_OPTIONS.map((o) => [o.value, o.label]));
 		expect(labelMap.get('shovel')).toBe('Shovel');
 		expect(labelMap.get('wateringCan')).toBe('Watering Can');
@@ -87,11 +92,12 @@ describe('TOOL_OPTIONS', () => {
 		expect(labelMap.get('axe')).toBe('Axe');
 		expect(labelMap.get('rake')).toBe('Rake');
 		expect(labelMap.get('woodpecker')).toBe('Woodpecker');
+		expect(labelMap.get('grill')).toBe('Grill');
 	});
 });
 
 describe('createDefaultToolVisibility', () => {
-	it('has entries for all 6 tools', () => {
+	it('has entries for all 7 tools', () => {
 		const visibility = createDefaultToolVisibility();
 		for (const toolType of Object.values(TOOL_TYPES)) {
 			expect(visibility).toHaveProperty(toolType);

--- a/src/lib/trees/tools/tool_types.ts
+++ b/src/lib/trees/tools/tool_types.ts
@@ -7,6 +7,7 @@ export const TOOL_TYPES = {
 	axe: 'axe',
 	rake: 'rake',
 	woodpecker: 'woodpecker',
+	grill: 'grill',
 } as const;
 
 export type ToolType = (typeof TOOL_TYPES)[keyof typeof TOOL_TYPES];
@@ -25,6 +26,7 @@ export const TOOL_ANCHOR_MAP = {
 	[TOOL_TYPES.axe]: 'trunkBase',
 	[TOOL_TYPES.rake]: 'trunkBase',
 	[TOOL_TYPES.woodpecker]: 'trunkMiddle',
+	[TOOL_TYPES.grill]: 'trunkBase',
 } as const satisfies Record<ToolType, keyof TreeAnchors>;
 
 export function createDefaultToolVisibility(): ToolVisibility {
@@ -35,6 +37,7 @@ export function createDefaultToolVisibility(): ToolVisibility {
 		[TOOL_TYPES.axe]: { visible: false, size: 1 },
 		[TOOL_TYPES.rake]: { visible: false, size: 1 },
 		[TOOL_TYPES.woodpecker]: { visible: false, size: 1 },
+		[TOOL_TYPES.grill]: { visible: false, size: 1 },
 	};
 }
 
@@ -45,4 +48,5 @@ export const TOOL_OPTIONS = [
 	{ value: TOOL_TYPES.axe, label: 'Axe' },
 	{ value: TOOL_TYPES.rake, label: 'Rake' },
 	{ value: TOOL_TYPES.woodpecker, label: 'Woodpecker' },
+	{ value: TOOL_TYPES.grill, label: 'Grill' },
 ] as const;


### PR DESCRIPTION
## Description
- Adds grill tool to tool system registries (ToolType, ToolDefinition, ToolAnimationConfig)
- Grill anchors at trunkBase with x-offset via snapOffset {x:10, y:20}
- GrillSvg.svelte: renders placeholder with rectangle body, 3 grate lines, 4 legs
- FlameSvg.svelte: animated teardrop flames with opacity flicker + translateX sway (3 instances)
- Flames hidden by default, visible only when animateTools is enabled
- CSS keyframe animation with staggered delays (0s, 0.3s, 0.6s) for flame instances
- Size range 0.5-2.0 via existing size slider (default 1.0)
- All 3 test files updated (tool_types, tool_definitions, tool_animations) — 7 tools total
- TreeTool.svelte: added grill idle keyframe + CSS rule

## Resolves
Closes #161

## Testing
- [ ] Grill renders at correct position with snap offset applied
- [ ] Flames animate only when animateTools is enabled
- [ ] Grill size slider adjusts flame scale correctly (0.5-2.0)
- [ ] Flame animations are staggered and smooth
- [ ] All tool test suites pass