### PR TITLE
fix(auth): prevent avatar selection from reverting

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -6,7 +6,6 @@
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import Check from '@lucide/svelte/icons/check';
 	import { onMount } from 'svelte';
-	import { invalidateAll } from '$app/navigation';
 	import AvatarCircle from '$lib/avatar/AvatarCircle.svelte';
 	import AnimalIcon from '$lib/avatar/AnimalIcon.svelte';
 	import { ANIMAL_PRESETS, PRESET_COLORS, type AnimalPreset } from '$lib/avatar/presets.js';
@@ -30,15 +29,12 @@
 		selectedColor !== null && !(PRESET_COLORS as readonly string[]).includes(selectedColor),
 	);
 
-	async function updateAvatar(updates: { avatarPreset?: string; avatarColor?: string }) {
-		await fetch('/api/avatar', {
+	function updateAvatar(updates: { avatarPreset?: string; avatarColor?: string }) {
+		void fetch('/api/avatar', {
 			method: 'PATCH',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(updates),
 		});
-		await invalidateAll();
-		presetOverride = undefined;
-		colorOverride = undefined;
 	}
 
 	function selectPreset(preset: AnimalPreset) {


### PR DESCRIPTION
## Summary
- Fix avatar swatch selection reverting immediately after click
- Root cause: `invalidateAll()` returned stale data from better-auth's cookie-cached session (5-min TTL), then local overrides were reset to `undefined`, falling back to the stale `data`
- Fix: remove `invalidateAll()` and override resets — local state is the source of truth, PATCH persists to DB in background

## Test plan
- [ ] Click an animal swatch → stays selected, does not revert
- [ ] Click a color swatch → stays selected, does not revert  
- [ ] Use color picker → custom color persists
- [ ] Refresh page → selections persist (read from DB)