### PR TITLE
#162 feat(auth): Add avatar settings with animal presets

### DIFF
--- a/drizzle/0002_avatar_columns.sql
+++ b/drizzle/0002_avatar_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user" ADD COLUMN "avatar_preset" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "avatar_color" text;

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,11 +2,16 @@
 // for information about these interfaces
 import type { User, Session } from 'better-auth';
 
+type AppUser = User & {
+	avatarPreset?: string | null;
+	avatarColor?: string | null;
+};
+
 declare global {
 	namespace App {
 		// interface Error {}
 		interface Locals {
-			user: User | null;
+			user: AppUser | null;
 			session: Session | null;
 		}
 		// interface PageData {}

--- a/src/lib/avatar/AnimalIcon.svelte
+++ b/src/lib/avatar/AnimalIcon.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { AnimalPreset } from './presets.js';
+	import Cat from './animals/Cat.svelte';
+	import Dog from './animals/Dog.svelte';
+	import Fox from './animals/Fox.svelte';
+	import Owl from './animals/Owl.svelte';
+	import Bear from './animals/Bear.svelte';
+	import Rabbit from './animals/Rabbit.svelte';
+	import Penguin from './animals/Penguin.svelte';
+	import Deer from './animals/Deer.svelte';
+	import Wolf from './animals/Wolf.svelte';
+	import Frog from './animals/Frog.svelte';
+	import type { Component } from 'svelte';
+
+	const ANIMAL_COMPONENTS = {
+		cat: Cat,
+		dog: Dog,
+		fox: Fox,
+		owl: Owl,
+		bear: Bear,
+		rabbit: Rabbit,
+		penguin: Penguin,
+		deer: Deer,
+		wolf: Wolf,
+		frog: Frog,
+	} as const satisfies Record<AnimalPreset, Component<{ class?: string }>>;
+
+	let { preset, class: className = '' }: { preset: AnimalPreset; class?: string } = $props();
+
+	const AnimalComponent = $derived(ANIMAL_COMPONENTS[preset]);
+</script>
+
+<AnimalComponent class={className} />

--- a/src/lib/avatar/AvatarCircle.svelte
+++ b/src/lib/avatar/AvatarCircle.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import User from '@lucide/svelte/icons/user';
+	import AnimalIcon from './AnimalIcon.svelte';
+	import { isValidPreset, type AnimalPreset } from './presets.js';
+
+	let {
+		preset = null,
+		color = null,
+		size = 'sm',
+	}: {
+		preset?: string | null;
+		color?: string | null;
+		size?: 'sm' | 'lg';
+	} = $props();
+
+	const sizeClass = $derived(size === 'lg' ? 'size-16' : 'size-8');
+	const iconClass = $derived(size === 'lg' ? 'size-10' : 'size-5');
+	const fallbackIconClass = $derived(size === 'lg' ? 'size-6' : 'size-4');
+	const validPreset = $derived.by((): AnimalPreset | null => {
+		if (preset !== null && isValidPreset(preset)) {
+			return preset;
+		}
+		return null;
+	});
+</script>
+
+{#if validPreset !== null && color !== null}
+	<div
+		class="flex items-center justify-center rounded-full {sizeClass}"
+		style:background-color={color}
+	>
+		<AnimalIcon preset={validPreset} class="{iconClass} text-white drop-shadow-sm" />
+	</div>
+{:else}
+	<div class="flex items-center justify-center rounded-full bg-muted {sizeClass}">
+		<User class="{fallbackIconClass} text-muted-foreground" />
+	</div>
+{/if}

--- a/src/lib/avatar/animals/Bear.svelte
+++ b/src/lib/avatar/animals/Bear.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<circle cx="16" cy="16" r="8" />
+	<circle cx="48" cy="16" r="8" />
+	<ellipse cx="32" cy="34" rx="20" ry="18" />
+	<circle cx="24" cy="30" r="2.5" fill="white" />
+	<circle cx="40" cy="30" r="2.5" fill="white" />
+	<ellipse cx="32" cy="38" rx="6" ry="5" fill="white" opacity="0.3" />
+	<ellipse cx="32" cy="36" rx="3" ry="2" />
+	<path d="M29 40q3 2 6 0" stroke="currentColor" fill="none" stroke-width="1.5" />
+</svg>

--- a/src/lib/avatar/animals/Cat.svelte
+++ b/src/lib/avatar/animals/Cat.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<path d="M16 8l-4 16h4l-2 8c4-2 8-4 12-4s8 2 12 4l-2-8h4L36 8l-4 6-6-2-6 2-4-6z" />
+	<ellipse cx="32" cy="38" rx="14" ry="12" />
+	<circle cx="26" cy="35" r="2.5" fill="white" />
+	<circle cx="38" cy="35" r="2.5" fill="white" />
+	<ellipse cx="32" cy="40" rx="2" ry="1.5" />
+	<path d="M30 42q2 2 4 0" stroke="currentColor" fill="none" stroke-width="1.5" />
+	<path
+		d="M18 39h-8M46 39h8M18 42h-7M46 42h7"
+		stroke="currentColor"
+		stroke-width="1"
+		fill="none"
+	/>
+</svg>

--- a/src/lib/avatar/animals/Deer.svelte
+++ b/src/lib/avatar/animals/Deer.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<path d="M20 4v8l-4 4h4v4" stroke="currentColor" fill="none" stroke-width="2" />
+	<path d="M16 8h-4M18 12h-6" stroke="currentColor" fill="none" stroke-width="2" />
+	<path d="M44 4v8l4 4h-4v4" stroke="currentColor" fill="none" stroke-width="2" />
+	<path d="M48 8h4M46 12h6" stroke="currentColor" fill="none" stroke-width="2" />
+	<ellipse cx="32" cy="36" rx="14" ry="16" />
+	<ellipse cx="20" cy="28" rx="4" ry="6" transform="rotate(-10 20 28)" />
+	<ellipse cx="44" cy="28" rx="4" ry="6" transform="rotate(10 44 28)" />
+	<circle cx="26" cy="32" r="2.5" fill="white" />
+	<circle cx="38" cy="32" r="2.5" fill="white" />
+	<ellipse cx="32" cy="40" rx="3" ry="2" />
+</svg>

--- a/src/lib/avatar/animals/Dog.svelte
+++ b/src/lib/avatar/animals/Dog.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<ellipse cx="32" cy="36" rx="16" ry="14" />
+	<ellipse cx="16" cy="20" rx="6" ry="10" transform="rotate(-15 16 20)" />
+	<ellipse cx="48" cy="20" rx="6" ry="10" transform="rotate(15 48 20)" />
+	<circle cx="26" cy="33" r="2.5" fill="white" />
+	<circle cx="38" cy="33" r="2.5" fill="white" />
+	<ellipse cx="32" cy="39" rx="4" ry="3" />
+	<circle cx="32" cy="38" r="2" fill="white" />
+	<path d="M28 44q4 3 8 0" stroke="currentColor" fill="none" stroke-width="1.5" />
+</svg>

--- a/src/lib/avatar/animals/Fox.svelte
+++ b/src/lib/avatar/animals/Fox.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<path d="M12 6l6 20h-4l18 18 18-18h-4L52 6l-10 14H22L12 6z" />
+	<ellipse cx="32" cy="40" rx="14" ry="10" />
+	<circle cx="25" cy="34" r="2.5" fill="white" />
+	<circle cx="39" cy="34" r="2.5" fill="white" />
+	<path d="M32 42l-3 3h6l-3-3z" />
+	<circle cx="32" cy="42" r="1.5" fill="white" />
+</svg>

--- a/src/lib/avatar/animals/Frog.svelte
+++ b/src/lib/avatar/animals/Frog.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<circle cx="20" cy="18" r="8" />
+	<circle cx="44" cy="18" r="8" />
+	<circle cx="20" cy="18" r="4" fill="white" />
+	<circle cx="44" cy="18" r="4" fill="white" />
+	<circle cx="20" cy="18" r="2" />
+	<circle cx="44" cy="18" r="2" />
+	<ellipse cx="32" cy="38" rx="20" ry="14" />
+	<path d="M22 42q10 6 20 0" stroke="currentColor" fill="none" stroke-width="2" />
+	<circle cx="18" cy="36" r="1" />
+	<circle cx="46" cy="36" r="1" />
+</svg>

--- a/src/lib/avatar/animals/Owl.svelte
+++ b/src/lib/avatar/animals/Owl.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<path d="M14 12l4 10-6 4 20 2 20-2-6-4 4-10-10 8H24L14 12z" />
+	<ellipse cx="32" cy="36" rx="18" ry="16" />
+	<circle cx="24" cy="32" r="7" fill="white" />
+	<circle cx="40" cy="32" r="7" fill="white" />
+	<circle cx="24" cy="32" r="3.5" />
+	<circle cx="40" cy="32" r="3.5" />
+	<path d="M30 40l2 3 2-3z" />
+	<path d="M20 46q12 6 24 0" stroke="currentColor" fill="none" stroke-width="1.5" />
+</svg>

--- a/src/lib/avatar/animals/Penguin.svelte
+++ b/src/lib/avatar/animals/Penguin.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<ellipse cx="32" cy="34" rx="16" ry="22" />
+	<ellipse cx="32" cy="38" rx="10" ry="16" fill="white" opacity="0.3" />
+	<circle cx="26" cy="26" r="2.5" fill="white" />
+	<circle cx="38" cy="26" r="2.5" fill="white" />
+	<path d="M30 32l2 3 2-3z" />
+	<path d="M12 30q-4 14 6 18" stroke="currentColor" fill="none" stroke-width="3" />
+	<path d="M52 30q4 14-6 18" stroke="currentColor" fill="none" stroke-width="3" />
+</svg>

--- a/src/lib/avatar/animals/Rabbit.svelte
+++ b/src/lib/avatar/animals/Rabbit.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<ellipse cx="24" cy="14" rx="5" ry="14" />
+	<ellipse cx="40" cy="14" rx="5" ry="14" />
+	<ellipse cx="24" cy="14" rx="2.5" ry="10" fill="white" opacity="0.3" />
+	<ellipse cx="40" cy="14" rx="2.5" ry="10" fill="white" opacity="0.3" />
+	<ellipse cx="32" cy="40" rx="16" ry="14" />
+	<circle cx="26" cy="36" r="2.5" fill="white" />
+	<circle cx="38" cy="36" r="2.5" fill="white" />
+	<ellipse cx="32" cy="42" rx="2" ry="1.5" />
+	<path d="M30 44q2 2 4 0" stroke="currentColor" fill="none" stroke-width="1.5" />
+	<circle cx="24" cy="42" r="3" fill="white" opacity="0.3" />
+	<circle cx="40" cy="42" r="3" fill="white" opacity="0.3" />
+</svg>

--- a/src/lib/avatar/animals/Wolf.svelte
+++ b/src/lib/avatar/animals/Wolf.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<svg viewBox="0 0 64 64" fill="currentColor" class={className} xmlns="http://www.w3.org/2000/svg">
+	<path d="M10 8l8 18h-4l18 14 18-14h-4L54 8l-12 12H22L10 8z" />
+	<ellipse cx="32" cy="38" rx="16" ry="14" />
+	<circle cx="25" cy="33" r="2.5" fill="white" />
+	<circle cx="39" cy="33" r="2.5" fill="white" />
+	<ellipse cx="32" cy="40" rx="4" ry="3" fill="white" opacity="0.3" />
+	<ellipse cx="32" cy="39" rx="2.5" ry="1.5" />
+	<path d="M28 44q4 2 8 0" stroke="currentColor" fill="none" stroke-width="1.5" />
+</svg>

--- a/src/lib/avatar/presets.test.ts
+++ b/src/lib/avatar/presets.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+	ANIMAL_PRESETS,
+	PRESET_COLORS,
+	getRandomPreset,
+	getRandomColor,
+	isValidPreset,
+	isValidColor,
+} from './presets.js';
+
+describe('ANIMAL_PRESETS', () => {
+	it('contains exactly 10 animals', () => {
+		expect(ANIMAL_PRESETS).toHaveLength(10);
+	});
+
+	it('contains the required animals', () => {
+		const expected = [
+			'cat',
+			'dog',
+			'fox',
+			'owl',
+			'bear',
+			'rabbit',
+			'penguin',
+			'deer',
+			'wolf',
+			'frog',
+		];
+		expect([...ANIMAL_PRESETS]).toEqual(expect.arrayContaining(expected));
+	});
+});
+
+describe('PRESET_COLORS', () => {
+	it('contains exactly 10 colors', () => {
+		expect(PRESET_COLORS).toHaveLength(10);
+	});
+
+	it('all values are valid hex colors', () => {
+		for (const color of PRESET_COLORS) {
+			expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+		}
+	});
+});
+
+describe('getRandomPreset', () => {
+	it('returns a value from ANIMAL_PRESETS', () => {
+		for (let i = 0; i < 20; i++) {
+			const result = getRandomPreset();
+			expect(ANIMAL_PRESETS).toContain(result);
+		}
+	});
+});
+
+describe('getRandomColor', () => {
+	it('returns a value from PRESET_COLORS', () => {
+		for (let i = 0; i < 20; i++) {
+			const result = getRandomColor();
+			expect(PRESET_COLORS).toContain(result);
+		}
+	});
+});
+
+describe('isValidPreset', () => {
+	it('returns true for valid presets', () => {
+		expect(isValidPreset('cat')).toBe(true);
+		expect(isValidPreset('frog')).toBe(true);
+	});
+
+	it('returns false for invalid presets', () => {
+		expect(isValidPreset('unicorn')).toBe(false);
+		expect(isValidPreset('')).toBe(false);
+	});
+});
+
+describe('isValidColor', () => {
+	it('returns true for preset colors', () => {
+		expect(isValidColor(PRESET_COLORS[0])).toBe(true);
+	});
+
+	it('returns true for valid hex colors', () => {
+		expect(isValidColor('#FF00AA')).toBe(true);
+		expect(isValidColor('#abcdef')).toBe(true);
+	});
+
+	it('returns false for invalid colors', () => {
+		expect(isValidColor('red')).toBe(false);
+		expect(isValidColor('#GGG')).toBe(false);
+		expect(isValidColor('')).toBe(false);
+	});
+});

--- a/src/lib/avatar/presets.ts
+++ b/src/lib/avatar/presets.ts
@@ -1,0 +1,47 @@
+export const ANIMAL_PRESETS = [
+	'cat',
+	'dog',
+	'fox',
+	'owl',
+	'bear',
+	'rabbit',
+	'penguin',
+	'deer',
+	'wolf',
+	'frog',
+] as const;
+
+export type AnimalPreset = (typeof ANIMAL_PRESETS)[number];
+
+export const PRESET_COLORS = [
+	'#F4A6A0',
+	'#A8D8B9',
+	'#A0C4E8',
+	'#F5D6A8',
+	'#C4B0E0',
+	'#F0B8D0',
+	'#B0D8D8',
+	'#E8C8A0',
+	'#A0B8D8',
+	'#D8D0A0',
+] as const;
+
+type PresetColor = (typeof PRESET_COLORS)[number];
+
+export function getRandomPreset(): AnimalPreset {
+	return ANIMAL_PRESETS[Math.floor(Math.random() * ANIMAL_PRESETS.length)];
+}
+
+export function getRandomColor(): PresetColor {
+	return PRESET_COLORS[Math.floor(Math.random() * PRESET_COLORS.length)];
+}
+
+export function isValidPreset(value: string): value is AnimalPreset {
+	return (ANIMAL_PRESETS as readonly string[]).includes(value);
+}
+
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export function isValidColor(value: string): boolean {
+	return HEX_COLOR_PATTERN.test(value);
+}

--- a/src/lib/components/app-shell/AppSidebar.svelte
+++ b/src/lib/components/app-shell/AppSidebar.svelte
@@ -12,6 +12,7 @@
 	import User from '@lucide/svelte/icons/user';
 	import Sun from '@lucide/svelte/icons/sun';
 	import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
+	import AvatarCircle from '$lib/avatar/AvatarCircle.svelte';
 	import { userPrefersMode, setMode } from 'mode-watcher';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -145,19 +146,11 @@
 								>
 									{#snippet child({ props })}
 										<div data-testid="sidebar-user-trigger" {...props}>
-											{#if user.image}
-												<img
-													src={user.image}
-													alt={user.name}
-													class="size-8 rounded-full object-cover"
-												/>
-											{:else}
-												<div
-													class="flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold"
-												>
-													{user.name.slice(0, 2).toUpperCase()}
-												</div>
-											{/if}
+											<AvatarCircle
+												preset={user.avatarPreset}
+												color={user.avatarColor}
+												size="sm"
+											/>
 											<div
 												class="grid flex-1 text-left text-sm leading-tight"
 											>

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -6,6 +6,7 @@ import { env } from '$env/dynamic/private';
 import { getRequestEvent } from '$app/server';
 import { db } from './db/index.js';
 import * as schema from './db/schema.js';
+import { getRandomPreset, getRandomColor } from '$lib/avatar/presets.js';
 
 if (env.AUTH_SECRET === undefined || env.AUTH_SECRET === '') {
 	throw new Error('AUTH_SECRET environment variable is required');
@@ -38,6 +39,37 @@ export const auth = betterAuth({
 	secret: env.AUTH_SECRET,
 
 	database: drizzleAdapter(db, { provider: 'pg', schema }),
+
+	user: {
+		additionalFields: {
+			avatarPreset: {
+				type: 'string',
+				required: false,
+				input: false,
+			},
+			avatarColor: {
+				type: 'string',
+				required: false,
+				input: false,
+			},
+		},
+	},
+
+	databaseHooks: {
+		user: {
+			create: {
+				before: async (user) => {
+					return {
+						data: {
+							...user,
+							avatarPreset: getRandomPreset(),
+							avatarColor: getRandomColor(),
+						},
+					};
+				},
+			},
+		},
+	},
 
 	emailAndPassword: {
 		enabled: true,

--- a/src/lib/server/db/auth.schema.ts
+++ b/src/lib/server/db/auth.schema.ts
@@ -6,6 +6,8 @@ export const user = pgTable('user', {
 	email: text('email').notNull().unique(),
 	emailVerified: boolean('email_verified').notNull().default(false),
 	image: text('image'),
+	avatarPreset: text('avatar_preset'),
+	avatarColor: text('avatar_color'),
 	createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 	updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -11,6 +11,8 @@ export const load: LayoutServerLoad = ({ locals, cookies }) => {
 					name: locals.user.name,
 					email: locals.user.email,
 					image: locals.user.image ?? null,
+					avatarPreset: locals.user.avatarPreset ?? null,
+					avatarColor: locals.user.avatarColor ?? null,
 				}
 			: null,
 	};

--- a/src/routes/api/avatar/+server.ts
+++ b/src/routes/api/avatar/+server.ts
@@ -1,0 +1,43 @@
+import { json, error } from '@sveltejs/kit';
+import { db } from '$lib/server/db/index.js';
+import { user } from '$lib/server/db/schema.js';
+import { eq } from 'drizzle-orm';
+import { isValidPreset, isValidColor } from '$lib/avatar/presets.js';
+import type { RequestHandler } from './$types.js';
+
+export const PATCH: RequestHandler = async ({ locals, request }) => {
+	if (!locals.user) {
+		error(401, 'Unauthorized');
+	}
+
+	const body: unknown = await request.json();
+
+	if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+		error(400, 'Invalid request body');
+	}
+
+	const { avatarPreset, avatarColor } = body as Record<string, unknown>;
+	const updates: { avatarPreset?: string; avatarColor?: string } = {};
+
+	if (avatarPreset !== undefined) {
+		if (typeof avatarPreset !== 'string' || !isValidPreset(avatarPreset)) {
+			error(400, 'Invalid avatar preset');
+		}
+		updates.avatarPreset = avatarPreset;
+	}
+
+	if (avatarColor !== undefined) {
+		if (typeof avatarColor !== 'string' || !isValidColor(avatarColor)) {
+			error(400, 'Invalid avatar color');
+		}
+		updates.avatarColor = avatarColor;
+	}
+
+	if (Object.keys(updates).length === 0) {
+		error(400, 'No fields to update');
+	}
+
+	await db.update(user).set(updates).where(eq(user.id, locals.user.id));
+
+	return json({ success: true });
+};

--- a/src/routes/api/avatar/server.test.ts
+++ b/src/routes/api/avatar/server.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { updateMock, setMock, whereMock } = vi.hoisted(() => ({
+	updateMock: vi.fn(),
+	setMock: vi.fn(),
+	whereMock: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/index.js', () => ({
+	db: {
+		update: updateMock,
+	},
+}));
+
+vi.mock('$lib/server/db/schema.js', () => ({
+	user: { id: 'id' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+	eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
+}));
+
+import { PATCH } from './+server.js';
+import { PRESET_COLORS } from '$lib/avatar/presets.js';
+
+function makeEvent(
+	body: Record<string, unknown>,
+	user: { id: string } | null = { id: 'user-1' },
+): Parameters<typeof PATCH>[0] {
+	const request = new Request('http://localhost/api/avatar', {
+		method: 'PATCH',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	return { locals: { user }, request } as unknown as Parameters<typeof PATCH>[0];
+}
+
+describe('PATCH /api/avatar', () => {
+	beforeEach(() => {
+		updateMock.mockReset();
+		setMock.mockReset();
+		whereMock.mockReset();
+		updateMock.mockReturnValue({ set: setMock });
+		setMock.mockReturnValue({ where: whereMock });
+		whereMock.mockResolvedValue(undefined);
+	});
+
+	it('returns 401 when not authenticated', async () => {
+		await expect(PATCH(makeEvent({ avatarPreset: 'cat' }, null))).rejects.toMatchObject({
+			status: 401,
+		});
+	});
+
+	it('updates avatarPreset with valid value', async () => {
+		const response = await PATCH(makeEvent({ avatarPreset: 'fox' }));
+		expect(response.status).toBe(200);
+		expect(setMock).toHaveBeenCalledWith({ avatarPreset: 'fox' });
+	});
+
+	it('updates avatarColor with valid hex', async () => {
+		const response = await PATCH(makeEvent({ avatarColor: PRESET_COLORS[0] }));
+		expect(response.status).toBe(200);
+		expect(setMock).toHaveBeenCalledWith({ avatarColor: PRESET_COLORS[0] });
+	});
+
+	it('updates both fields at once', async () => {
+		const response = await PATCH(makeEvent({ avatarPreset: 'owl', avatarColor: '#AABBCC' }));
+		expect(response.status).toBe(200);
+		expect(setMock).toHaveBeenCalledWith({ avatarPreset: 'owl', avatarColor: '#AABBCC' });
+	});
+
+	it('returns 400 for invalid preset', async () => {
+		await expect(PATCH(makeEvent({ avatarPreset: 'unicorn' }))).rejects.toMatchObject({
+			status: 400,
+		});
+	});
+
+	it('returns 400 for invalid color', async () => {
+		await expect(PATCH(makeEvent({ avatarColor: 'not-a-color' }))).rejects.toMatchObject({
+			status: 400,
+		});
+	});
+
+	it('returns 400 when no fields provided', async () => {
+		await expect(PATCH(makeEvent({}))).rejects.toMatchObject({
+			status: 400,
+		});
+	});
+});

--- a/src/routes/layout.server.test.ts
+++ b/src/routes/layout.server.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { SIDEBAR_COOKIE_NAME } from '$lib/components/ui/sidebar/constants.js';
 import { load } from './+layout.server.js';
 
-function makeEvent(cookieValue?: string) {
+const TEST_USER = {
+	id: 'user-1',
+	name: 'Test User',
+	email: 'test@example.com',
+	image: null,
+	avatarPreset: 'fox',
+	avatarColor: '#F4A6A0',
+};
+
+function makeEvent(cookieValue?: string, user: typeof TEST_USER | null = null) {
 	const cookies = {
 		get: vi.fn((name: string) => {
 			if (name === SIDEBAR_COOKIE_NAME) {
@@ -12,7 +21,7 @@ function makeEvent(cookieValue?: string) {
 		}),
 	};
 	return {
-		locals: { user: null },
+		locals: { user },
 		cookies,
 	} as unknown as Parameters<typeof load>[0];
 }
@@ -37,5 +46,29 @@ describe('+layout.server load', () => {
 		const result = await load(makeEvent('true'));
 		expect(result).toBeDefined();
 		expect(result!.sidebarOpen).toBe(true);
+	});
+
+	it('returns null user when not authenticated', async () => {
+		const result = await load(makeEvent());
+		expect(result!.user).toBeNull();
+	});
+
+	it('includes avatarPreset and avatarColor in user object', async () => {
+		const result = await load(makeEvent(undefined, TEST_USER));
+		expect(result!.user).toMatchObject({
+			avatarPreset: 'fox',
+			avatarColor: '#F4A6A0',
+		});
+	});
+
+	it('defaults avatarPreset and avatarColor to null when missing', async () => {
+		const userWithoutAvatar = { ...TEST_USER, avatarPreset: undefined, avatarColor: undefined };
+		const result = await load(
+			makeEvent(undefined, userWithoutAvatar as unknown as typeof TEST_USER),
+		);
+		expect(result!.user).toMatchObject({
+			avatarPreset: null,
+			avatarColor: null,
+		});
 	});
 });

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -5,4 +5,9 @@ export const load: PageServerLoad = ({ locals }) => {
 	if (!locals.user) {
 		redirect(303, '/auth/sign-in');
 	}
+
+	return {
+		avatarPreset: locals.user.avatarPreset ?? null,
+		avatarColor: locals.user.avatarColor ?? null,
+	};
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -4,12 +4,56 @@
 	import { authClient } from '$lib/auth/client.js';
 	import Fingerprint from '@lucide/svelte/icons/fingerprint';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
+	import Check from '@lucide/svelte/icons/check';
 	import { onMount } from 'svelte';
+	import { invalidateAll } from '$app/navigation';
+	import AvatarCircle from '$lib/avatar/AvatarCircle.svelte';
+	import AnimalIcon from '$lib/avatar/AnimalIcon.svelte';
+	import { ANIMAL_PRESETS, PRESET_COLORS, type AnimalPreset } from '$lib/avatar/presets.js';
 
+	let { data } = $props();
+
+	let presetOverride = $state<string | null | undefined>(undefined);
+	let colorOverride = $state<string | null | undefined>(undefined);
+
+	const selectedPreset = $derived(
+		presetOverride !== undefined ? presetOverride : data.avatarPreset,
+	);
+	const selectedColor = $derived(colorOverride !== undefined ? colorOverride : data.avatarColor);
 	let passkeys = $state<{ id: string; name?: string | undefined; createdAt: Date | null }[]>([]);
 	let loading = $state(true);
 	let registering = $state(false);
 	let errorMessage = $state<string | null>(null);
+	const colorPickerValue = $derived(selectedColor ?? '#888888');
+
+	const isCustomColor = $derived(
+		selectedColor !== null && !(PRESET_COLORS as readonly string[]).includes(selectedColor),
+	);
+
+	async function updateAvatar(updates: { avatarPreset?: string; avatarColor?: string }) {
+		await fetch('/api/avatar', {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(updates),
+		});
+		await invalidateAll();
+		presetOverride = undefined;
+		colorOverride = undefined;
+	}
+
+	function selectPreset(preset: AnimalPreset) {
+		presetOverride = preset;
+		void updateAvatar({ avatarPreset: preset });
+	}
+
+	function selectColor(color: string) {
+		colorOverride = color;
+		void updateAvatar({ avatarColor: color });
+	}
+
+	function handleColorPickerInput(event: Event) {
+		selectColor((event.target as HTMLInputElement).value);
+	}
 
 	async function loadPasskeys() {
 		loading = true;
@@ -64,6 +108,80 @@
 	<header class="mb-6">
 		<h1 class="text-2xl font-bold tracking-tight">Settings</h1>
 	</header>
+
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Avatar</Card.Title>
+			<Card.Description>Choose your animal and background color.</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-6">
+			<div class="flex justify-center">
+				<AvatarCircle preset={selectedPreset} color={selectedColor} size="lg" />
+			</div>
+
+			<div>
+				<p class="mb-3 text-sm font-medium">Animal</p>
+				<div class="flex flex-wrap gap-2" data-testid="animal-swatches">
+					{#each ANIMAL_PRESETS as preset (preset)}
+						<button
+							type="button"
+							class="flex size-10 items-center justify-center rounded-full border-2 transition-colors {selectedPreset ===
+							preset
+								? 'border-primary bg-primary/10'
+								: 'border-transparent hover:border-muted-foreground/30'}"
+							onclick={() => selectPreset(preset)}
+							aria-label="Select {preset}"
+							data-testid="animal-swatch-{preset}"
+						>
+							<AnimalIcon {preset} class="size-6" />
+						</button>
+					{/each}
+				</div>
+			</div>
+
+			<div>
+				<p class="mb-3 text-sm font-medium">Background Color</p>
+				<div class="flex flex-wrap gap-2" data-testid="color-swatches">
+					{#each PRESET_COLORS as color (color)}
+						<button
+							type="button"
+							class="flex size-10 items-center justify-center rounded-full border-2 transition-colors {selectedColor ===
+							color
+								? 'border-primary'
+								: 'border-transparent hover:border-muted-foreground/30'}"
+							style:background-color={color}
+							onclick={() => selectColor(color)}
+							aria-label="Select color {color}"
+							data-testid="color-swatch"
+						>
+							{#if selectedColor === color}
+								<Check class="size-4 text-white drop-shadow-sm" />
+							{/if}
+						</button>
+					{/each}
+					<label
+						class="flex size-10 cursor-pointer items-center justify-center rounded-full border-2 transition-colors {isCustomColor
+							? 'border-primary'
+							: 'border-dashed border-muted-foreground/40 hover:border-muted-foreground/60'}"
+						style:background-color={isCustomColor ? selectedColor : undefined}
+						data-testid="color-picker"
+					>
+						<input
+							type="color"
+							class="sr-only"
+							value={colorPickerValue}
+							onchange={handleColorPickerInput}
+						/>
+						{#if isCustomColor}
+							<Check class="size-4 text-white drop-shadow-sm" />
+						{:else}
+							<span class="text-xs text-muted-foreground">+</span>
+						{/if}
+					</label>
+				</div>
+			</div>
+		</Card.Content>
+	</Card.Root>
 
 	<Card.Root>
 		<Card.Header>


### PR DESCRIPTION
## Description
- Adds Drizzle migration with avatarPreset and avatarColor nullable columns to user table
- Implements 10 animal silhouette SVG components (cat, dog, fox, owl, bear, rabbit, penguin, deer, wolf, frog) with AnimalIcon mapper and AvatarCircle shared component
- Creates PATCH /api/avatar endpoint with auth guard, preset/hex validation, and immediate DB persistence
- Builds avatar settings section on settings page with animal swatches, 10 preset color swatches, and native color picker (11th option)
- Updates sidebar to show selected animal SVG on colored background for authenticated users, gray person silhouette for guests
- Assigns random avatar preset and color on account creation via better-auth databaseHooks.user.create.before
- Exposes avatarPreset/avatarColor in user object from layout server

## Test Coverage
- Added 11 tests for preset constants, random helpers, and validators (src/lib/avatar/presets.test.ts)
- Added 7 tests for avatar API endpoint auth guard, validation, and DB updates (src/routes/api/avatar/server.test.ts)
- Added 3 new tests for avatar fields in user object (src/routes/layout.server.test.ts)

## Resolves
Closes #162