### PR TITLE
feat(auth): add save button for avatar settings

### DIFF
--- a/src/lib/components/app-shell/AppSidebar.svelte
+++ b/src/lib/components/app-shell/AppSidebar.svelte
@@ -13,6 +13,7 @@
 	import Sun from '@lucide/svelte/icons/sun';
 	import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
 	import AvatarCircle from '$lib/avatar/AvatarCircle.svelte';
+	import { use_avatar } from '$lib/context/avatar.context.svelte.js';
 	import { userPrefersMode, setMode } from 'mode-watcher';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -28,6 +29,7 @@
 	const signOutPath = resolve('/auth/sign-out');
 
 	const user = $derived(page.data.user);
+	const { avatar } = use_avatar();
 
 	let signOutFormElement = $state<HTMLFormElement>();
 </script>
@@ -147,8 +149,8 @@
 									{#snippet child({ props })}
 										<div data-testid="sidebar-user-trigger" {...props}>
 											<AvatarCircle
-												preset={user.avatarPreset}
-												color={user.avatarColor}
+												preset={avatar.current.preset}
+												color={avatar.current.color}
 												size="sm"
 											/>
 											<div

--- a/src/lib/context/avatar.context.svelte.ts
+++ b/src/lib/context/avatar.context.svelte.ts
@@ -1,0 +1,26 @@
+import { getContext, setContext } from 'svelte';
+import { StateRaw } from '$lib/reactivity/state.svelte.js';
+import { CONTEXT_KEYS } from './context_keys.js';
+
+interface AvatarData {
+	preset: string | null;
+	color: string | null;
+}
+
+function create_avatar_context(initial: AvatarData) {
+	const avatar = new StateRaw<AvatarData>(initial);
+	return { avatar };
+}
+
+/** @knipignore */
+export type AvatarContext = ReturnType<typeof create_avatar_context>;
+
+export function set_avatar_context(initial: AvatarData) {
+	const context = create_avatar_context(initial);
+	setContext(CONTEXT_KEYS.avatar, context);
+	return context;
+}
+
+export function use_avatar() {
+	return getContext<AvatarContext>(CONTEXT_KEYS.avatar);
+}

--- a/src/lib/context/context_keys.ts
+++ b/src/lib/context/context_keys.ts
@@ -1,3 +1,4 @@
 export const CONTEXT_KEYS = {
 	settings_tier: 'settings_tier',
+	avatar: 'avatar',
 } as const;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,10 +7,19 @@
 	import figtreeLatinUrl from '@fontsource-variable/figtree/files/figtree-latin-wght-normal.woff2?url';
 	import notoSansLatinUrl from '@fontsource-variable/noto-sans/files/noto-sans-latin-wght-normal.woff2?url';
 	import { set_settings_tier_context } from '$lib/context/settings_tier.context.svelte.js';
+	import { set_avatar_context } from '$lib/context/avatar.context.svelte.js';
 
 	let { data, children } = $props();
 
 	set_settings_tier_context();
+	const avatarCtx = set_avatar_context({ preset: null, color: null });
+
+	$effect(() => {
+		avatarCtx.avatar.current = {
+			preset: data.user?.avatarPreset ?? null,
+			color: data.user?.avatarColor ?? null,
+		};
+	});
 </script>
 
 <ModeWatcher />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -5,20 +5,18 @@
 	import Fingerprint from '@lucide/svelte/icons/fingerprint';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import Check from '@lucide/svelte/icons/check';
+	import Save from '@lucide/svelte/icons/save';
 	import { onMount } from 'svelte';
 	import AvatarCircle from '$lib/avatar/AvatarCircle.svelte';
 	import AnimalIcon from '$lib/avatar/AnimalIcon.svelte';
 	import { ANIMAL_PRESETS, PRESET_COLORS, type AnimalPreset } from '$lib/avatar/presets.js';
+	import { use_avatar } from '$lib/context/avatar.context.svelte.js';
 
-	let { data } = $props();
+	const { avatar: avatarCtx } = use_avatar();
 
-	let presetOverride = $state<string | null | undefined>(undefined);
-	let colorOverride = $state<string | null | undefined>(undefined);
-
-	const selectedPreset = $derived(
-		presetOverride !== undefined ? presetOverride : data.avatarPreset,
-	);
-	const selectedColor = $derived(colorOverride !== undefined ? colorOverride : data.avatarColor);
+	let selectedPreset = $state<string | null>(avatarCtx.current.preset);
+	let selectedColor = $state<string | null>(avatarCtx.current.color);
+	let saving = $state(false);
 	let passkeys = $state<{ id: string; name?: string | undefined; createdAt: Date | null }[]>([]);
 	let loading = $state(true);
 	let registering = $state(false);
@@ -29,25 +27,45 @@
 		selectedColor !== null && !(PRESET_COLORS as readonly string[]).includes(selectedColor),
 	);
 
-	function updateAvatar(updates: { avatarPreset?: string; avatarColor?: string }) {
-		void fetch('/api/avatar', {
+	const hasChanges = $derived(
+		selectedPreset !== avatarCtx.current.preset || selectedColor !== avatarCtx.current.color,
+	);
+
+	async function saveAvatar() {
+		if (!hasChanges) {
+			return;
+		}
+		saving = true;
+		const updates: { avatarPreset?: string; avatarColor?: string } = {};
+		if (selectedPreset !== null && selectedPreset !== avatarCtx.current.preset) {
+			updates.avatarPreset = selectedPreset;
+		}
+		if (selectedColor !== null && selectedColor !== avatarCtx.current.color) {
+			updates.avatarColor = selectedColor;
+		}
+		const response = await fetch('/api/avatar', {
 			method: 'PATCH',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(updates),
 		});
+		if (response.ok) {
+			avatarCtx.current = {
+				preset: selectedPreset,
+				color: selectedColor,
+			};
+		}
+		saving = false;
 	}
 
 	function selectPreset(preset: AnimalPreset) {
-		presetOverride = preset;
-		void updateAvatar({ avatarPreset: preset });
+		selectedPreset = preset;
 	}
 
 	function selectColor(color: string) {
-		colorOverride = color;
-		void updateAvatar({ avatarColor: color });
+		selectedColor = color;
 	}
 
-	function handleColorPickerInput(event: Event) {
+	function handleColorPickerChange(event: Event) {
 		selectColor((event.target as HTMLInputElement).value);
 	}
 
@@ -166,7 +184,7 @@
 							type="color"
 							class="sr-only"
 							value={colorPickerValue}
-							onchange={handleColorPickerInput}
+							onchange={handleColorPickerChange}
 						/>
 						{#if isCustomColor}
 							<Check class="size-4 text-white drop-shadow-sm" />
@@ -177,6 +195,12 @@
 				</div>
 			</div>
 		</Card.Content>
+		<Card.Footer>
+			<Button data-testid="save-avatar" disabled={!hasChanges || saving} onclick={saveAvatar}>
+				<Save class="mr-2 size-4" />
+				{saving ? 'Saving…' : 'Save avatar'}
+			</Button>
+		</Card.Footer>
 	</Card.Root>
 
 	<Card.Root>


### PR DESCRIPTION
## Summary
- Replace immediate-persist-on-click with explicit save button pattern
- Add avatar context (`StateRaw`) shared between settings page and sidebar — sidebar updates instantly on save without relying on stale session cookie cache
- Swatch clicks are now preview-only; "Save avatar" button persists to DB and updates sidebar

## Test plan
- [ ] Click animal/color swatches — preview updates, no DB write, sidebar unchanged
- [ ] Click "Save avatar" — persists to DB, sidebar updates immediately
- [ ] Save button disabled when no changes
- [ ] Refresh page after save — selections persist