### PR TITLE
fix(tools): offset grill to the right of trunk

### DIFF
--- a/src/lib/trees/tools/tool_definitions.test.ts
+++ b/src/lib/trees/tools/tool_definitions.test.ts
@@ -68,7 +68,7 @@ describe('TOOL_DEFINITIONS', () => {
 	});
 
 	it('grill has correct snapOffset', () => {
-		expect(TOOL_DEFINITIONS.grill.snapOffset).toEqual({ x: 10, y: 20 });
+		expect(TOOL_DEFINITIONS.grill.snapOffset).toEqual({ x: -5, y: 20 });
 	});
 
 	it('grill anchorTarget is trunkBase', () => {

--- a/src/lib/trees/tools/tool_definitions.ts
+++ b/src/lib/trees/tools/tool_definitions.ts
@@ -50,6 +50,6 @@ export const TOOL_DEFINITIONS = {
 	[TOOL_TYPES.grill]: {
 		svgComponent: GrillSvg,
 		anchorTarget: 'trunkBase',
-		snapOffset: { x: 10, y: 20 },
+		snapOffset: { x: -5, y: 20 },
 	},
 } as const satisfies Record<ToolType, ToolDefinition>;


### PR DESCRIPTION
## Summary

- Adjusts grill snapOffset.x from `10` to `-5` so the grill is positioned to the right of the trunk instead of centered on it
- Follow-up to #168

## Test plan

- [ ] Grill renders to the right of the trunk base, not overlapping the trunk
- [ ] Unit test updated to match new snapOffset