### PR TITLE
feat: Grovekeeper visualization enhancements (#194)

### DIFF
--- a/src/lib/components/composed/ToolAccessoriesCard.svelte
+++ b/src/lib/components/composed/ToolAccessoriesCard.svelte
@@ -16,6 +16,8 @@
 		[TOOL_TYPES.grill]: () => m.tool_grill(),
 		[TOOL_TYPES.speechBubble]: () => m.tool_speech_bubble(),
 		[TOOL_TYPES.stormCloud]: () => m.tool_storm_cloud(),
+		[TOOL_TYPES.lantern]: () => 'Lantern',
+		[TOOL_TYPES.pruningShears]: () => 'Pruning Shears',
 	};
 
 	interface Props {
@@ -47,12 +49,25 @@
 				id="tool-{option.value}-size"
 			/>
 			{#if option.value === TOOL_TYPES.speechBubble}
-				<div class="ml-6">
+				<div class="ml-6 space-y-2">
 					<Textarea
 						data-testid="tool-speechBubble-text"
 						placeholder={m.placeholder_enter_text()}
 						bind:value={toolVisibility[option.value].text}
 					/>
+					<label class="flex items-center gap-2 text-sm">
+						<span>Bubble Color</span>
+						<input
+							type="color"
+							value={toolVisibility[option.value].color ?? '#ffffff'}
+							oninput={(e) =>
+								(toolVisibility[option.value] = {
+									...toolVisibility[option.value],
+									color: e.currentTarget.value,
+								})}
+							data-testid="tool-speechBubble-color"
+						/>
+					</label>
 				</div>
 			{/if}
 		{/if}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -25,6 +25,7 @@ export {
 	type BranchGeometry,
 	type JunctionData,
 	type BirchStripe,
+	type TrunkMushroom,
 	type TreeGeometry,
 } from './trees/types/core.js';
 
@@ -160,4 +161,11 @@ export {
 	hslToHex,
 	interpolateHslInHexSpace,
 	clamp,
+	relativeLuminance,
+	contrastTextColor,
 } from './trees/color.js';
+
+/** Bird system — sub-agent visualization */
+export { BIRD_SPECIES, type BirdSpecies, type BirdConfig } from './trees/birds/bird_types.js';
+
+export { type BirdDefinition, BIRD_DEFINITIONS } from './trees/birds/bird_definitions.js';

--- a/src/lib/trees/LowPolyTree.svelte
+++ b/src/lib/trees/LowPolyTree.svelte
@@ -40,7 +40,9 @@
 	import TreeCanopyLayer from '$lib/trees/TreeCanopyLayer.svelte';
 	import TreeFruitAndFlowerLayer from '$lib/trees/TreeFruitAndFlowerLayer.svelte';
 	import TreeFallingLeavesLayer from '$lib/trees/TreeFallingLeavesLayer.svelte';
+	import TreeBirdLayer from '$lib/trees/TreeBirdLayer.svelte';
 	import TreeDebugOverlays from '$lib/trees/TreeDebugOverlays.svelte';
+	import type { BirdConfig } from '$lib/trees/birds/bird_types.js';
 
 	interface Props {
 		config?: TreeConfig;
@@ -68,6 +70,8 @@
 		toolSnapOffsetOverride?: { toolType: ToolType; offset: Point2D };
 		toolAnchorTargetOverride?: { toolType: ToolType; anchorTarget: ToolAnchorKey };
 		showAnchorOverlay?: boolean;
+		birds?: BirdConfig[];
+		onbirdclick?: (bird: BirdConfig, index: number) => void;
 		/** @default false */
 		disabled?: boolean;
 		class?: string;
@@ -99,6 +103,8 @@
 		flowerOriginOffsetOverride,
 		toolSnapOffsetOverride,
 		toolAnchorTargetOverride,
+		birds,
+		onbirdclick,
 		showAnchorOverlay = false,
 		disabled = false,
 		class: className = '',
@@ -312,6 +318,7 @@
 							size={toolVisibility[toolType].size}
 							animate={animateTools}
 							text={toolVisibility[toolType].text}
+							color={toolVisibility[toolType].color}
 							snapOffsetOverride={toolSnapOffsetOverride?.toolType === toolType
 								? toolSnapOffsetOverride.offset
 								: undefined}
@@ -319,6 +326,10 @@
 					{/if}
 				{/each}
 			</g>
+		{/if}
+
+		{#if birds && birds.length > 0}
+			<TreeBirdLayer {birds} branchTips={geometry.anchors.branchTips} {onbirdclick} />
 		{/if}
 
 		<TreeDebugOverlays

--- a/src/lib/trees/TreeBirdLayer.svelte
+++ b/src/lib/trees/TreeBirdLayer.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import type { Point2D } from '$lib/trees/types/core.js';
+	import type { BirdConfig } from '$lib/trees/birds/bird_types.js';
+	import { BIRD_DEFINITIONS } from '$lib/trees/birds/bird_definitions.js';
+
+	interface Props {
+		birds: BirdConfig[];
+		branchTips: readonly Point2D[];
+		onbirdclick?: (bird: BirdConfig, index: number) => void;
+	}
+
+	let { birds, branchTips, onbirdclick }: Props = $props();
+
+	const displayedBirds = $derived(birds.slice(0, Math.min(birds.length, branchTips.length)));
+</script>
+
+{#if displayedBirds.length > 0}
+	<g class="bird-layer">
+		{#each displayedBirds as bird, index (index)}
+			{@const tip = branchTips[index]!}
+			{@const definition = BIRD_DEFINITIONS[bird.type]}
+			{@const isActive = bird.active !== false}
+			<g
+				transform="translate({tip.x}, {tip.y}) scale({definition.defaultScale})"
+				class={isActive ? 'bird-active' : 'bird-inactive'}
+				style="cursor: pointer;"
+				data-bird-type={bird.type}
+				role="button"
+				tabindex="0"
+				onclick={() => onbirdclick?.(bird, index)}
+				onkeydown={(event) => {
+					if (event.key === 'Enter' || event.key === ' ') {
+						onbirdclick?.(bird, index);
+					}
+				}}
+			>
+				{#if bird.label}
+					<title>{bird.label}</title>
+				{/if}
+				<definition.svgComponent />
+			</g>
+		{/each}
+	</g>
+{/if}
+
+<style>
+	.bird-active {
+		opacity: 1;
+		transition: opacity 0.3s ease;
+		animation: bird-idle 4s ease-in-out infinite;
+		transform-origin: center bottom;
+	}
+
+	.bird-inactive {
+		opacity: 0;
+		transition: opacity 1s ease;
+		pointer-events: none;
+	}
+
+	@keyframes bird-idle {
+		0%,
+		100% {
+			transform: translateY(0);
+		}
+
+		50% {
+			transform: translateY(-1px);
+		}
+	}
+</style>

--- a/src/lib/trees/TreeTool.svelte
+++ b/src/lib/trees/TreeTool.svelte
@@ -11,6 +11,7 @@
 		animate: boolean;
 		reviewerCount?: number;
 		text?: string;
+		color?: string;
 		snapOffsetOverride?: { x: number; y: number };
 	}
 
@@ -21,6 +22,7 @@
 		animate,
 		reviewerCount = 0,
 		text,
+		color,
 		snapOffsetOverride,
 	}: Props = $props();
 
@@ -46,7 +48,9 @@
 		style="--tool-duration: {animationConfig.duration}s; --pivot-x: {definition.pivotPoint
 			.x}px; --pivot-y: {definition.pivotPoint.y}px;"
 	>
-		{#if text !== undefined}
+		{#if text !== undefined && color !== undefined}
+			<SvgComponent {text} {color} />
+		{:else if text !== undefined}
 			<SvgComponent {text} />
 		{:else}
 			<SvgComponent />
@@ -232,6 +236,52 @@
 
 	.tool-anim.animate-tool[data-tool-type='stormCloud'] {
 		animation: tool-storm-cloud-idle var(--tool-duration) ease-in-out infinite;
+	}
+
+	@keyframes tool-lantern-idle {
+		0%,
+		100% {
+			transform: translate(0, 0);
+		}
+
+		25% {
+			transform: translate(6px, -3px);
+		}
+
+		50% {
+			transform: translate(0, 0);
+		}
+
+		75% {
+			transform: translate(-6px, -3px);
+		}
+	}
+
+	.tool-anim.animate-tool[data-tool-type='lantern'] {
+		animation: tool-lantern-idle var(--tool-duration) ease-in-out infinite;
+	}
+
+	@keyframes tool-pruning-shears-idle {
+		0%,
+		100% {
+			transform: rotate(0deg);
+		}
+
+		40% {
+			transform: rotate(-8deg);
+		}
+
+		50% {
+			transform: rotate(5deg);
+		}
+
+		60% {
+			transform: rotate(-3deg);
+		}
+	}
+
+	.tool-anim.animate-tool[data-tool-type='pruningShears'] {
+		animation: tool-pruning-shears-idle var(--tool-duration) ease-in-out infinite;
 	}
 
 	.woodpecker-badge text {

--- a/src/lib/trees/TreeTrunkLayer.svelte
+++ b/src/lib/trees/TreeTrunkLayer.svelte
@@ -3,6 +3,7 @@
 	import { TREE_STAGES } from '$lib/trees/types.js';
 	import type { TreeGeometry } from '$lib/trees/types/core.js';
 	import type { TreeStage } from '$lib/trees/types.js';
+	import MushroomSvg from '$lib/trees/assets/decorations/MushroomSvg.svelte';
 
 	const STAGE_TO_ASSET_TYPE: Partial<Record<TreeStage, keyof typeof STAGE_DEFINITIONS>> = {
 		[TREE_STAGES.seed]: STAGE_ASSET_TYPES.seed,
@@ -60,6 +61,16 @@
 				height={stripe.height}
 				fill={stripe.color}
 			/>
+		{/each}
+		{#each geometry.trunkMushrooms as mushroom (mushroom)}
+			<g
+				transform="translate({mushroom.centerX}, {mushroom.y}) scale({mushroom.side ===
+				'left'
+					? -1
+					: 1}, 1) scale({mushroom.scale})"
+			>
+				<MushroomSvg variant={mushroom.variant} />
+			</g>
 		{/each}
 	{/if}
 </g>

--- a/src/lib/trees/assets/birds/CardinalSvg.svelte
+++ b/src/lib/trees/assets/birds/CardinalSvg.svelte
@@ -1,0 +1,41 @@
+<!--
+	Cardinal SVG — bright red with prominent crest.
+	Low-poly geometric style, ~22px wide.
+	Origin (0,0) = center-bottom (feet position).
+-->
+<g>
+	<!-- Body (bright red) -->
+	<ellipse cx="0" cy="-8" rx="8" ry="9" fill="#CC3333" />
+	<!-- Belly -->
+	<ellipse cx="0" cy="-5" rx="5" ry="5" fill="#DD5555" />
+	<!-- Head -->
+	<circle cx="1" cy="-15" r="4.5" fill="#CC3333" />
+	<!-- Crest (pointed) -->
+	<path d="M-1,-18 L1,-25 L3,-18" fill="#CC3333" />
+	<!-- Black face mask -->
+	<path d="M-1,-16 L1,-13 L4,-14 L3,-17 Z" fill="#1A1A1A" />
+	<!-- Eye -->
+	<circle cx="2" cy="-16" r="1" fill="white" />
+	<circle cx="2.2" cy="-16" r="0.5" fill="#1A1A1A" />
+	<!-- Beak (orange) -->
+	<path d="M4,-15 L8,-14 L4,-13" fill="#E88C30" />
+	<!-- Wing -->
+	<path d="M-5,-10 L-8,-4 L-4,-1 L-2,-6 Z" fill="#AA2222" />
+	<!-- Tail -->
+	<path d="M-4,-1 L-8,4 L-3,2 Z" fill="#AA2222" />
+	<!-- Feet -->
+	<path
+		d="M-2,0 L-3,2 M-2,0 L-1,2"
+		stroke="#4A4A4A"
+		stroke-width="0.8"
+		fill="none"
+		stroke-linecap="round"
+	/>
+	<path
+		d="M2,0 L1,2 M2,0 L3,2"
+		stroke="#4A4A4A"
+		stroke-width="0.8"
+		fill="none"
+		stroke-linecap="round"
+	/>
+</g>

--- a/src/lib/trees/assets/birds/HummingbirdSvg.svelte
+++ b/src/lib/trees/assets/birds/HummingbirdSvg.svelte
@@ -1,0 +1,30 @@
+<!--
+	Hummingbird SVG — tiny darting bird with long thin beak.
+	Low-poly geometric style, ~20px wide.
+	Origin (0,0) = center-bottom (feet position).
+-->
+<g>
+	<!-- Body (iridescent green) -->
+	<ellipse cx="0" cy="-5" rx="4" ry="5" fill="#2E8B57" />
+	<!-- Belly (lighter) -->
+	<ellipse cx="0" cy="-3" rx="3" ry="3" fill="#7EC8A0" />
+	<!-- Head -->
+	<circle cx="2" cy="-9" r="3" fill="#2E8B57" />
+	<!-- Eye -->
+	<circle cx="3.5" cy="-10" r="0.7" fill="#1A1A1A" />
+	<!-- Long thin beak -->
+	<path d="M5,-9 L14,-8 L5,-8" fill="#4A4A4A" />
+	<!-- Wing (semi-transparent blur effect) -->
+	<ellipse cx="-3" cy="-6" rx="5" ry="2.5" fill="#2E8B57" opacity="0.5" />
+	<ellipse cx="-4" cy="-7" rx="4" ry="2" fill="#3CB371" opacity="0.3" />
+	<!-- Tail -->
+	<path d="M-2,0 L-5,3 L-1,2 Z" fill="#1E6B3E" />
+	<!-- Tiny feet -->
+	<path
+		d="M-1,0 L-1,1.5 M0,0 L0,1.5"
+		stroke="#4A4A4A"
+		stroke-width="0.5"
+		fill="none"
+		stroke-linecap="round"
+	/>
+</g>

--- a/src/lib/trees/assets/birds/OwlSvg.svelte
+++ b/src/lib/trees/assets/birds/OwlSvg.svelte
@@ -1,0 +1,40 @@
+<!--
+	Owl SVG — large-eyed, squat perched posture.
+	Low-poly geometric style, ~25px wide.
+	Origin (0,0) = center-bottom (feet position).
+-->
+<g>
+	<!-- Body -->
+	<ellipse cx="0" cy="-10" rx="10" ry="12" fill="#6B4226" />
+	<!-- Belly -->
+	<ellipse cx="0" cy="-6" rx="7" ry="8" fill="#8B6B4A" />
+	<!-- Left ear tuft -->
+	<path d="M-6,-20 L-4,-24 L-2,-19" fill="#6B4226" />
+	<!-- Right ear tuft -->
+	<path d="M6,-20 L4,-24 L2,-19" fill="#6B4226" />
+	<!-- Left eye (yellow) -->
+	<circle cx="-4" cy="-14" r="3.5" fill="#FFD700" />
+	<!-- Left pupil -->
+	<circle cx="-4" cy="-14" r="1.5" fill="#1A1A1A" />
+	<!-- Right eye (yellow) -->
+	<circle cx="4" cy="-14" r="3.5" fill="#FFD700" />
+	<!-- Right pupil -->
+	<circle cx="4" cy="-14" r="1.5" fill="#1A1A1A" />
+	<!-- Beak -->
+	<path d="M-2,-11 L0,-8 L2,-11" fill="#4A4A4A" />
+	<!-- Feet -->
+	<path
+		d="M-4,0 L-5,2 M-4,0 L-3,2"
+		stroke="#4A4A4A"
+		stroke-width="1"
+		fill="none"
+		stroke-linecap="round"
+	/>
+	<path
+		d="M4,0 L3,2 M4,0 L5,2"
+		stroke="#4A4A4A"
+		stroke-width="1"
+		fill="none"
+		stroke-linecap="round"
+	/>
+</g>

--- a/src/lib/trees/assets/birds/ParrotSvg.svelte
+++ b/src/lib/trees/assets/birds/ParrotSvg.svelte
@@ -1,0 +1,41 @@
+<!--
+	Parrot SVG — colorful, stocky tropical bird.
+	Low-poly geometric style, ~24px wide.
+	Origin (0,0) = center-bottom (feet position).
+-->
+<g>
+	<!-- Body (bright green) -->
+	<ellipse cx="0" cy="-9" rx="8" ry="10" fill="#3CB371" />
+	<!-- Breast (yellow) -->
+	<ellipse cx="1" cy="-6" rx="5" ry="5" fill="#FFD700" />
+	<!-- Head -->
+	<circle cx="2" cy="-17" r="5" fill="#3CB371" />
+	<!-- Eye ring (white) -->
+	<circle cx="4" cy="-18" r="1.8" fill="white" />
+	<!-- Eye pupil -->
+	<circle cx="4.2" cy="-18" r="0.8" fill="#1A1A1A" />
+	<!-- Curved beak -->
+	<path d="M6,-17 L10,-16 L8,-14 L6,-15 Z" fill="#4A4A4A" />
+	<!-- Wing (green with blue tips) -->
+	<path d="M-5,-12 L-9,-6 L-7,0 L-3,-2 L-3,-10 Z" fill="#2E8B57" />
+	<!-- Wing blue tips -->
+	<path d="M-9,-6 L-10,-2 L-7,0 Z" fill="#4169E1" />
+	<!-- Tail -->
+	<path d="M-4,0 L-6,6 L-2,4 Z" fill="#2E8B57" />
+	<path d="M-2,0 L-3,7 L0,4 Z" fill="#4169E1" />
+	<!-- Feet -->
+	<path
+		d="M-2,0 L-3,2 M-2,0 L-1,2"
+		stroke="#4A4A4A"
+		stroke-width="0.8"
+		fill="none"
+		stroke-linecap="round"
+	/>
+	<path
+		d="M2,0 L1,2 M2,0 L3,2"
+		stroke="#4A4A4A"
+		stroke-width="0.8"
+		fill="none"
+		stroke-linecap="round"
+	/>
+</g>

--- a/src/lib/trees/assets/birds/RobinSvg.svelte
+++ b/src/lib/trees/assets/birds/RobinSvg.svelte
@@ -1,0 +1,35 @@
+<!--
+	Robin SVG — small, busy bird with orange-red breast.
+	Low-poly geometric style, ~20px wide.
+	Origin (0,0) = center-bottom (feet position).
+-->
+<g>
+	<!-- Body (brown back) -->
+	<ellipse cx="0" cy="-8" rx="7" ry="8" fill="#8B6914" />
+	<!-- Breast (orange-red) -->
+	<ellipse cx="0" cy="-5" rx="5" ry="5" fill="#E25822" />
+	<!-- Head -->
+	<circle cx="0" cy="-14" r="4" fill="#8B6914" />
+	<!-- Eye -->
+	<circle cx="2" cy="-15" r="1" fill="white" />
+	<circle cx="2.3" cy="-15" r="0.5" fill="#1A1A1A" />
+	<!-- Beak (thin) -->
+	<path d="M4,-14 L8,-13 L4,-12" fill="#4A4A4A" />
+	<!-- Tail (upright) -->
+	<path d="M-4,-2 L-7,4 L-3,2 Z" fill="#6B4E10" />
+	<!-- Feet -->
+	<path
+		d="M-2,0 L-3,2 M-2,0 L-1,2"
+		stroke="#4A4A4A"
+		stroke-width="0.8"
+		fill="none"
+		stroke-linecap="round"
+	/>
+	<path
+		d="M2,0 L1,2 M2,0 L3,2"
+		stroke="#4A4A4A"
+		stroke-width="0.8"
+		fill="none"
+		stroke-linecap="round"
+	/>
+</g>

--- a/src/lib/trees/assets/birds/SparrowSvg.svelte
+++ b/src/lib/trees/assets/birds/SparrowSvg.svelte
@@ -1,0 +1,34 @@
+<!--
+	Sparrow SVG — tiny, simple rounded bird.
+	Low-poly geometric style, ~18px wide.
+	Origin (0,0) = center-bottom (feet position).
+-->
+<g>
+	<!-- Body -->
+	<ellipse cx="0" cy="-6" rx="6" ry="6" fill="#C4A882" />
+	<!-- Wing -->
+	<ellipse cx="-2" cy="-7" rx="4" ry="3" fill="#7A6B52" />
+	<!-- Head -->
+	<circle cx="2" cy="-11" r="3.5" fill="#C4A882" />
+	<!-- Eye -->
+	<circle cx="3.5" cy="-12" r="0.8" fill="#1A1A1A" />
+	<!-- Beak (short conical) -->
+	<path d="M5,-11 L8,-10.5 L5,-10" fill="#8B7355" />
+	<!-- Tail -->
+	<path d="M-5,-3 L-8,0 L-5,1 Z" fill="#7A6B52" />
+	<!-- Feet -->
+	<path
+		d="M-1,0 L-2,2 M-1,0 L0,2"
+		stroke="#4A4A4A"
+		stroke-width="0.7"
+		fill="none"
+		stroke-linecap="round"
+	/>
+	<path
+		d="M2,0 L1,2 M2,0 L3,2"
+		stroke="#4A4A4A"
+		stroke-width="0.7"
+		fill="none"
+		stroke-linecap="round"
+	/>
+</g>

--- a/src/lib/trees/assets/birds/index.ts
+++ b/src/lib/trees/assets/birds/index.ts
@@ -1,0 +1,6 @@
+export { default as OwlSvg } from './OwlSvg.svelte';
+export { default as RobinSvg } from './RobinSvg.svelte';
+export { default as SparrowSvg } from './SparrowSvg.svelte';
+export { default as CardinalSvg } from './CardinalSvg.svelte';
+export { default as HummingbirdSvg } from './HummingbirdSvg.svelte';
+export { default as ParrotSvg } from './ParrotSvg.svelte';

--- a/src/lib/trees/assets/decorations/MushroomSvg.svelte
+++ b/src/lib/trees/assets/decorations/MushroomSvg.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	interface Props {
+		variant: number;
+	}
+
+	let { variant }: Props = $props();
+</script>
+
+<!--
+  Each variant draws 2-3 small mushrooms in a ~20x15 cluster.
+  Origin (0,0) is at the attachment point (right edge, mid-height).
+  Mushroom = stem (rect) + cap (ellipse).
+-->
+{#if variant === 0}
+	<!-- Classic brown mushroom cluster (3 mushrooms) -->
+	<g>
+		<!-- Large mushroom -->
+		<rect x={-14} y={-2} width={3} height={5} fill="#d4c5a0" />
+		<ellipse cx={-12.5} cy={-3} rx={5} ry={3} fill="#8B6914" />
+		<!-- Medium mushroom -->
+		<rect x={-7} y={0} width={2.5} height={4} fill="#d4c5a0" />
+		<ellipse cx={-5.8} cy={-1} rx={4} ry={2.5} fill="#7a5a10" />
+		<!-- Small mushroom -->
+		<rect x={-3} y={1} width={2} height={3} fill="#d4c5a0" />
+		<ellipse cx={-2} cy={0.5} rx={3} ry={2} fill="#8B6914" />
+	</g>
+{:else if variant === 1}
+	<!-- Amanita-style red mushroom cluster (2 mushrooms) -->
+	<g>
+		<!-- Large amanita -->
+		<rect x={-12} y={-1} width={3} height={5} fill="#e8d8c0" />
+		<ellipse cx={-10.5} cy={-2} rx={5.5} ry={3.5} fill="#cc4444" />
+		<circle cx={-12} cy={-3} r={0.8} fill="white" />
+		<circle cx={-9.5} cy={-3.5} r={0.6} fill="white" />
+		<circle cx={-10.5} cy={-1.5} r={0.5} fill="white" />
+		<!-- Small amanita -->
+		<rect x={-5} y={1} width={2} height={3.5} fill="#e8d8c0" />
+		<ellipse cx={-4} cy={0.5} rx={3.5} ry={2.5} fill="#cc4444" />
+		<circle cx={-5} cy={0} r={0.5} fill="white" />
+		<circle cx={-3} cy={-0.5} r={0.4} fill="white" />
+	</g>
+{:else}
+	<!-- Shelf fungus cluster (3 shelves) -->
+	<g>
+		<!-- Large shelf -->
+		<rect x={-13} y={-2} width={2} height={3} fill="#c8c8c8" />
+		<ellipse cx={-11} cy={-1.5} rx={5} ry={2.5} fill="#7a8899" />
+		<!-- Medium shelf -->
+		<rect x={-8} y={1} width={1.5} height={2.5} fill="#c8c8c8" />
+		<ellipse cx={-6.5} cy={1.5} rx={4} ry={2} fill="#6a7888" />
+		<!-- Small shelf -->
+		<rect x={-4} y={3} width={1.5} height={2} fill="#c8c8c8" />
+		<ellipse cx={-3} cy={3.5} rx={3} ry={1.5} fill="#7a8899" />
+	</g>
+{/if}

--- a/src/lib/trees/assets/tools/LanternSvg.svelte
+++ b/src/lib/trees/assets/tools/LanternSvg.svelte
@@ -1,0 +1,66 @@
+<!--
+	Lantern SVG -- low-poly kerosene lantern with warm glow.
+	Local (0,0) is at the top-left; snap point is base bottom-center (~20, 60).
+	Glow animation gated by :global(.animate-tool) CSS class.
+-->
+<script lang="ts">
+</script>
+
+<g class="lantern">
+	<!-- Glow effect behind glass -->
+	<ellipse class="lantern-glow" cx="20" cy="35" rx="22" ry="18" fill="#f5a623" opacity="0.3" />
+
+	<!-- Handle arc -->
+	<path
+		d="M12,12 Q20,0 28,12"
+		fill="none"
+		stroke="#3a3a3a"
+		stroke-width="2"
+		stroke-linecap="round"
+	/>
+
+	<!-- Metal top cap -->
+	<rect x="14" y="12" width="12" height="4" rx="1" fill="#3a3a3a" />
+
+	<!-- Glass body (hexagonal) -->
+	<polygon
+		points="14,16 12,28 14,42 26,42 28,28 26,16"
+		fill="#f5a623"
+		fill-opacity="0.7"
+		stroke="#4a4a4a"
+		stroke-width="1"
+	/>
+
+	<!-- Metal frame lines -->
+	<line x1="14" y1="16" x2="14" y2="42" stroke="#4a4a4a" stroke-width="0.5" />
+	<line x1="26" y1="16" x2="26" y2="42" stroke="#4a4a4a" stroke-width="0.5" />
+	<line x1="12" y1="28" x2="28" y2="28" stroke="#4a4a4a" stroke-width="0.5" />
+
+	<!-- Inner flame (teardrop) -->
+	<path d="M20,24 Q22,28 20,34 Q18,28 20,24 Z" fill="#ff6b00" />
+
+	<!-- Base trapezoid -->
+	<polygon points="12,42 10,50 30,50 28,42" fill="#3a3a3a" />
+</g>
+
+<style>
+	@keyframes lantern-glow {
+		0%,
+		100% {
+			opacity: 0.2;
+		}
+
+		50% {
+			opacity: 0.5;
+		}
+	}
+
+	.lantern-glow {
+		display: none;
+	}
+
+	:global(.animate-tool) .lantern-glow {
+		display: block;
+		animation: lantern-glow 3s ease-in-out infinite;
+	}
+</style>

--- a/src/lib/trees/assets/tools/PruningShearsSvg.svelte
+++ b/src/lib/trees/assets/tools/PruningShearsSvg.svelte
@@ -1,0 +1,105 @@
+<!--
+	Pruning Shears SVG -- low-poly garden secateurs with snipping animation.
+	Local (0,0) is at the top-left; snap point is handle bottoms (~15, 55).
+	Snipping animation gated by :global(.animate-tool) CSS class.
+-->
+<script lang="ts">
+</script>
+
+<g class="pruning-shears">
+	<!-- Pivot bolt -->
+	<circle cx="17" cy="20" r="2.5" fill="#4a4a4a" />
+
+	<!-- Upper blade (rotates around pivot) -->
+	<g class="shears-upper-blade">
+		<path d="M17,20 Q10,10 8,2 Q14,4 17,20 Z" fill="#7a7a7a" stroke="#555" stroke-width="0.5" />
+	</g>
+
+	<!-- Lower blade (rotates around pivot) -->
+	<g class="shears-lower-blade">
+		<path
+			d="M17,20 Q24,10 26,2 Q20,4 17,20 Z"
+			fill="#8a8a8a"
+			stroke="#555"
+			stroke-width="0.5"
+		/>
+	</g>
+
+	<!-- Red handle -->
+	<path
+		d="M17,20 Q12,30 8,42 Q10,44 14,42 Q16,32 17,20 Z"
+		fill="#cc3333"
+		stroke="#993333"
+		stroke-width="0.5"
+	/>
+
+	<!-- Orange handle -->
+	<path
+		d="M17,20 Q22,30 26,42 Q24,44 20,42 Q18,32 17,20 Z"
+		fill="#cc6633"
+		stroke="#994422"
+		stroke-width="0.5"
+	/>
+
+	<!-- Spring between handles -->
+	<path
+		d="M13,32 Q17,28 21,32"
+		fill="none"
+		stroke="#888888"
+		stroke-width="1"
+		stroke-linecap="round"
+	/>
+</g>
+
+<style>
+	@keyframes shears-snip-upper {
+		0%,
+		100% {
+			transform: rotate(0deg);
+		}
+
+		40% {
+			transform: rotate(8deg);
+		}
+
+		50% {
+			transform: rotate(-5deg);
+		}
+
+		60% {
+			transform: rotate(3deg);
+		}
+	}
+
+	@keyframes shears-snip-lower {
+		0%,
+		100% {
+			transform: rotate(0deg);
+		}
+
+		40% {
+			transform: rotate(-8deg);
+		}
+
+		50% {
+			transform: rotate(5deg);
+		}
+
+		60% {
+			transform: rotate(-3deg);
+		}
+	}
+
+	.shears-upper-blade,
+	.shears-lower-blade {
+		transform-origin: 17px 20px;
+	}
+
+	:global(.animate-tool) .shears-upper-blade {
+		animation: shears-snip-upper 1.5s ease-in-out infinite;
+	}
+
+	:global(.animate-tool) .shears-lower-blade {
+		animation: shears-snip-lower 1.5s ease-in-out infinite;
+	}
+</style>

--- a/src/lib/trees/assets/tools/SpeechBubbleSvg.svelte
+++ b/src/lib/trees/assets/tools/SpeechBubbleSvg.svelte
@@ -5,11 +5,15 @@
 	Static — no animation.
 -->
 <script lang="ts">
+	import { hexToHsl, hslToHex } from '$lib/trees/color.js';
+	import { contrastTextColor } from '$lib/trees/color.js';
+
 	interface Props {
 		text?: string;
+		color?: string;
 	}
 
-	let { text = '' }: Props = $props();
+	let { text = '', color }: Props = $props();
 
 	const bubbleWidth = 80;
 	const bubbleHeight = 50;
@@ -24,6 +28,16 @@
 	const tailPath = `M${-8},${-tailHeight} Q${-2},${-tailHeight / 2} 0,0 Q${2},${-tailHeight / 2} ${8},${-tailHeight}`;
 
 	const textLines = $derived(text.split('\n').filter((line) => line.length > 0));
+
+	const bubbleFill = $derived(color ?? 'white');
+	const bubbleStroke = $derived.by(() => {
+		if (color === undefined) {
+			return '#555';
+		}
+		const hsl = hexToHsl(color);
+		return hslToHex(hsl.h, hsl.s, Math.max(0, hsl.l - 20));
+	});
+	const textFill = $derived(color !== undefined ? contrastTextColor(color) : '#333');
 </script>
 
 <g class="speech-bubble">
@@ -35,16 +49,16 @@
 		height={bubbleHeight}
 		rx={cornerRadius}
 		ry={cornerRadius}
-		fill="white"
-		stroke="#555"
+		fill={bubbleFill}
+		stroke={bubbleStroke}
 		stroke-width="1"
 		opacity="0.95"
 	/>
 
 	<!-- Curved tail -->
-	<path d={tailPath} fill="white" stroke="#555" stroke-width="1" opacity="0.95" />
+	<path d={tailPath} fill={bubbleFill} stroke={bubbleStroke} stroke-width="1" opacity="0.95" />
 	<!-- Cover the stroke where tail meets bubble -->
-	<rect x={-9} y={-tailHeight - 1} width={18} height={3} fill="white" opacity="0.95" />
+	<rect x={-9} y={-tailHeight - 1} width={18} height={3} fill={bubbleFill} opacity="0.95" />
 
 	{#if textLines.length > 0}
 		<text
@@ -53,7 +67,7 @@
 			text-anchor="middle"
 			dominant-baseline="central"
 			font-size="8"
-			fill="#333"
+			fill={textFill}
 		>
 			{#each textLines as line, i (i)}
 				<tspan x={0} dy={i === 0 ? 0 : 11}>{line}</tspan>

--- a/src/lib/trees/assets/tools/index.ts
+++ b/src/lib/trees/assets/tools/index.ts
@@ -5,3 +5,5 @@ export { default as RakeSvg } from './RakeSvg.svelte';
 export { default as ShovelSvg } from './ShovelSvg.svelte';
 export { default as WateringCanSvg } from './WateringCanSvg.svelte';
 export { default as WoodpeckerSvg } from './WoodpeckerSvg.svelte';
+export { default as LanternSvg } from './LanternSvg.svelte';
+export { default as PruningShearsSvg } from './PruningShearsSvg.svelte';

--- a/src/lib/trees/birds/bird_definitions.test.ts
+++ b/src/lib/trees/birds/bird_definitions.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { BIRD_DEFINITIONS } from './bird_definitions.js';
+import { BIRD_SPECIES } from './bird_types.js';
+
+describe('BIRD_DEFINITIONS', () => {
+	it('has entry for every BIRD_SPECIES', () => {
+		for (const species of Object.values(BIRD_SPECIES)) {
+			expect(BIRD_DEFINITIONS).toHaveProperty(species);
+		}
+	});
+
+	it('each entry has truthy svgComponent', () => {
+		for (const [key, def] of Object.entries(BIRD_DEFINITIONS)) {
+			expect(def.svgComponent, `${key} svgComponent`).toBeTruthy();
+		}
+	});
+
+	it('each entry has positive defaultScale', () => {
+		for (const [key, def] of Object.entries(BIRD_DEFINITIONS)) {
+			expect(def.defaultScale, `${key} defaultScale`).toBeGreaterThan(0);
+		}
+	});
+
+	it('owl is the largest scale and hummingbird the smallest', () => {
+		const scales = Object.entries(BIRD_DEFINITIONS).map(([key, def]) => ({
+			key,
+			scale: def.defaultScale,
+		}));
+		const maxEntry = scales.reduce((a, b) => (a.scale >= b.scale ? a : b));
+		const minEntry = scales.reduce((a, b) => (a.scale <= b.scale ? a : b));
+		expect(maxEntry.key).toBe('owl');
+		expect(minEntry.key).toBe('hummingbird');
+	});
+});

--- a/src/lib/trees/birds/bird_definitions.ts
+++ b/src/lib/trees/birds/bird_definitions.ts
@@ -1,0 +1,23 @@
+import type { Component } from 'svelte';
+import type { BirdSpecies } from './bird_types.js';
+import { BIRD_SPECIES } from './bird_types.js';
+import OwlSvg from '$lib/trees/assets/birds/OwlSvg.svelte';
+import RobinSvg from '$lib/trees/assets/birds/RobinSvg.svelte';
+import SparrowSvg from '$lib/trees/assets/birds/SparrowSvg.svelte';
+import CardinalSvg from '$lib/trees/assets/birds/CardinalSvg.svelte';
+import HummingbirdSvg from '$lib/trees/assets/birds/HummingbirdSvg.svelte';
+import ParrotSvg from '$lib/trees/assets/birds/ParrotSvg.svelte';
+
+export interface BirdDefinition {
+	readonly svgComponent: Component;
+	readonly defaultScale: number;
+}
+
+export const BIRD_DEFINITIONS = {
+	[BIRD_SPECIES.owl]: { svgComponent: OwlSvg, defaultScale: 1.2 },
+	[BIRD_SPECIES.robin]: { svgComponent: RobinSvg, defaultScale: 0.9 },
+	[BIRD_SPECIES.sparrow]: { svgComponent: SparrowSvg, defaultScale: 0.7 },
+	[BIRD_SPECIES.cardinal]: { svgComponent: CardinalSvg, defaultScale: 1.0 },
+	[BIRD_SPECIES.hummingbird]: { svgComponent: HummingbirdSvg, defaultScale: 0.6 },
+	[BIRD_SPECIES.parrot]: { svgComponent: ParrotSvg, defaultScale: 1.1 },
+} as const satisfies Record<BirdSpecies, BirdDefinition>;

--- a/src/lib/trees/birds/bird_types.test.ts
+++ b/src/lib/trees/birds/bird_types.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { BIRD_SPECIES, type BirdConfig } from './bird_types.js';
+
+describe('BIRD_SPECIES', () => {
+	it('has exactly 6 species', () => {
+		expect(Object.values(BIRD_SPECIES)).toHaveLength(6);
+	});
+
+	it('contains owl, robin, sparrow, cardinal, hummingbird, parrot', () => {
+		expect(BIRD_SPECIES.owl).toBe('owl');
+		expect(BIRD_SPECIES.robin).toBe('robin');
+		expect(BIRD_SPECIES.sparrow).toBe('sparrow');
+		expect(BIRD_SPECIES.cardinal).toBe('cardinal');
+		expect(BIRD_SPECIES.hummingbird).toBe('hummingbird');
+		expect(BIRD_SPECIES.parrot).toBe('parrot');
+	});
+});
+
+describe('BirdConfig', () => {
+	it('can be constructed with just type', () => {
+		const config: BirdConfig = { type: 'owl' };
+		expect(config.type).toBe('owl');
+		expect(config.label).toBeUndefined();
+		expect(config.active).toBeUndefined();
+	});
+
+	it('can include label and active', () => {
+		const config: BirdConfig = { type: 'robin', label: 'Test bird', active: false };
+		expect(config.type).toBe('robin');
+		expect(config.label).toBe('Test bird');
+		expect(config.active).toBe(false);
+	});
+});

--- a/src/lib/trees/birds/bird_types.ts
+++ b/src/lib/trees/birds/bird_types.ts
@@ -1,0 +1,16 @@
+export const BIRD_SPECIES = {
+	owl: 'owl',
+	robin: 'robin',
+	sparrow: 'sparrow',
+	cardinal: 'cardinal',
+	hummingbird: 'hummingbird',
+	parrot: 'parrot',
+} as const;
+
+export type BirdSpecies = (typeof BIRD_SPECIES)[keyof typeof BIRD_SPECIES];
+
+export interface BirdConfig {
+	readonly type: BirdSpecies;
+	readonly label?: string;
+	readonly active?: boolean;
+}

--- a/src/lib/trees/color.test.ts
+++ b/src/lib/trees/color.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { hexToHsl, hslToHex, interpolateHslInHexSpace } from './color.js';
+import {
+	hexToHsl,
+	hslToHex,
+	interpolateHslInHexSpace,
+	relativeLuminance,
+	contrastTextColor,
+} from './color.js';
 
 // Round-trip tolerance in HSL channel units. Converting hex -> HSL -> hex
 // is lossy at the edges due to integer rounding on 0..255 channels, so
@@ -172,5 +178,39 @@ describe('color: interpolateHslInHexSpace', () => {
 		const a = interpolateHslInHexSpace(dark, light, 0.37);
 		const b = interpolateHslInHexSpace(dark, light, 0.37);
 		expect(a).toBe(b);
+	});
+});
+
+describe('color: relativeLuminance', () => {
+	it('white has luminance ≈ 1.0', () => {
+		expect(relativeLuminance('#ffffff')).toBeCloseTo(1.0, 2);
+	});
+
+	it('black has luminance ≈ 0.0', () => {
+		expect(relativeLuminance('#000000')).toBeCloseTo(0.0, 2);
+	});
+
+	it('red luminance is between 0.1 and 0.3', () => {
+		const lum = relativeLuminance('#ff0000');
+		expect(lum).toBeGreaterThan(0.1);
+		expect(lum).toBeLessThan(0.3);
+	});
+});
+
+describe('color: contrastTextColor', () => {
+	it('returns black text on white background', () => {
+		expect(contrastTextColor('#ffffff')).toBe('#000000');
+	});
+
+	it('returns white text on black background', () => {
+		expect(contrastTextColor('#000000')).toBe('#ffffff');
+	});
+
+	it('returns white text on dark red (#cc0000)', () => {
+		expect(contrastTextColor('#cc0000')).toBe('#ffffff');
+	});
+
+	it('returns black text on yellow (#ffff00)', () => {
+		expect(contrastTextColor('#ffff00')).toBe('#000000');
 	});
 });

--- a/src/lib/trees/color.ts
+++ b/src/lib/trees/color.ts
@@ -25,18 +25,30 @@ function normalizeHue(hue: number): number {
 	return ((hue % 360) + 360) % 360;
 }
 
-/**
- * Parse a `#rrggbb` hex string into HSL. Throws on malformed input.
- */
-export function hexToHsl(hex: string): HslColor {
+interface Rgb {
+	readonly r: number;
+	readonly g: number;
+	readonly b: number;
+}
+
+function parseHexToRgb(hex: string): Rgb {
 	const match = /^#([0-9a-f]{6})$/i.exec(hex);
 	if (!match) {
 		throw new Error(`Invalid hex color: ${hex}`);
 	}
 	const digits = match[1]!;
-	const r = parseInt(digits.slice(0, 2), 16) / 255;
-	const g = parseInt(digits.slice(2, 4), 16) / 255;
-	const b = parseInt(digits.slice(4, 6), 16) / 255;
+	return {
+		r: parseInt(digits.slice(0, 2), 16) / 255,
+		g: parseInt(digits.slice(2, 4), 16) / 255,
+		b: parseInt(digits.slice(4, 6), 16) / 255,
+	};
+}
+
+/**
+ * Parse a `#rrggbb` hex string into HSL. Throws on malformed input.
+ */
+export function hexToHsl(hex: string): HslColor {
+	const { r, g, b } = parseHexToRgb(hex);
 
 	const max = Math.max(r, g, b);
 	const min = Math.min(r, g, b);
@@ -117,6 +129,27 @@ function lerpHue(from: number, to: number, t: number): number {
 		shortest = diff + 360;
 	}
 	return normalizeHue(from + shortest * t);
+}
+
+/**
+ * Compute W3C relative luminance from a `#rrggbb` hex string.
+ * Linearizes sRGB channels then applies the ITU-R BT.709 coefficients.
+ */
+export function relativeLuminance(hex: string): number {
+	const { r, g, b } = parseHexToRgb(hex);
+
+	const linearize = (channel: number): number =>
+		channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+
+	return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/**
+ * Return `'#000000'` (dark text) for light backgrounds, `'#ffffff'` (light
+ * text) for dark backgrounds. Uses the W3C 0.179 luminance threshold.
+ */
+export function contrastTextColor(backgroundHex: string): string {
+	return relativeLuminance(backgroundHex) > 0.179 ? '#000000' : '#ffffff';
 }
 
 /**

--- a/src/lib/trees/generate.ts
+++ b/src/lib/trees/generate.ts
@@ -46,12 +46,14 @@ import {
 import { generateAllBranchQuads } from './generate/branch_geometry.js';
 import { generateBlobCanopy, generateTierCanopy } from './generate/canopy_triangulation.js';
 import { generateBirchStripes } from './generate/birch_stripes.js';
+import { generateTrunkMushrooms } from './generate/trunk_mushrooms.js';
 import { computeAnchors } from './generate/anchors.js';
 
 export { computeJunctionStripRatios, computeHybridTaper };
 
 const FRUIT_COUNT_CAP = 7;
 const BIRCH_STRIPE_SEED_OFFSET = 9999;
+const MUSHROOM_SEED_OFFSET = 8888;
 
 interface StageFlags {
 	readonly addStakes: boolean;
@@ -91,6 +93,7 @@ export function generateTree(config: TreeConfig): TreeGeometry {
 	return generateTreeCore(config, customFlags);
 }
 
+// fallow-ignore-next-line complexity
 function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 	const rng = createPrng(config.seed);
 	const shapeDef = getShapeDefinition(config.shape);
@@ -557,6 +560,15 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 				)
 			: [];
 
+	const trunkMushrooms =
+		config.showMushrooms === true
+			? generateTrunkMushrooms(
+					trunkJunctions,
+					trunkResult.junctionWidths,
+					createPrng(config.seed + MUSHROOM_SEED_OFFSET),
+				)
+			: [];
+
 	return {
 		trunkQuads,
 		trunkTriangles: [],
@@ -570,6 +582,7 @@ function generateTreeCore(config: TreeConfig, flags: StageFlags): TreeGeometry {
 		showSnowBlobs: flags.addSnowBlobs,
 		snowAboveCanopy: flags.addSnowBlobs && !isTiered,
 		birchStripes,
+		trunkMushrooms,
 		anchors: anchorsWithTipDepths,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 		junctionData,

--- a/src/lib/trees/generate/birch_stripes.ts
+++ b/src/lib/trees/generate/birch_stripes.ts
@@ -1,50 +1,20 @@
 import type { BirchStripe, Point2D } from '../types.js';
+import { computeTrunkHeightRange, interpolateTrunkAtY } from './trunk_interpolation.js';
 
 // ---------------------------------------------------------------------------
 // Birch trunk stripes
 // ---------------------------------------------------------------------------
-
-/** Interpolate trunk centerX and width at a given y by finding bracketing junctions. */
-function interpolateTrunkAtY(
-	y: number,
-	junctions: readonly { x: number; y: number }[],
-	junctionWidths: readonly number[],
-): { centerX: number; width: number } {
-	// Junctions are ordered bottom-to-top (index 0 = bottom = highest Y).
-	// Find two junctions that bracket the given y.
-	for (let i = 0; i < junctions.length - 1; i++) {
-		const lower = junctions[i]!; // higher Y (lower on screen)
-		const upper = junctions[i + 1]!; // lower Y (higher on screen)
-		if (y <= lower.y && y >= upper.y) {
-			const range = lower.y - upper.y;
-			const t = range > 0 ? (lower.y - y) / range : 0;
-			const centerX = lower.x + (upper.x - lower.x) * t;
-			const lowerWidth = junctionWidths[i] ?? 0;
-			const upperWidth = junctionWidths[i + 1] ?? 0;
-			const width = lowerWidth + (upperWidth - lowerWidth) * t;
-			return { centerX, width };
-		}
-	}
-	// Fallback: use the closest junction
-	const last = junctions[junctions.length - 1]!;
-	return { centerX: last.x, width: junctionWidths[junctions.length - 1] ?? 0 };
-}
 
 export function generateBirchStripes(
 	junctions: readonly Point2D[],
 	junctionWidths: readonly number[],
 	rng: () => number,
 ): BirchStripe[] {
-	if (junctions.length < 2) {
+	const range = computeTrunkHeightRange(junctions);
+	if (range === null) {
 		return [];
 	}
-	const topY = junctions[junctions.length - 1]!.y;
-	const bottomY = junctions[0]!.y;
-	const trunkHeight = bottomY - topY;
-	if (trunkHeight <= 0) {
-		return [];
-	}
-	// 3-6 stripes evenly distributed along trunk height
+	const { topY, height: trunkHeight } = range;
 	const stripeCount = 3 + Math.floor(rng() * 4);
 	const stripes: BirchStripe[] = [];
 	for (let i = 0; i < stripeCount; i++) {

--- a/src/lib/trees/generate/trunk_interpolation.ts
+++ b/src/lib/trees/generate/trunk_interpolation.ts
@@ -1,0 +1,46 @@
+interface TrunkHeightRange {
+	readonly topY: number;
+	readonly bottomY: number;
+	readonly height: number;
+}
+
+export function computeTrunkHeightRange(
+	junctions: readonly { y: number }[],
+): TrunkHeightRange | null {
+	if (junctions.length < 2) {
+		return null;
+	}
+	const topY = junctions[junctions.length - 1]!.y;
+	const bottomY = junctions[0]!.y;
+	const height = bottomY - topY;
+	if (height <= 0) {
+		return null;
+	}
+	return { topY, bottomY, height };
+}
+
+/** Interpolate trunk centerX and width at a given y by finding bracketing junctions. */
+export function interpolateTrunkAtY(
+	y: number,
+	junctions: readonly { x: number; y: number }[],
+	junctionWidths: readonly number[],
+): { centerX: number; width: number } {
+	// Junctions are ordered bottom-to-top (index 0 = bottom = highest Y).
+	// Find two junctions that bracket the given y.
+	for (let i = 0; i < junctions.length - 1; i++) {
+		const lower = junctions[i]!; // higher Y (lower on screen)
+		const upper = junctions[i + 1]!; // lower Y (higher on screen)
+		if (y <= lower.y && y >= upper.y) {
+			const range = lower.y - upper.y;
+			const t = range > 0 ? (lower.y - y) / range : 0;
+			const centerX = lower.x + (upper.x - lower.x) * t;
+			const lowerWidth = junctionWidths[i] ?? 0;
+			const upperWidth = junctionWidths[i + 1] ?? 0;
+			const width = lowerWidth + (upperWidth - lowerWidth) * t;
+			return { centerX, width };
+		}
+	}
+	// Fallback: use the closest junction
+	const last = junctions[junctions.length - 1]!;
+	return { centerX: last.x, width: junctionWidths[junctions.length - 1] ?? 0 };
+}

--- a/src/lib/trees/generate/trunk_mushrooms.test.ts
+++ b/src/lib/trees/generate/trunk_mushrooms.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { generateTrunkMushrooms } from './trunk_mushrooms.js';
+import { interpolateTrunkAtY } from './trunk_interpolation.js';
+import { createPrng } from '../prng.js';
+import type { Point2D } from '../types.js';
+
+/** 4-junction straight trunk centered at x=250, from y=400 (bottom) to y=100 (top). */
+function makeTrunkJunctions(): Point2D[] {
+	return [
+		{ x: 250, y: 400 },
+		{ x: 250, y: 300 },
+		{ x: 250, y: 200 },
+		{ x: 250, y: 100 },
+	];
+}
+
+function makeTrunkWidths(): number[] {
+	return [20, 18, 14, 10];
+}
+
+describe('generateTrunkMushrooms', () => {
+	it('returns empty array when junctions.length < 2', () => {
+		const result = generateTrunkMushrooms([{ x: 250, y: 300 }], [20], createPrng(42));
+		expect(result).toEqual([]);
+	});
+
+	it('returns 2-4 mushrooms for valid trunk', () => {
+		// Test with multiple seeds to verify range
+		for (let seed = 0; seed < 20; seed++) {
+			const result = generateTrunkMushrooms(
+				makeTrunkJunctions(),
+				makeTrunkWidths(),
+				createPrng(seed),
+			);
+			expect(result.length).toBeGreaterThanOrEqual(2);
+			expect(result.length).toBeLessThanOrEqual(4);
+		}
+	});
+
+	it('each mushroom has y within trunk Y range', () => {
+		const junctions = makeTrunkJunctions();
+		const topY = junctions[junctions.length - 1]!.y; // 100
+		const bottomY = junctions[0]!.y; // 400
+		const result = generateTrunkMushrooms(junctions, makeTrunkWidths(), createPrng(42));
+		for (const mushroom of result) {
+			expect(mushroom.y).toBeGreaterThanOrEqual(topY);
+			expect(mushroom.y).toBeLessThanOrEqual(bottomY);
+		}
+	});
+
+	it('each mushroom has valid side', () => {
+		const result = generateTrunkMushrooms(
+			makeTrunkJunctions(),
+			makeTrunkWidths(),
+			createPrng(42),
+		);
+		for (const mushroom of result) {
+			expect(['left', 'right']).toContain(mushroom.side);
+		}
+	});
+
+	it('each mushroom has variant 0, 1, or 2', () => {
+		const result = generateTrunkMushrooms(
+			makeTrunkJunctions(),
+			makeTrunkWidths(),
+			createPrng(42),
+		);
+		for (const mushroom of result) {
+			expect([0, 1, 2]).toContain(mushroom.variant);
+		}
+	});
+
+	it('each mushroom has scale between 0.6 and 1.2', () => {
+		const result = generateTrunkMushrooms(
+			makeTrunkJunctions(),
+			makeTrunkWidths(),
+			createPrng(42),
+		);
+		for (const mushroom of result) {
+			expect(mushroom.scale).toBeGreaterThanOrEqual(0.6);
+			expect(mushroom.scale).toBeLessThanOrEqual(1.2);
+		}
+	});
+
+	it('mushroom centerX is at trunk edge, not center', () => {
+		const junctions = makeTrunkJunctions();
+		const widths = makeTrunkWidths();
+		const result = generateTrunkMushrooms(junctions, widths, createPrng(42));
+		for (const mushroom of result) {
+			const { centerX: trunkCenter, width: trunkWidth } = interpolateTrunkAtY(
+				mushroom.y,
+				junctions,
+				widths,
+			);
+			const expectedLeftEdge = trunkCenter - trunkWidth / 2;
+			const expectedRightEdge = trunkCenter + trunkWidth / 2;
+			if (mushroom.side === 'left') {
+				expect(mushroom.centerX).toBeCloseTo(expectedLeftEdge, 1);
+			} else {
+				expect(mushroom.centerX).toBeCloseTo(expectedRightEdge, 1);
+			}
+		}
+	});
+});

--- a/src/lib/trees/generate/trunk_mushrooms.ts
+++ b/src/lib/trees/generate/trunk_mushrooms.ts
@@ -1,0 +1,42 @@
+import type { TrunkMushroom, Point2D } from '../types.js';
+import { computeTrunkHeightRange, interpolateTrunkAtY } from './trunk_interpolation.js';
+
+const MUSHROOM_COUNT_MIN = 2;
+const MUSHROOM_COUNT_MAX = 4;
+const VARIANT_COUNT = 3;
+const SCALE_MIN = 0.6;
+const SCALE_RANGE = 0.6;
+
+export function generateTrunkMushrooms(
+	junctions: readonly Point2D[],
+	junctionWidths: readonly number[],
+	rng: () => number,
+): TrunkMushroom[] {
+	const range = computeTrunkHeightRange(junctions);
+	if (range === null) {
+		return [];
+	}
+	const { topY, height: trunkHeight } = range;
+
+	const mushroomCount =
+		MUSHROOM_COUNT_MIN + Math.floor(rng() * (MUSHROOM_COUNT_MAX - MUSHROOM_COUNT_MIN + 1));
+	const mushrooms: TrunkMushroom[] = [];
+
+	for (let i = 0; i < mushroomCount; i++) {
+		const y = topY + rng() * trunkHeight;
+		const { centerX: trunkCenterX, width: trunkWidth } = interpolateTrunkAtY(
+			y,
+			junctions,
+			junctionWidths,
+		);
+		const side: 'left' | 'right' = rng() < 0.5 ? 'left' : 'right';
+		const centerX =
+			side === 'left' ? trunkCenterX - trunkWidth / 2 : trunkCenterX + trunkWidth / 2;
+		const variant = Math.floor(rng() * VARIANT_COUNT);
+		const scale = SCALE_MIN + rng() * SCALE_RANGE;
+
+		mushrooms.push({ y, centerX, side, variant, scale });
+	}
+
+	return mushrooms;
+}

--- a/src/lib/trees/oak_prd_generator.ts
+++ b/src/lib/trees/oak_prd_generator.ts
@@ -92,6 +92,7 @@ function scaleGeometry(geometry: TreeGeometry): TreeGeometry {
 		showSnowBlobs: geometry.showSnowBlobs,
 		snowAboveCanopy: geometry.snowAboveCanopy,
 		birchStripes: [],
+		trunkMushrooms: [],
 		anchors: scaleAnchors(geometry.anchors),
 		viewBox: OAK_PRD_VIEWBOX,
 	};

--- a/src/lib/trees/potted_plant_generator.ts
+++ b/src/lib/trees/potted_plant_generator.ts
@@ -167,6 +167,7 @@ function generateFruitSlotPositions(
 	return slots;
 }
 
+// fallow-ignore-next-line complexity
 export function generatePottedPlant(config: PottedPlantConfig): TreeGeometry {
 	const rng = createPrng(config.seed);
 	const cx = VIEWBOX_WIDTH / 2;
@@ -263,6 +264,7 @@ export function generatePottedPlant(config: PottedPlantConfig): TreeGeometry {
 		showSnowBlobs: false,
 		snowAboveCanopy: false,
 		birchStripes: [],
+		trunkMushrooms: [],
 		anchors,
 		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
 	};

--- a/src/lib/trees/stages/constants.ts
+++ b/src/lib/trees/stages/constants.ts
@@ -1,4 +1,25 @@
-import { VIEWBOX_HEIGHT } from '../types.js';
+import type { TreeAnchors, TreeGeometry } from '../types.js';
+import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
 
 /** Ground line Y position, aligned with shape system trunkBottom (H * 0.95). */
 export const GROUND_LINE_Y = VIEWBOX_HEIGHT * 0.95;
+
+export function createEmptyStageGeometry(anchors: TreeAnchors): TreeGeometry {
+	return {
+		trunkQuads: [],
+		trunkTriangles: [],
+		branchGroups: [],
+		canopyBlobs: [],
+		fruitTriangles: [],
+		stakeTriangles: [],
+		fruitSlots: [],
+		flowerSlots: [],
+		showFallingLeaves: false,
+		showSnowBlobs: false,
+		snowAboveCanopy: false,
+		birchStripes: [],
+		trunkMushrooms: [],
+		anchors,
+		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
+	};
+}

--- a/src/lib/trees/stages/seed_generator.ts
+++ b/src/lib/trees/stages/seed_generator.ts
@@ -1,13 +1,13 @@
 import type { TreeGeometry } from '../types.js';
-import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
-import { GROUND_LINE_Y } from './constants.js';
+import { VIEWBOX_WIDTH } from '../types.js';
+import { GROUND_LINE_Y, createEmptyStageGeometry } from './constants.js';
 
 /** Seed geometry — visual rendering handled by SeedSvg component. */
 export function generateSeedGeometry(): TreeGeometry {
 	const cx = VIEWBOX_WIDTH / 2;
 	const groundY = GROUND_LINE_Y;
 
-	const anchors = {
+	return createEmptyStageGeometry({
 		trunkTop: { x: cx, y: groundY - 14 },
 		trunkMiddle: { x: cx, y: groundY - 6 },
 		trunkBase: { x: cx, y: groundY + 2 },
@@ -16,22 +16,5 @@ export function generateSeedGeometry(): TreeGeometry {
 		roots: { x: cx, y: groundY + 15 },
 		branchTips: [],
 		fruitSlots: [],
-	};
-
-	return {
-		trunkQuads: [],
-		trunkTriangles: [],
-		branchGroups: [],
-		canopyBlobs: [],
-		fruitTriangles: [],
-		stakeTriangles: [],
-		fruitSlots: [],
-		flowerSlots: [],
-		showFallingLeaves: false,
-		showSnowBlobs: false,
-		snowAboveCanopy: false,
-		birchStripes: [],
-		anchors,
-		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
-	};
+	});
 }

--- a/src/lib/trees/stages/sprouting_generator.ts
+++ b/src/lib/trees/stages/sprouting_generator.ts
@@ -1,6 +1,6 @@
 import type { TreeGeometry } from '../types.js';
-import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
-import { GROUND_LINE_Y } from './constants.js';
+import { VIEWBOX_WIDTH } from '../types.js';
+import { GROUND_LINE_Y, createEmptyStageGeometry } from './constants.js';
 
 /** Sprouting geometry — visual rendering handled by SproutingSvg component. */
 export function generateSproutingGeometry(): TreeGeometry {
@@ -8,7 +8,7 @@ export function generateSproutingGeometry(): TreeGeometry {
 	const groundY = GROUND_LINE_Y;
 	const stemTop = groundY - 30;
 
-	const anchors = {
+	return createEmptyStageGeometry({
 		trunkTop: { x: cx, y: stemTop },
 		trunkMiddle: { x: cx, y: (groundY + stemTop) / 2 },
 		trunkBase: { x: cx, y: groundY },
@@ -17,22 +17,5 @@ export function generateSproutingGeometry(): TreeGeometry {
 		roots: { x: cx, y: groundY + 15 },
 		branchTips: [],
 		fruitSlots: [],
-	};
-
-	return {
-		trunkQuads: [],
-		trunkTriangles: [],
-		branchGroups: [],
-		canopyBlobs: [],
-		fruitTriangles: [],
-		stakeTriangles: [],
-		fruitSlots: [],
-		flowerSlots: [],
-		showFallingLeaves: false,
-		showSnowBlobs: false,
-		snowAboveCanopy: false,
-		birchStripes: [],
-		anchors,
-		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
-	};
+	});
 }

--- a/src/lib/trees/stages/stump_generator.ts
+++ b/src/lib/trees/stages/stump_generator.ts
@@ -1,6 +1,6 @@
 import type { TreeGeometry } from '../types.js';
-import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types.js';
-import { GROUND_LINE_Y } from './constants.js';
+import { VIEWBOX_WIDTH } from '../types.js';
+import { GROUND_LINE_Y, createEmptyStageGeometry } from './constants.js';
 
 /** Stump geometry — visual rendering handled by StumpSvg component. */
 export function generateStumpGeometry(): TreeGeometry {
@@ -8,7 +8,7 @@ export function generateStumpGeometry(): TreeGeometry {
 	const groundY = GROUND_LINE_Y;
 	const stumpTop = groundY - 20;
 
-	const anchors = {
+	return createEmptyStageGeometry({
 		trunkTop: { x: cx, y: stumpTop - 3 },
 		trunkMiddle: { x: cx, y: (groundY + stumpTop) / 2 },
 		trunkBase: { x: cx, y: groundY },
@@ -17,22 +17,5 @@ export function generateStumpGeometry(): TreeGeometry {
 		roots: { x: cx, y: groundY + 15 },
 		branchTips: [],
 		fruitSlots: [],
-	};
-
-	return {
-		trunkQuads: [],
-		trunkTriangles: [],
-		branchGroups: [],
-		canopyBlobs: [],
-		fruitTriangles: [],
-		stakeTriangles: [],
-		fruitSlots: [],
-		flowerSlots: [],
-		showFallingLeaves: false,
-		showSnowBlobs: false,
-		snowAboveCanopy: false,
-		birchStripes: [],
-		anchors,
-		viewBox: { width: VIEWBOX_WIDTH, height: VIEWBOX_HEIGHT },
-	};
+	});
 }

--- a/src/lib/trees/tools/tool_animations.test.ts
+++ b/src/lib/trees/tools/tool_animations.test.ts
@@ -4,7 +4,7 @@ import type { ToolAnimationConfig } from './tool_animations.js';
 import { TOOL_TYPES } from './tool_types.js';
 
 describe('TOOL_ANIMATIONS', () => {
-	it('has animation config for all 9 tool types', () => {
+	it('has animation config for all 11 tool types', () => {
 		for (const toolType of Object.values(TOOL_TYPES)) {
 			expect(TOOL_ANIMATIONS).toHaveProperty(toolType);
 		}
@@ -54,6 +54,14 @@ describe('TOOL_ANIMATIONS', () => {
 
 	it('stormCloud duration is 2s', () => {
 		expect(TOOL_ANIMATIONS.stormCloud.duration).toBe(2);
+	});
+
+	it('lantern duration is 4s', () => {
+		expect(TOOL_ANIMATIONS.lantern.duration).toBe(4);
+	});
+
+	it('pruningShears duration is 1.5s', () => {
+		expect(TOOL_ANIMATIONS.pruningShears.duration).toBe(1.5);
 	});
 
 	it('ToolAnimationConfig type is exported and usable', () => {

--- a/src/lib/trees/tools/tool_animations.ts
+++ b/src/lib/trees/tools/tool_animations.ts
@@ -14,4 +14,6 @@ export const TOOL_ANIMATIONS = {
 	grill: { duration: 2 },
 	speechBubble: { duration: 0 },
 	stormCloud: { duration: 2 },
+	lantern: { duration: 4 },
+	pruningShears: { duration: 1.5 },
 } as const satisfies Record<ToolType, ToolAnimationConfig>;

--- a/src/lib/trees/tools/tool_definitions.test.ts
+++ b/src/lib/trees/tools/tool_definitions.test.ts
@@ -3,7 +3,7 @@ import { TOOL_DEFINITIONS } from './tool_definitions.js';
 import { TOOL_TYPES } from './tool_types.js';
 
 describe('TOOL_DEFINITIONS', () => {
-	it('has entries for all 9 tool types', () => {
+	it('has entries for all 11 tool types', () => {
 		for (const toolType of Object.values(TOOL_TYPES)) {
 			expect(TOOL_DEFINITIONS).toHaveProperty(toolType);
 		}
@@ -60,5 +60,13 @@ describe('TOOL_DEFINITIONS', () => {
 
 	it('stormCloud anchorTarget is crownTop', () => {
 		expect(TOOL_DEFINITIONS.stormCloud.anchorTarget).toBe('crownTop');
+	});
+
+	it('lantern anchorTarget is trunkBase', () => {
+		expect(TOOL_DEFINITIONS.lantern.anchorTarget).toBe('trunkBase');
+	});
+
+	it('pruningShears anchorTarget is trunkBase', () => {
+		expect(TOOL_DEFINITIONS.pruningShears.anchorTarget).toBe('trunkBase');
 	});
 });

--- a/src/lib/trees/tools/tool_definitions.ts
+++ b/src/lib/trees/tools/tool_definitions.ts
@@ -18,6 +18,8 @@ import WoodpeckerSvg from '$lib/trees/assets/tools/WoodpeckerSvg.svelte';
 import GrillSvg from '$lib/trees/assets/tools/GrillSvg.svelte';
 import SpeechBubbleSvg from '$lib/trees/assets/tools/SpeechBubbleSvg.svelte';
 import StormCloudSvg from '$lib/trees/assets/tools/StormCloudSvg.svelte';
+import LanternSvg from '$lib/trees/assets/tools/LanternSvg.svelte';
+import PruningShearsSvg from '$lib/trees/assets/tools/PruningShearsSvg.svelte';
 
 export interface ToolDefinition {
 	readonly svgComponent: Component;
@@ -80,5 +82,17 @@ export const TOOL_DEFINITIONS = {
 		anchorTarget: 'crownTop',
 		snapOffset: { x: 0, y: 10 },
 		pivotPoint: { x: 0, y: -20 },
+	},
+	[TOOL_TYPES.lantern]: {
+		svgComponent: LanternSvg,
+		anchorTarget: 'trunkBase',
+		snapOffset: { x: -20, y: 25 },
+		pivotPoint: { x: 20, y: 50 },
+	},
+	[TOOL_TYPES.pruningShears]: {
+		svgComponent: PruningShearsSvg,
+		anchorTarget: 'trunkBase',
+		snapOffset: { x: 20, y: 30 },
+		pivotPoint: { x: 15, y: 20 },
 	},
 } as const satisfies Record<ToolType, ToolDefinition>;

--- a/src/lib/trees/tools/tool_types.test.ts
+++ b/src/lib/trees/tools/tool_types.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { TOOL_TYPES, TOOL_OPTIONS, createDefaultToolVisibility } from './tool_types.js';
 
 describe('TOOL_TYPES', () => {
-	it('defines exactly 9 tools', () => {
+	it('defines exactly 11 tools', () => {
 		const types = Object.values(TOOL_TYPES);
-		expect(types).toHaveLength(9);
+		expect(types).toHaveLength(11);
 	});
 
-	it('contains shovel, wateringCan, ladder, axe, rake, woodpecker, grill, speechBubble, stormCloud', () => {
+	it('contains all 11 tool types', () => {
 		expect(TOOL_TYPES.shovel).toBe('shovel');
 		expect(TOOL_TYPES.wateringCan).toBe('wateringCan');
 		expect(TOOL_TYPES.ladder).toBe('ladder');
@@ -17,6 +17,8 @@ describe('TOOL_TYPES', () => {
 		expect(TOOL_TYPES.grill).toBe('grill');
 		expect(TOOL_TYPES.speechBubble).toBe('speechBubble');
 		expect(TOOL_TYPES.stormCloud).toBe('stormCloud');
+		expect(TOOL_TYPES.lantern).toBe('lantern');
+		expect(TOOL_TYPES.pruningShears).toBe('pruningShears');
 	});
 
 	it('does not contain birdNest', () => {
@@ -44,7 +46,7 @@ describe('TOOL_OPTIONS', () => {
 		}
 	});
 
-	it('has correct labels for all 9 tools', () => {
+	it('has correct labels for all 11 tools', () => {
 		const labelMap = new Map(TOOL_OPTIONS.map((o) => [o.value, o.label]));
 		expect(labelMap.get('shovel')).toBe('Shovel');
 		expect(labelMap.get('wateringCan')).toBe('Watering Can');
@@ -55,11 +57,13 @@ describe('TOOL_OPTIONS', () => {
 		expect(labelMap.get('grill')).toBe('Grill');
 		expect(labelMap.get('speechBubble')).toBe('Speech Bubble');
 		expect(labelMap.get('stormCloud')).toBe('Storm Cloud');
+		expect(labelMap.get('lantern')).toBe('Lantern');
+		expect(labelMap.get('pruningShears')).toBe('Pruning Shears');
 	});
 });
 
 describe('createDefaultToolVisibility', () => {
-	it('has entries for all 9 tools', () => {
+	it('has entries for all 11 tools', () => {
 		const visibility = createDefaultToolVisibility();
 		for (const toolType of Object.values(TOOL_TYPES)) {
 			expect(visibility).toHaveProperty(toolType);
@@ -83,6 +87,11 @@ describe('createDefaultToolVisibility', () => {
 	it('speechBubble entry has text field defaulting to empty string', () => {
 		const visibility = createDefaultToolVisibility();
 		expect(visibility.speechBubble.text).toBe('');
+	});
+
+	it('speechBubble entry has color field defaulting to undefined', () => {
+		const visibility = createDefaultToolVisibility();
+		expect(visibility.speechBubble.color).toBeUndefined();
 	});
 
 	it('returns a new object each call', () => {

--- a/src/lib/trees/tools/tool_types.ts
+++ b/src/lib/trees/tools/tool_types.ts
@@ -8,6 +8,8 @@ export const TOOL_TYPES = {
 	grill: 'grill',
 	speechBubble: 'speechBubble',
 	stormCloud: 'stormCloud',
+	lantern: 'lantern',
+	pruningShears: 'pruningShears',
 } as const;
 
 export type ToolType = (typeof TOOL_TYPES)[keyof typeof TOOL_TYPES];
@@ -16,6 +18,7 @@ export interface ToolVisibilityEntry {
 	visible: boolean;
 	size: number;
 	text?: string;
+	color?: string;
 }
 
 export type ToolVisibility = Record<ToolType, ToolVisibilityEntry>;
@@ -29,8 +32,10 @@ export function createDefaultToolVisibility(): ToolVisibility {
 		[TOOL_TYPES.rake]: { visible: false, size: 1 },
 		[TOOL_TYPES.woodpecker]: { visible: false, size: 1 },
 		[TOOL_TYPES.grill]: { visible: false, size: 1 },
-		[TOOL_TYPES.speechBubble]: { visible: false, size: 1, text: '' },
+		[TOOL_TYPES.speechBubble]: { visible: false, size: 1, text: '', color: undefined },
 		[TOOL_TYPES.stormCloud]: { visible: false, size: 1 },
+		[TOOL_TYPES.lantern]: { visible: false, size: 1 },
+		[TOOL_TYPES.pruningShears]: { visible: false, size: 1 },
 	};
 }
 
@@ -44,4 +49,6 @@ export const TOOL_OPTIONS = [
 	{ value: TOOL_TYPES.grill, label: 'Grill' },
 	{ value: TOOL_TYPES.speechBubble, label: 'Speech Bubble' },
 	{ value: TOOL_TYPES.stormCloud, label: 'Storm Cloud' },
+	{ value: TOOL_TYPES.lantern, label: 'Lantern' },
+	{ value: TOOL_TYPES.pruningShears, label: 'Pruning Shears' },
 ] as const;

--- a/src/lib/trees/types.ts
+++ b/src/lib/trees/types.ts
@@ -11,6 +11,7 @@ export {
 	type BranchGeometry,
 	type JunctionData,
 	type BirchStripe,
+	type TrunkMushroom,
 	type TreeGeometry,
 } from './types/core.js';
 

--- a/src/lib/trees/types/core.ts
+++ b/src/lib/trees/types/core.ts
@@ -115,6 +115,14 @@ export interface BirchStripe {
 	readonly color: string;
 }
 
+export interface TrunkMushroom {
+	readonly y: number;
+	readonly centerX: number;
+	readonly side: 'left' | 'right';
+	readonly variant: number;
+	readonly scale: number;
+}
+
 export interface TreeGeometry {
 	/** Stacked trapezoid quads for trunk (BR-1). Empty for simple stages. */
 	readonly trunkQuads: readonly Quad[];
@@ -137,6 +145,8 @@ export interface TreeGeometry {
 	readonly viewBox: { readonly width: number; readonly height: number };
 	/** Dark horizontal stripes on birch trunks. Empty for non-birch shapes. */
 	readonly birchStripes: readonly BirchStripe[];
+	/** Small mushroom clusters on trunk edges. Empty when showMushrooms is off. */
+	readonly trunkMushrooms: readonly TrunkMushroom[];
 	/** Junction positions/widths/ratios for Phase 2 (REQ-EV2-C-01). */
 	readonly junctionData?: readonly JunctionData[];
 	/** Canopy envelope bounds for Phase 2 (REQ-EV2-C-04). */

--- a/src/lib/trees/types/tree_config.ts
+++ b/src/lib/trees/types/tree_config.ts
@@ -75,6 +75,7 @@ export interface TreeConfig {
 	readonly customBlobs?: readonly CustomBlob[];
 	readonly fruitType: FruitType;
 	readonly fruitCount: number;
+	readonly showMushrooms?: boolean;
 }
 
 export const DEFAULT_TREE_CONFIG: TreeConfig = {


### PR DESCRIPTION
## Summary

Implements all 5 independent visualization enhancements for Grovekeeper state-to-tree mapping:

- **Lantern tool**: kerosene/oil lantern SVG with lemniscate (figure-8) float animation at `trunkBase`, for the analyzing execution phase
- **Pruning shears tool**: garden secateurs SVG with snipping blade animation at `trunkBase`, for the checks/testing phase
- **Trunk mushrooms**: 2-4 fungi clusters rendered on trunk surface (3 visual variants), gated by `showMushrooms` config flag, for branch-behind-base state
- **Speech bubble color prop**: optional `color` field on `ToolVisibilityEntry` with auto-contrast text via W3C luminance, backwards compatible
- **Bird system**: 6 species (owl/robin/sparrow/cardinal/hummingbird/parrot) positioned at `branchTips` with active/inactive states, tooltips, click events, and idle animations

Also includes:
- Extracted `parseHexToRgb` in color.ts to eliminate hex parsing duplication
- Extracted `computeTrunkHeightRange` to shared `trunk_interpolation.ts` for birch stripes and mushrooms
- Extracted `createEmptyStageGeometry` for stage generators (seed/sprouting/stump)

## Test plan

- [x] 2860 unit tests pass (27 new tests added)
- [x] `pnpm check:all` passes (format, lint, fallow, typecheck, eslint)
- [x] All tool system tests updated for 11 tools (from 9)
- [x] Mushroom generator tests: empty junctions, valid trunk, Y range, side, variant, scale, edge positioning
- [x] Bird type tests: species count, values, BirdConfig construction
- [x] Bird definition tests: coverage, svgComponent, defaultScale, scale ordering
- [x] Color tests: relativeLuminance, contrastTextColor for light/dark backgrounds
- [ ] Visual verification of new SVGs in dev server

Fixes #194