### PR TITLE
#163 feat(tree): add disabled tree state with debug toggle

### DIFF
--- a/src/lib/components/composed/DebugCard.svelte
+++ b/src/lib/components/composed/DebugCard.svelte
@@ -12,6 +12,7 @@
 		showAnchors: boolean;
 		showEnvelope?: boolean;
 		showViewBox: boolean;
+		debugDisableBackRows?: boolean;
 	}
 
 	let {
@@ -23,6 +24,7 @@
 		showAnchors = $bindable(),
 		showEnvelope = $bindable(false),
 		showViewBox = $bindable(),
+		debugDisableBackRows = $bindable(false),
 	}: Props = $props();
 </script>
 
@@ -38,4 +40,7 @@
 		<LabeledCheckbox label="Show Envelope" bind:checked={showEnvelope} />
 	{/if}
 	<LabeledCheckbox label="Show View Box" bind:checked={showViewBox} />
+	{#if mode === 'scene'}
+		<LabeledCheckbox label="Disable trees from row 2+" bind:checked={debugDisableBackRows} />
+	{/if}
 </SectionCard>

--- a/src/lib/config/validators.test.ts
+++ b/src/lib/config/validators.test.ts
@@ -3,11 +3,13 @@ import {
 	isValidTreeConfig,
 	isValidSceneConfig,
 	isValidEnvironmentConfig,
+	isValidEditorViewState,
 	migrateStageValue,
 } from './validators.js';
 import { DEFAULT_TREE_CONFIG } from '$lib/trees/types.js';
 import { SCENE_DEFAULTS } from '$lib/scene/scene_config.js';
 import { ENVIRONMENT_DEFAULTS } from '$lib/environment/environment_config.js';
+import { EDITOR_VIEW_DEFAULTS } from '$lib/config/editor_view_state.js';
 
 describe('isValidTreeConfig', () => {
 	it('accepts DEFAULT_TREE_CONFIG', () => {
@@ -86,6 +88,12 @@ describe('isValidEnvironmentConfig', () => {
 		expect(isValidEnvironmentConfig({ ...ENVIRONMENT_DEFAULTS, rainEnabled: 'yes' })).toBe(
 			false,
 		);
+	});
+});
+
+describe('isValidEditorViewState', () => {
+	it('accepts EDITOR_VIEW_DEFAULTS', () => {
+		expect(isValidEditorViewState(EDITOR_VIEW_DEFAULTS)).toBe(true);
 	});
 });
 

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -66,6 +66,8 @@
 		groundElements?: boolean;
 		groundElementCount?: number;
 		groundElementSize?: number;
+		/** @default false */
+		disabled?: boolean;
 		class?: string;
 		onanchors?: (anchors: TreeAnchors) => void;
 	}
@@ -89,6 +91,7 @@
 		groundElements = false,
 		groundElementCount,
 		groundElementSize,
+		disabled = false,
 		class: className = '',
 		onanchors,
 	}: Props = $props();
@@ -185,6 +188,7 @@
 	xmlns="http://www.w3.org/2000/svg"
 	overflow="hidden"
 	class={className}
+	class:disabled-tree={disabled}
 >
 	<GlowEffect config={overlayConfig.glow} filterId={glowFilterId} />
 
@@ -313,5 +317,10 @@
 	.wilting-droop {
 		transform: skewY(3deg);
 		transform-origin: center top;
+	}
+
+	.disabled-tree {
+		filter: grayscale(1) opacity(0.5);
+		pointer-events: none;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -52,6 +52,7 @@
 	import { PaneGroup, Pane, Handle } from '$lib/components/ui/resizable/index.js';
 
 	const USE_PER_SHAPE_DEFAULTS_KEY = 'use-per-shape-defaults';
+	const DEBUG_DISABLE_BACK_ROWS_KEY = 'debug-disable-back-rows';
 
 	const treeConfig = setTreeConfigContext();
 	const sceneConfig = setSceneConfigContext();
@@ -82,6 +83,11 @@
 		key: USE_PER_SHAPE_DEFAULTS_KEY,
 		serde: jsonSerde(isValidBoolean),
 		defaultValue: true,
+	});
+	const debugDisableBackRows = new Persisted<boolean>({
+		key: DEBUG_DISABLE_BACK_ROWS_KEY,
+		serde: jsonSerde(isValidBoolean),
+		defaultValue: false,
 	});
 	let showAnchors = $state(false);
 	let showViewBox = $state(false);
@@ -181,6 +187,7 @@
 					"
 					>
 						<LowPolyTree
+							disabled={debugDisableBackRows.current && placement.layer > 1}
 							config={{
 								...treeConfig.current,
 								shape: placement.shape,
@@ -396,6 +403,7 @@
 						bind:showTrunk
 						bind:showAnchors
 						bind:showViewBox
+						bind:debugDisableBackRows={debugDisableBackRows.current}
 					/>
 
 					<OverlaysCard />


### PR DESCRIPTION
## Description
- Added `disabled` boolean prop to `LowPolyTree` component: applies greyscale and reduced opacity CSS styling with pointer-events disabled
- Integrated "Disable trees from row 2+" checkbox into `DebugCard` (scene mode only) for testing visual feedback on background trees
- Scene page uses `Persisted<boolean>` state to toggle disabled status based on tree depth (`layer > 1`)
- All tree content (canopy, trunk, branches, tools, overlays) still renders when disabled; styling is CSS-only
- Added test coverage for `isValidEditorViewState` validator
- Disabled state is independent of stage and part of the public component API

## Resolves
Closes #163

## Testing
- [ ] Debug toggle appears in DebugCard (scene mode only)
- [ ] Checkbox state persists across page reloads
- [ ] Trees in row 2+ are greyed out when enabled
- [ ] Pointer interactions disabled on greyed trees
- [ ] All existing stage and tree rendering tests pass